### PR TITLE
ci: update release workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -356,6 +356,22 @@ jobs:
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
 
+  package-version-bump:
+    name: Trigger Package Version Bump workflow
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs:
+      - audit
+      - dist
+      - test
+      - build
+    steps:
+      - name: Trigger pkg-version-bump workflow
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.GH_TOKEN }}
+          event-type: released
+
   release:
     name: Release
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,7 +53,7 @@ jobs:
         run: cargo install cargo-audit
 
       - name: Run audit
-        run: cargo audit --ignore RUSTSEC-2021-0076
+        run: cargo audit --ignore RUSTSEC-2021-0076 --ignore RUSTSEC-2021-0079 --ignore RUSTSEC-2021-0078
 
       - name: Run rustfmt
         run: cargo fmt --all -- --check

--- a/.github/workflows/open-develop-pr.yml
+++ b/.github/workflows/open-develop-pr.yml
@@ -17,16 +17,16 @@ jobs:
       - name: Checkout Clarinet
         uses: actions/checkout@v2
 
-    - name: pull-request
-      uses: repo-sync/pull-request@v2
-      with:
-        source_branch: main
-        destination_branch: develop
-        pr_title: "chore: update develop branch"
-        pr_body: |
-          :robot: This is an automated pull request created from a new release in [clarinet](https://github.com/hirosystems/clarinet/releases).
+      - name: pull-request
+        uses: repo-sync/pull-request@v2
+        with:
+          source_branch: main
+          destination_branch: develop
+          pr_title: "chore: update develop branch"
+          pr_body: |
+            :robot: This is an automated pull request created from a new release in [clarinet](https://github.com/hirosystems/clarinet/releases).
 
-          Updates the develop branch from main.
-        pr_reviewer: lgalabru
-        pr_assignee: lgalabru
-        github_token: ${{ secrets.GH_TOKEN }}
+            Updates the develop branch from main.
+          pr_reviewer: lgalabru
+          pr_assignee: lgalabru
+          github_token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/open-develop-pr.yml
+++ b/.github/workflows/open-develop-pr.yml
@@ -16,19 +16,17 @@ jobs:
     steps:
       - name: Checkout Clarinet
         uses: actions/checkout@v2
-        with:
-          ref: main
 
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v3
-        with:
-          token: ${{ secrets.GH_TOKEN }}
-          base: develop
-          branch: main
-          title: "chore: update develop branch"
-          body: |
-            :robot: This is an automated pull request created from a new release in [clarinet](https://github.com/hirosystems/clarinet/releases).
+    - name: pull-request
+      uses: repo-sync/pull-request@v2
+      with:
+        source_branch: main
+        destination_branch: develop
+        pr_title: "chore: update develop branch"
+        pr_body: |
+          :robot: This is an automated pull request created from a new release in [clarinet](https://github.com/hirosystems/clarinet/releases).
 
-            Updates the develop branch from main.
-          assignees: lgalabru
-          reviewers: lgalabru
+          Updates the develop branch from main.
+        pr_reviewer: lgalabru
+        pr_assignee: lgalabru
+        github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/open-develop-pr.yml
+++ b/.github/workflows/open-develop-pr.yml
@@ -29,4 +29,4 @@ jobs:
           Updates the develop branch from main.
         pr_reviewer: lgalabru
         pr_assignee: lgalabru
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+        github_token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/pkg-version-bump.yaml
+++ b/.github/workflows/pkg-version-bump.yaml
@@ -4,10 +4,10 @@
 
 name: Package Version Bump
 on:
-  release:
+  workflow_dispatch:
+  repository_dispatch:
     types:
       - released
-  workflow_dispatch:
 
 env:
   GIT_USER_NAME: Hiro DevOps


### PR DESCRIPTION
Changes the release process to:
- wait until all packages have been built and uploaded to the GH release before attempting to rev the package manager manifests
- use a different GH action to open a PR, as the previous action being used would overwrite the latest commit in the `main` branch

