### PR TITLE
Feat: add assertions for NFT events

### DIFF
--- a/deno/index.ts
+++ b/deno/index.ts
@@ -404,7 +404,12 @@ declare global {
       assetAddress: String,
       assetId: String
     ): Object;
-    // expectNonFungibleTokenMintEvent(token: String, recipient: String, assetId: String): Object;
+    expectNonFungibleTokenMintEvent(
+      tokenId: String, 
+      recipient: String, 
+      assetAddress: String,
+      assetId: String
+    ): Object;
     // expectNonFungibleTokenBurnEvent(token: String, sender: String, assetId: String): Object;
     // expectEvent(sel: (e: Object) => Object): Object;
   }
@@ -773,24 +778,33 @@ Array.prototype.expectNonFungibleTokenTransferEvent = function(
     throw new Error(`Unable to retrieve expected NonFungibleTokenTransferEvent`);
 }
 
-// Array.prototype.expectNonFungibleTokenMintEvent = function(token: String, recipient: String, assetId: String) {
-//     for (let event of this) {
-//         try {
-//             let e: any = {};
-//             e["token"] = event.nft_mint_event.amount.expectInt(token);
-//             e["recipient"] = event.nft_mint_event.recipient.expectPrincipal(recipient);
-//             if (event.nft_mint_event.asset_identifier.endsWith(assetId)) {
-//                 e["assetId"] = event.nft_mint_event.asset_identifier;
-//             } else {
-//                 continue;
-//             }
-//             return e;
-//         } catch (error) {
-//             continue;
-//         }
-//     }
-//     throw new Error(`Unable to retrieve expected NonFungibleTokenTransferEvent`);
-// }
+Array.prototype.expectNonFungibleTokenMintEvent = function(
+  tokenId: String, 
+  recipient: String, 
+  assetAddress: String,
+  assetId: String
+  ) {
+    for (let event of this) {
+        try {
+            let e: any = {};
+            if(event.nft_mint_event.value === tokenId) {
+              e["tokenId"] = event.nft_mint_event.value;
+            } else {
+              continue;
+            }
+            e["recipient"] = event.nft_mint_event.recipient.expectPrincipal(recipient);
+            if (event.nft_mint_event.asset_identifier === `${assetAddress}::${assetId}`) {
+                e["assetId"] = event.nft_mint_event.asset_identifier;
+            } else {
+                continue;
+            }
+            return e;
+        } catch (error) {
+            continue;
+        }
+    }
+    throw new Error(`Unable to retrieve expected NonFungibleTokenMintEvent`);
+}
 
 // Array.prototype.expectNonFungibleTokenBurnEvent = function(token: String, sender: String, assetId: String) {
 //     for (let event of this) {

--- a/deno/index.ts
+++ b/deno/index.ts
@@ -397,7 +397,13 @@ declare global {
       value: string
     ): Object;
     // Absence of test vectors at the moment - token field could present some challenges.
-    // expectNonFungibleTokenTransferEvent(token: String, sender: String, recipient: String, assetId: String): Object;
+    expectNonFungibleTokenTransferEvent(
+      tokenId: String, 
+      sender: String, 
+      recipient: String, 
+      assetAddress: String,
+      assetId: String
+    ): Object;
     // expectNonFungibleTokenMintEvent(token: String, recipient: String, assetId: String): Object;
     // expectNonFungibleTokenBurnEvent(token: String, sender: String, assetId: String): Object;
     // expectEvent(sel: (e: Object) => Object): Object;
