### PR TITLE
add prereqs to readme for build from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,18 @@ provided in case Cargo is not available to you.
 
 ### Install from source using Cargo
 
+#### Prerequisites
+
+[Install Rust](https://www.rust-lang.org/tools/install) for access to `cargo`, the Rust package manager.
+
+On Debian and Ubuntu-based distributions, please install the following packages before building Clarinet.
+
+```bash
+sudo apt-get install build-essential pkg-config libssl-dev
+```
+
+#### Build Clarinet
+
 You can build Clarinet from source using Cargo with the following commands:
 
 ```bash


### PR DESCRIPTION
This fixes #7 by adding a note about installing Rust and the required packages for Debian/Ubuntu Linux.