### PR TITLE
ci: add new workflow to update develop branch on release

### DIFF
--- a/.github/workflows/open-develop-pr.yml
+++ b/.github/workflows/open-develop-pr.yml
@@ -7,7 +7,7 @@ name: Open Develop PR
 on:
   release:
     types:
-      - published
+      - released
   workflow_dispatch:
 
 jobs:      

--- a/.github/workflows/open-develop-pr.yml
+++ b/.github/workflows/open-develop-pr.yml
@@ -1,0 +1,33 @@
+##
+## Auto-opens a PR from main -> develop after a release has been published.
+##
+
+name: Open Develop PR
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+
+jobs:      
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Clarinet
+        uses: actions/checkout@v2
+          ref: main
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.GH_TOKEN }}
+          base: develop
+          branch: main
+          title: "chore: update develop branch"
+          body: |
+            :robot: This is an automated pull request created from a new release in [clarinet](https://github.com/hirosystems/clarinet/releases).
+
+            Updates the develop branch from main.
+          assignees: lgalabru
+          reviewers: lgalabru


### PR DESCRIPTION
On release, the semantic-release plugin will create a commit to update the CHANGELOG and some other files, and then tag that commit with the new version. If someone then pushes a commit to the `develop` branch, semantic-release will create a new release candidate using the _previous_ version tag.

This is because when analyzing the commits in the `develop` branch, it does not see the recently-generated tag available on the `develop` branch. Ideally, a PR would be opened against the develop branch automatically after a release is performed to port over the new commit and tag from the `main` branch.

This would allow any further new commits to the `develop` branch to generate a release candidate with the most up-to-date tag version from `main`.