@@ -737,26 +743,35 @@ Array.prototype.expectPrintEvent = function (
 //     }
 //     throw new Error(`Unable to retrieve expected PrintEvent`);
 // }
-
-// Array.prototype.expectNonFungibleTokenTransferEvent = function(token: String, sender: String, recipient: String, assetId: String) {
-//     for (let event of this) {
-//         try {
-//             let e: any = {};
-//             e["token"] = event.nft_transfer_event.amount.expectInt(token);
-//             e["sender"] = event.nft_transfer_event.sender.expectPrincipal(sender);
-//             e["recipient"] = event.nft_transfer_event.recipient.expectPrincipal(recipient);
-//             if (event.nft_transfer_event.asset_identifier.endsWith(assetId)) {
-//                 e["assetId"] = event.nft_transfer_event.asset_identifier;
-//             } else {
-//                 continue;
-//             }
-//             return e;
-//         } catch (error) {
-//             continue;
-//         }
-//     }
-//     throw new Error(`Unable to retrieve expected NonFungibleTokenTransferEvent`);
-// }
+Array.prototype.expectNonFungibleTokenTransferEvent = function(
+  tokenId: String, 
+  sender: String, 
+  recipient: String, 
+  assetAddress: String, 
+  assetId: String
+  ) {
+    for (let event of this) {
+        try {
+            let e: any = {};
+            if(event.nft_transfer_event.value === tokenId) {
+              e["tokenId"] = event.nft_transfer_event.value;
+            } else {
+              continue;
+            }
+            e["sender"] = event.nft_transfer_event.sender.expectPrincipal(sender);
+            e["recipient"] = event.nft_transfer_event.recipient.expectPrincipal(recipient);
+            if (event.nft_transfer_event.asset_identifier === `${assetAddress}::${assetId}`) {
+              e["assetId"] = event.nft_transfer_event.asset_identifier;
+            } else {
+               continue;
+            }
+            return e;
+        } catch (error) {
+            continue;
+        }
+    }
+    throw new Error(`Unable to retrieve expected NonFungibleTokenTransferEvent`);
+}
 
 // Array.prototype.expectNonFungibleTokenMintEvent = function(token: String, recipient: String, assetId: String) {
 //     for (let event of this) {

--- a/deno/index.ts
+++ b/deno/index.ts
@@ -410,7 +410,12 @@ declare global {
       assetAddress: String,
       assetId: String
     ): Object;
-    // expectNonFungibleTokenBurnEvent(token: String, sender: String, assetId: String): Object;
+    expectNonFungibleTokenBurnEvent(
+      tokenId: String, 
+      sender: String, 
+      assetAddress: String,
+      assetId: String
+    ): Object;
     // expectEvent(sel: (e: Object) => Object): Object;
   }
 }
@@ -806,24 +811,33 @@ Array.prototype.expectNonFungibleTokenMintEvent = function(
     throw new Error(`Unable to retrieve expected NonFungibleTokenMintEvent`);
 }
 
-// Array.prototype.expectNonFungibleTokenBurnEvent = function(token: String, sender: String, assetId: String) {
-//     for (let event of this) {
-//         try {
-//             let e: any = {};
-//             e["token"] = event.nft_burn_event.amount.expectInt(token);
-//             e["sender"] = event.nft_burn_event.sender.expectPrincipal(sender);
-//             if (event.nft_burn_event.asset_identifier.endsWith(assetId)) {
-//                 e["assetId"] = event.nft_burn_event.asset_identifier;
-//             } else {
-//                 continue;
-//             }
-//             return e;
-//         } catch (error) {
-//             continue;
-//         }
-//     }
-//     throw new Error(`Unable to retrieve expected NonFungibleTokenTransferEvent`);
-// }
+Array.prototype.expectNonFungibleTokenBurnEvent = function(
+  tokenId: String, 
+  sender: String, 
+  assetAddress: String,
+  assetId: String
+  ) {
+    for (let event of this) {
+        try {
+            let e: any = {};
+            if(event.nft_burn_event.value === tokenId) {
+              e["tokenId"] = event.nft_burn_event.value;
+            } else {
+              continue;
+            }
+            e["sender"] = event.nft_burn_event.sender.expectPrincipal(sender);
+            if (event.nft_burn_event.asset_identifier === `${assetAddress}::${assetId}`) {
+                e["assetId"] = event.nft_burn_event.asset_identifier;
+            } else {
+                continue;
+            }
+            return e;
+        } catch (error) {
+            continue;
+        }
+    }
+    throw new Error(`Unable to retrieve expected NonFungibleTokenTransferEvent`);
+}
 
 const noColor = globalThis.Deno?.noColor ?? true;
 

--- a/deno/index.ts
+++ b/deno/index.ts
@@ -396,7 +396,6 @@ declare global {
       contract_identifier: string, 
       value: string
     ): Object;
