### PR TITLE
ci: update workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,8 @@ on:
     paths-ignore:
       - '**/CHANGELOG.md'
       - '**/package.json'
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
     branches:
       - main
       - develop

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -249,7 +249,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: ${{ matrix.platform }}.zip
-          asset_name: ${{ matrix.platform }}
+          asset_name: clarity-${{ matrix.platform }}.zip
           tag: ${{ github.ref }}
 
       # Cleans the `./target` dir after the build such that only dependencies are cached on CI

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -251,7 +251,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: ${{ matrix.platform }}.zip
-          asset_name: clarity-${{ matrix.platform }}.zip
+          asset_name: clarinet-${{ matrix.platform }}.zip
           tag: ${{ github.ref }}
 
       # Cleans the `./target` dir after the build such that only dependencies are cached on CI

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -240,9 +240,7 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: |
           foreach($testdir in Get-ChildItem examples) {
-            ls
-            ls $testdir
-            ./target/${{ matrix.target }}/release/clarinet test --manifest-path examples/${testdir}/Clarinet.toml
+            ./target/${{ matrix.target }}/release/clarinet test --manifest-path ${testdir}/Clarinet.toml
           }
 
       - name: Upload Artifacts to GH release

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -236,12 +236,14 @@ jobs:
             ./target/${{ matrix.target }}/release/clarinet test --manifest-path examples/${testdir}/Clarinet.toml
           done
 
-      # - name: Functional Tests (Windows)
-      #   if: matrix.os == 'windows-latest'
-      #   run: |
-      #     foreach($testdir in Get-ChildItem examples) {
-      #       ./target/${{ matrix.target }}/release/clarinet test --manifest-path examples/${testdir}/Clarinet.toml
-      #     }
+      - name: Functional Tests (Windows)
+        if: matrix.os == 'windows-latest'
+        run: |
+          foreach($testdir in Get-ChildItem examples) {
+            ls
+            ls $testdir
+            ./target/${{ matrix.target }}/release/clarinet test --manifest-path examples/${testdir}/Clarinet.toml
+          }
 
       - name: Upload Artifacts to GH release
         uses: svenstaro/upload-release-action@v2


### PR DESCRIPTION
* Updates artifact names
* Don't run CI after semantic-release pushes up Cargo files.
* Fixes Windows functional tests

Closes https://github.com/hirosystems/clarinet/issues/60