### PR TITLE
Improve argument types

### DIFF
--- a/deno/ext/stacksjs-helper-generator.ts
+++ b/deno/ext/stacksjs-helper-generator.ts
@@ -45,6 +45,38 @@
 
 import { Clarinet, Contract, Account, StacksNode } from '../index.ts';
 
+function typeToCVType(argType: any) {
+  switch (argType) {
+    case "bool":
+      return "BooleanCV";
+    case "int128":
+      return "IntCV";
+    case "uint128":
+      return "UIntCV";
+    case "principal":
+      return "PrincipalCV";
+    case "response":
+      return "ResponseCV";
+    default:
+      switch (Object.keys(argType)[0]) {
+        case "buffer":
+          return "BufferCV";
+        case "optional":
+          return "NoneCV";
+        case "list":
+          return "ListCV";
+        case "tuple":
+          return "TupleCV";
+        case "string-ascii":
+          return "StringAsciiCV";
+        case "string-utf8":
+          return "StringUtf8CV";
+        default:
+          return "ClarityValue";
+      }
+  }
+}
+
 Clarinet.run({
     async fn(accounts: Map<string, Account>, contracts: Map<string, Contract>, node: StacksNode) {
         let code = [];
@@ -97,7 +129,7 @@ Clarinet.run({
                         ]);
                         for (let arg of f.args) {
                             code.push([
-                                `                ${kebabToCamel(arg.name)}: ClarityValue,`,
+                                `                ${kebabToCamel(arg.name)}: ${typeToCVType(arg.type)},`,
                             ]);
                         }
                         code.push([

--- a/deno/ext/stacksjs-helper-generator.ts
+++ b/deno/ext/stacksjs-helper-generator.ts
@@ -18,7 +18,7 @@
 //             export interface IncrementArgs {
 //                 step: ClarityValue,
 //             }
-//             export function args(args: IncrementArgs): [ClarityValue] {
+//             export function args(args: IncrementArgs): ClarityValue[] {
 //                 return [
 //                     args.step,
 //                 ];
@@ -84,7 +84,7 @@ Clarinet.run({
             `// Code generated with the stacksjs-helper-generator extension`,
             `// Manual edits will be overwritten`,
             ``,
-            `import { ClarityValue } from "@stacks/transactions"`,
+            `import { ClarityValue, BooleanCV, IntCV, UIntCV, BufferCV, OptionalCV, ResponseCV, PrincipalCV, ListCV, TupleCV, StringAsciiCV, StringUtf8CV } from "@stacks/transactions"`,
             ``,
         ]);
 
@@ -139,7 +139,7 @@ Clarinet.run({
 
                         // Generate code for helper function
                         code.push([
-                            `            export function args(args: ${kebabToCamel(capitalize(f.name))}Args): [ClarityValue] {`,
+                            `            export function args(args: ${kebabToCamel(capitalize(f.name))}Args): ClarityValue[] {`,
                             `                return [`
                         ]);
                         for (let arg of f.args) {


### PR DESCRIPTION
This PR
* set the argument type to a specific type instead of `ClarityValue`

Still to do: The generated import should reflect the used types. What is the best approach here?