-    // Absence of test vectors at the moment - token field could present some challenges.
     expectNonFungibleTokenTransferEvent(
       tokenId: String, 
       sender: String, 

--- a/deno/index.ts
+++ b/deno/index.ts
@@ -760,27 +760,27 @@ Array.prototype.expectNonFungibleTokenTransferEvent = function(
   assetAddress: String, 
   assetId: String
   ) {
-    for (let event of this) {
-        try {
-            let e: any = {};
-            if(event.nft_transfer_event.value === tokenId) {
-              e["tokenId"] = event.nft_transfer_event.value;
-            } else {
-              continue;
-            }
-            e["sender"] = event.nft_transfer_event.sender.expectPrincipal(sender);
-            e["recipient"] = event.nft_transfer_event.recipient.expectPrincipal(recipient);
-            if (event.nft_transfer_event.asset_identifier === `${assetAddress}::${assetId}`) {
-              e["assetId"] = event.nft_transfer_event.asset_identifier;
-            } else {
-               continue;
-            }
-            return e;
-        } catch (error) {
-            continue;
-        }
+  for (let event of this) {
+    try {
+      let e: any = {};
+      if(event.nft_transfer_event.value === tokenId) {
+        e["tokenId"] = event.nft_transfer_event.value;
+      } else {
+        continue;
+      }
+      e["sender"] = event.nft_transfer_event.sender.expectPrincipal(sender);
+      e["recipient"] = event.nft_transfer_event.recipient.expectPrincipal(recipient);
+      if (event.nft_transfer_event.asset_identifier === `${assetAddress}::${assetId}`) {
+        e["assetId"] = event.nft_transfer_event.asset_identifier;
+      } else {
+        continue;
+      }
+      return e;
+    } catch (error) {
+      continue;
     }
-    throw new Error(`Unable to retrieve expected NonFungibleTokenTransferEvent`);
+  }
+  throw new Error(`Unable to retrieve expected NonFungibleTokenTransferEvent`);
 }
 
 Array.prototype.expectNonFungibleTokenMintEvent = function(
@@ -789,26 +789,26 @@ Array.prototype.expectNonFungibleTokenMintEvent = function(
   assetAddress: String,
   assetId: String
   ) {
-    for (let event of this) {
-        try {
-            let e: any = {};
-            if(event.nft_mint_event.value === tokenId) {
-              e["tokenId"] = event.nft_mint_event.value;
-            } else {
-              continue;
-            }
-            e["recipient"] = event.nft_mint_event.recipient.expectPrincipal(recipient);
-            if (event.nft_mint_event.asset_identifier === `${assetAddress}::${assetId}`) {
-                e["assetId"] = event.nft_mint_event.asset_identifier;
-            } else {
-                continue;
-            }
-            return e;
-        } catch (error) {
-            continue;
-        }
+  for (let event of this) {
+    try {
+      let e: any = {};
+      if(event.nft_mint_event.value === tokenId) {
+        e["tokenId"] = event.nft_mint_event.value;
+      } else {
+        continue;
+      }
+      e["recipient"] = event.nft_mint_event.recipient.expectPrincipal(recipient);
+      if (event.nft_mint_event.asset_identifier === `${assetAddress}::${assetId}`) {
+        e["assetId"] = event.nft_mint_event.asset_identifier;
+      } else {
+        continue;
+      }
+      return e;
+    } catch (error) {
+      continue;
     }
-    throw new Error(`Unable to retrieve expected NonFungibleTokenMintEvent`);
+  }
+  throw new Error(`Unable to retrieve expected NonFungibleTokenMintEvent`);
 }
 
 Array.prototype.expectNonFungibleTokenBurnEvent = function(
@@ -817,26 +817,26 @@ Array.prototype.expectNonFungibleTokenBurnEvent = function(
   assetAddress: String,
   assetId: String
   ) {
-    for (let event of this) {
-        try {
-            let e: any = {};
-            if(event.nft_burn_event.value === tokenId) {
-              e["tokenId"] = event.nft_burn_event.value;
-            } else {
-              continue;
-            }
-            e["sender"] = event.nft_burn_event.sender.expectPrincipal(sender);
-            if (event.nft_burn_event.asset_identifier === `${assetAddress}::${assetId}`) {
-                e["assetId"] = event.nft_burn_event.asset_identifier;
-            } else {
-                continue;
-            }
-            return e;
-        } catch (error) {
-            continue;
-        }
+  for (let event of this) {
+    try {
+      let e: any = {};
+      if(event.nft_burn_event.value === tokenId) {
+        e["tokenId"] = event.nft_burn_event.value;
+      } else {
+        continue;
+      }
+      e["sender"] = event.nft_burn_event.sender.expectPrincipal(sender);
+      if (event.nft_burn_event.asset_identifier === `${assetAddress}::${assetId}`) {
+        e["assetId"] = event.nft_burn_event.asset_identifier;
+      } else {
+        continue;
+      }
+      return e;
+    } catch (error) {
+      continue;
     }
-    throw new Error(`Unable to retrieve expected NonFungibleTokenTransferEvent`);
+  }
+  throw new Error(`Unable to retrieve expected NonFungibleTokenTransferEvent`);
 }
 
 const noColor = globalThis.Deno?.noColor ?? true;

--- a/deno/index.ts
+++ b/deno/index.ts
@@ -836,7 +836,7 @@ Array.prototype.expectNonFungibleTokenBurnEvent = function(
       continue;
     }
   }
-  throw new Error(`Unable to retrieve expected NonFungibleTokenTransferEvent`);
+  throw new Error(`Unable to retrieve expected NonFungibleTokenBurnEvent`);
 }
 
 const noColor = globalThis.Deno?.noColor ?? true;

--- a/examples/simple-nft/.vscode/settings.json
+++ b/examples/simple-nft/.vscode/settings.json
@@ -1,0 +1,4 @@
+
+{
+    "deno.enable": true,
+}

--- a/examples/simple-nft/Clarinet.toml
+++ b/examples/simple-nft/Clarinet.toml
@@ -1,0 +1,12 @@
+
+[project]
+name = "simple-nft"
+
+[contracts.simple-nft]
+path = "contracts/simple-nft.clar"
+depends_on = ["sip-009-trait-ft-standard"]
+
+# EXTERNAL CONTRACTS
+[contracts.sip-009-trait-ft-standard]
+path = "contracts/external/sip-009-nft-trait-standard.clar"
+depends_on = []

--- a/examples/simple-nft/contracts/external/sip-009-nft-trait-standard.clar
+++ b/examples/simple-nft/contracts/external/sip-009-nft-trait-standard.clar
@@ -1,0 +1,15 @@
+(define-trait nft-trait
+  (
+    ;; Last token ID, limited to uint range
+    (get-last-token-id () (response uint uint))
+
+    ;; URI for metadata associated with the token
+    (get-token-uri (uint) (response (optional (string-ascii 256)) uint))
+
+     ;; Owner of a given token identifier
+    (get-owner (uint) (response (optional principal) uint))
+
+    ;; Transfer from the sender to a new principal
+    (transfer (uint principal principal) (response bool uint))
+  )
+)

--- a/examples/simple-nft/contracts/simple-nft.clar
+++ b/examples/simple-nft/contracts/simple-nft.clar
@@ -50,3 +50,10 @@
     (nft-mint? nft newId recipient)
   )
 )
+
+(define-public (test-burn (id uint) (sender principal))
+  (begin
+    (asserts! (is-eq tx-sender sender) ERR_NOT_AUTHORIZED)
+    (nft-burn? nft id sender)
+  )
+)

--- a/examples/simple-nft/contracts/simple-nft.clar
+++ b/examples/simple-nft/contracts/simple-nft.clar
@@ -1,0 +1,52 @@
+(define-constant CONTRACT_OWNER tx-sender)
+(define-constant CONTRACT_ADDRESS (as-contract tx-sender))
+(define-constant DEPLOYED_AT block-height)
+
+(define-constant ERR_NOT_AUTHORIZED (err u1001))
+
+(impl-trait .sip-009-trait-ft-standard.nft-trait)
+
+(define-data-var lastId uint u0)
+(define-map CFG_BASE_URI bool (string-ascii 256))
+
+(define-non-fungible-token nft uint)
+
+(define-read-only (get-last-token-id)
+  (ok (var-get lastId))
+)
+
+(define-read-only (get-owner (id uint))
+  (ok (nft-get-owner? nft id))
+)
+
+(define-read-only (get-token-uri (id uint))
+  (ok (map-get? CFG_BASE_URI true))
+)
+
+(define-public (transfer (id uint) (sender principal) (recipient principal))
+  (begin
+    (asserts! (is-eq tx-sender sender) ERR_NOT_AUTHORIZED)
+    (nft-transfer? nft id sender recipient)
+  )
+)
+
+;; extra functions
+(define-public (set-base-uri (uri (optional (string-ascii 256))))
+  (begin
+    (asserts! (is-eq contract-caller CONTRACT_OWNER) ERR_NOT_AUTHORIZED)
+    (ok (match uri uriVal
+      (map-set CFG_BASE_URI true uriVal)
+      (map-delete CFG_BASE_URI true)
+    ))
+  )
+)
+
+;; test functions
+(define-public (test-mint (recipient principal))
+  (let
+    ((newId (+ (var-get lastId) u1)))
+    (asserts! (is-eq DEPLOYED_AT u0) ERR_NOT_AUTHORIZED)
+    (var-set lastId newId)
+    (nft-mint? nft newId recipient)
+  )
+)

--- a/examples/simple-nft/settings/Devnet.toml
+++ b/examples/simple-nft/settings/Devnet.toml
@@ -1,0 +1,126 @@
+[network]
+name = "devnet"
+
+[accounts.deployer]
+mnemonic = "twice kind fence tip hidden tilt action fragile skin nothing glory cousin green tomorrow spring wrist shed math olympic multiply hip blue scout claw"
+balance = 100_000_000_000_000
+# secret_key: 753b7cc01a1a2e86221266a154af739463fce51219d97e4f856cd7200c3bd2a601
+# stx_address: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+# btc_address: mqVnk6NPRdhntvfm4hh9vvjiRkFDUuSYsH
+
+[accounts.wallet_1]
+mnemonic = "sell invite acquire kitten bamboo drastic jelly vivid peace spawn twice guilt pave pen trash pretty park cube fragile unaware remain midnight betray rebuild"
+balance = 100_000_000_000_000
+# secret_key: 7287ba251d44a4d3fd9276c88ce34c5c52a038955511cccaf77e61068649c17801
+# stx_address: ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5
+# btc_address: mr1iPkD9N3RJZZxXRk7xF9d36gffa6exNC
+
+[accounts.wallet_2]
+mnemonic = "hold excess usual excess ring elephant install account glad dry fragile donkey gaze humble truck breeze nation gasp vacuum limb head keep delay hospital"
+balance = 100_000_000_000_000
+# secret_key: 530d9f61984c888536871c6573073bdfc0058896dc1adfe9a6a10dfacadc209101
+# stx_address: ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG
+# btc_address: muYdXKmX9bByAueDe6KFfHd5Ff1gdN9ErG
+
+[accounts.wallet_3]
+mnemonic = "cycle puppy glare enroll cost improve round trend wrist mushroom scorpion tower claim oppose clever elephant dinosaur eight problem before frozen dune wagon high"
+balance = 100_000_000_000_000
+# secret_key: d655b2523bcd65e34889725c73064feb17ceb796831c0e111ba1a552b0f31b3901
+# stx_address: ST2JHG361ZXG51QTKY2NQCVBPPRRE2KZB1HR05NNC
+# btc_address: mvZtbibDAAA3WLpY7zXXFqRa3T4XSknBX7
+
+[accounts.wallet_4]
+mnemonic = "board list obtain sugar hour worth raven scout denial thunder horse logic fury scorpion fold genuine phrase wealth news aim below celery when cabin"
+balance = 100_000_000_000_000
+# secret_key: f9d7206a47f14d2870c163ebab4bf3e70d18f5d14ce1031f3902fbbc894fe4c701
+# stx_address: ST2NEB84ASENDXKYGJPQW86YXQCEFEX2ZQPG87ND
+# btc_address: mg1C76bNTutiCDV3t9nWhZs3Dc8LzUufj8
+
+[accounts.wallet_5]
+mnemonic = "hurry aunt blame peanut heavy update captain human rice crime juice adult scale device promote vast project quiz unit note reform update climb purchase"
+balance = 100_000_000_000_000
+# secret_key: 3eccc5dac8056590432db6a35d52b9896876a3d5cbdea53b72400bc9c2099fe801
+# stx_address: ST2REHHS5J3CERCRBEPMGH7921Q6PYKAADT7JP2VB
+# btc_address: mweN5WVqadScHdA81aATSdcVr4B6dNokqx
+
+[accounts.wallet_6]
+mnemonic = "area desk dutch sign gold cricket dawn toward giggle vibrant indoor bench warfare wagon number tiny universe sand talk dilemma pottery bone trap buddy"
+balance = 100_000_000_000_000
+# secret_key: 7036b29cb5e235e5fd9b09ae3e8eec4404e44906814d5d01cbca968a60ed4bfb01
+# stx_address: ST3AM1A56AK2C1XAFJ4115ZSV26EB49BVQ10MGCS0
+# btc_address: mzxXgV6e4BZSsz8zVHm3TmqbECt7mbuErt
+
+[accounts.wallet_7]
+mnemonic = "prevent gallery kind limb income control noise together echo rival record wedding sense uncover school version force bleak nuclear include danger skirt enact arrow"
+balance = 100_000_000_000_000
+# secret_key: b463f0df6c05d2f156393eee73f8016c5372caa0e9e29a901bb7171d90dc4f1401
+# stx_address: ST3PF13W7Z0RRM42A8VZRVFQ75SV1K26RXEP8YGKJ
+# btc_address: n37mwmru2oaVosgfuvzBwgV2ysCQRrLko7
+
+[accounts.wallet_8]
+mnemonic = "female adjust gallery certain visit token during great side clown fitness like hurt clip knife warm bench start reunion globe detail dream depend fortune"
+balance = 100_000_000_000_000
+# secret_key: 6a1a754ba863d7bab14adbbc3f8ebb090af9e871ace621d3e5ab634e1422885e01
+# stx_address: ST3NBRSFKX28FQ2ZJ1MAKX58HKHSDGNV5N7R21XCP
+# btc_address: n2v875jbJ4RjBnTjgbfikDfnwsDV5iUByw
+
+[accounts.wallet_9]
+mnemonic = "shadow private easily thought say logic fault paddle word top book during ignore notable orange flight clock image wealth health outside kitten belt reform"
+balance = 100_000_000_000_000
+# secret_key: de433bdfa14ec43aa1098d5be594c8ffb20a31485ff9de2923b2689471c401b801
+# stx_address: STNHKEPYEPJ8ET55ZZ0M5A34J0R3N5FM2CMMMAZ6
+# btc_address: mjSrB3wS4xab3kYqFktwBzfTdPg367ZJ2d
+
+[devnet]
+disable_bitcoin_explorer = true
+# disable_stacks_explorer = true
+# disable_stacks_api = true
+# working_dir = "tmp/devnet"
+# stacks_node_events_observers = ["host.docker.internal:8002"]
+# miner_mnemonic = "twice kind fence tip hidden tilt action fragile skin nothing glory cousin green tomorrow spring wrist shed math olympic multiply hip blue scout claw"
+# miner_derivation_path = "m/44'/5757'/0'/0/0"
+# orchestrator_port = 20445
+# bitcoin_node_p2p_port = 18444
+# bitcoin_node_rpc_port = 18443
+# bitcoin_node_username = "devnet"
+# bitcoin_node_password = "devnet"
+# bitcoin_controller_port = 18442
+# bitcoin_controller_block_time = 30_000
+# stacks_node_rpc_port = 20443
+# stacks_node_p2p_port = 20444
+# stacks_api_port = 3999
+# stacks_api_events_port = 3700
+# bitcoin_explorer_port = 8001
+# stacks_explorer_port = 8000
+# postgres_port = 5432
+# postgres_username = "postgres"
+# postgres_password = "postgres"
+# postgres_database = "postgres"
+# bitcoin_node_image_url = "quay.io/hirosystems/bitcoind:devnet"
+# stacks_node_image_url = "localhost:5000/stacks-node:devnet"
+# stacks_api_image_url = "blockstack/stacks-blockchain-api:latest"
+# stacks_explorer_image_url = "blockstack/explorer:latest"
+# bitcoin_explorer_image_url = "quay.io/hirosystems/bitcoin-explorer:devnet"
+# postgres_image_url = "postgres:alpine"
+
+# Send some stacking orders
+[[devnet.pox_stacking_orders]]
+start_at_cycle = 3
+duration = 12
+wallet = "wallet_1"
+slots = 2
+btc_address = "mr1iPkD9N3RJZZxXRk7xF9d36gffa6exNC"
+
+[[devnet.pox_stacking_orders]]
+start_at_cycle = 3
+duration = 12
+wallet = "wallet_2"
+slots = 1
+btc_address = "muYdXKmX9bByAueDe6KFfHd5Ff1gdN9ErG"
+
+[[devnet.pox_stacking_orders]]
+start_at_cycle = 3
+duration = 12
+wallet = "wallet_3"
+slots = 1
+btc_address = "mvZtbibDAAA3WLpY7zXXFqRa3T4XSknBX7"

--- a/examples/simple-nft/tests/simple-nft.test.ts
+++ b/examples/simple-nft/tests/simple-nft.test.ts
@@ -1,0 +1,37 @@
+// import { Clarinet, Tx, Chain, Account, Contract, types } from 'https://deno.land/x/clarinet@v0.13.0/index.ts';
+import { Clarinet, Tx, Chain, Account, Contract, types } from '../../../deno/index.ts';
+import { assertEquals } from "https://deno.land/std@0.90.0/testing/asserts.ts";
+
+Clarinet.test({
+    name: "Ensure that nft can be transferred form one account to another",
+    async fn(chain: Chain, accounts: Map<string, Account>, contracts: Map<string, Contract>) {
+        let deployer = accounts.get("deployer")!;
+        let wallet_1 = accounts.get("wallet_1")!;
+        let wallet_2 = accounts.get("wallet_2")!;
+
+        
+        let block = chain.mineBlock([
+            Tx.contractCall("simple-nft", "test-mint", [types.principal(wallet_1.address)], wallet_1.address),
+        ]);
+
+        block.receipts[0].result.expectOk().expectBool(true);
+
+        block = chain.mineBlock([
+            Tx.contractCall("simple-nft", "transfer", [
+                types.uint(1),
+                types.principal(wallet_1.address),
+                types.principal(wallet_2.address)
+            ], wallet_1.address)
+        ]);
+
+        block.receipts[0].result.expectOk().expectBool(true);
+
+        block.receipts[0].events.expectNonFungibleTokenTransferEvent(
+            types.uint(1),
+            wallet_1.address, 
+            wallet_2.address, 
+            `${deployer.address}.simple-nft`,
+            "nft"
+        )
+    },
+});

--- a/examples/simple-nft/tests/simple-nft.test.ts
+++ b/examples/simple-nft/tests/simple-nft.test.ts
@@ -35,3 +35,25 @@ Clarinet.test({
         )
     },
 });
