### PR TITLE
Add expectPrintEvent function

### DIFF
--- a/deno/index.ts
+++ b/deno/index.ts
@@ -390,6 +390,10 @@ declare global {
       sender: String,
       assetId: String,
     ): Object;
+    expectPrintEvent(
+      contract_identifier: string, 
+      value: string
+    ): Object;
     // Absence of test vectors at the moment - token field could present some challenges.
     // expectNonFungibleTokenTransferEvent(token: String, sender: String, recipient: String, assetId: String): Object;
     // expectNonFungibleTokenMintEvent(token: String, recipient: String, assetId: String): Object;
@@ -690,6 +694,36 @@ Array.prototype.expectFungibleTokenBurnEvent = function (
   throw new Error(`Unable to retrieve expected FungibleTokenBurnEvent`);
 };
 
+Array.prototype.expectPrintEvent = function (
+  contract_identifier: string,
+  value: string
+) {
+  for (let event of this) {
+    try {
+      let e: any = {};
+      e["contract_identifier"] =
+        event.contract_event.contract_identifier.expectPrincipal(
+          contract_identifier
+        );
+
+      if (event.contract_event.topic.endsWith("print")) {
+        e["topic"] = event.contract_event.topic;
+      } else {
+        continue;
+      }
+
+      if (event.contract_event.value.endsWith(value)) {
+        e["value"] = event.contract_event.value;
+      } else {
+        continue;
+      }
+      return e;
+    } catch (error) {
+      continue;
+    }
+  }
+  throw new Error(`Unable to retrieve expected PrintEvent`);
+};
 // Array.prototype.expectEvent = function(sel: (e: Object) => Object) {
 //     for (let event of this) {
 //         try {


### PR DESCRIPTION
This PR introduces `expectPrintEvent`, which allows to verify in tests if specific PrintEvent occurred or not. 

Usage is very similar to all other events verification:
```typescript
const receipt = chain.mineBlock([Tx.contractCall("some-contract", "do-something", [], sender.address)]).receipts[0];

receipt.events.expectPrintEvent("ST1HTBVD3JG9C05J7HBJTHGR0GGW7KXW28M5JS8QE.some-contract", "printed value")
```