### PR TITLE
Fix: batch of one liners

### DIFF
--- a/src/frontend/cli.rs
+++ b/src/frontend/cli.rs
@@ -469,7 +469,7 @@ pub fn main() {
 
                 let tx_bytes = signed_tx.serialize_to_vec();
                 let client = reqwest::blocking::Client::new();
-                let path = format!("{}/v2/transactions", "http://localhost:20443");
+                let path = format!("{}/v2/transactions", host);
                 let res = client
                     .post(&path)
                     .header("Content-Type", "application/octet-stream")

--- a/src/test/deno.rs
+++ b/src/test/deno.rs
@@ -170,6 +170,7 @@ pub async fn do_run_tests(
 ) -> Result<bool, AnyError> {
     let mut flags = Flags::default();
     flags.unstable = true;
+    flags.reload = true;
     let program_state = ProgramState::build(flags.clone()).await?;
     let permissions = Permissions::from_options(&flags.clone().into());
     let mut project_path = manifest_path.clone();


### PR DESCRIPTION
This PR is batching 2 issues:
- https://github.com/hirosystems/clarinet/issues/70: it looks like using `deno` concurrently with `clarinet`, either directly or via the deno vs-code extension, could cause some issues where a cache of the project is created, that clarinet then tries to use by default. This fix is making sure that `clarinet test` does not try to use this aforementioned cache.
- The `clarinet deploy` command always try to use localhost, instead of using the path coming from the network manifest.   