+
+Clarinet.test({
+    name: "Ensure that nft can be minted",
+    async fn(chain: Chain, accounts: Map<string, Account>, contracts: Map<string, Contract>) {
+        let deployer = accounts.get("deployer")!;
+        let wallet_1 = accounts.get("wallet_1")!;
+
+        
+        let block = chain.mineBlock([
+            Tx.contractCall("simple-nft", "test-mint", [types.principal(wallet_1.address)], wallet_1.address),
+        ]);
+
+        block.receipts[0].result.expectOk().expectBool(true);
+
+        block.receipts[0].events.expectNonFungibleTokenMintEvent(
+            types.uint(1),
+            wallet_1.address, 
+            `${deployer.address}.simple-nft`,
+            "nft"
+        )
+    },
+});

--- a/examples/simple-nft/tests/simple-nft.test.ts
+++ b/examples/simple-nft/tests/simple-nft.test.ts
@@ -57,3 +57,30 @@ Clarinet.test({
         )
     },
 });
+
+Clarinet.test({
+    name: "Ensure that nft can be burned",
+    async fn(chain: Chain, accounts: Map<string, Account>, contracts: Map<string, Contract>) {
+        let deployer = accounts.get("deployer")!;
+        let wallet_1 = accounts.get("wallet_1")!;
+
+        
+        let block = chain.mineBlock([
+            Tx.contractCall("simple-nft", "test-mint", [types.principal(wallet_1.address)], wallet_1.address),
+        ]);
+
+        block.receipts[0].result.expectOk().expectBool(true);
+
+        block = chain.mineBlock([
+            Tx.contractCall("simple-nft", "test-burn", [types.uint(1), types.principal(wallet_1.address)], wallet_1.address),
+        ]);
+        block.receipts[0].result.expectOk().expectBool(true);
+
+        block.receipts[0].events.expectNonFungibleTokenBurnEvent(
+            types.uint(1),
+            wallet_1.address, 
+            `${deployer.address}.simple-nft`,
+            "nft"
+        )
+    },
+});


### PR DESCRIPTION
This PR adds working assertions for all 3 (mint, transfer, burn) NFT events.

I decided to detect events not only based on `assetId` but also `assetAddress`. Same contract can be deployed using different addresses and in such cases using only `assetId` is not selective enough and can give false positive results.

I added example project with simple SIP-009 compliant contract and tests that shows how these new assertions could be used.