### PR TITLE
Feat/generate `tasks.json` file

### DIFF
--- a/src/generate/project.rs
+++ b/src/generate/project.rs
@@ -26,6 +26,7 @@ impl GetChangesForNewProject {
         self.create_environment_devnet_toml();
         self.create_vscode_directory();
         self.create_vscode_settings_json();
+        self.create_vscode_tasks_json();
         self.create_gitignore();
         self.changes.clone()
     }
@@ -87,6 +88,47 @@ impl GetChangesForNewProject {
 "#
         );
         let name = format!("settings.json");
+        let path = format!(
+            "{}/{}/.vscode/{}",
+            self.project_path, self.project_name, name
+        );
+        let change = FileCreation {
+            comment: format!(
+                "{} {}/.vscode/{}",
+                green!("Created file"),
+                self.project_name,
+                name
+            ),
+            name,
+            content,
+            path,
+        };
+        self.changes.push(Changes::AddFile(change));
+    }
+
+    fn create_vscode_tasks_json(&mut self) {
+        let content = format!(
+            r#"
+{{
+    "version": "2.0.0",
+    "tasks": [
+        {{
+            "label": "check contracts",
+            "group": "test",
+            "type": "shell",
+            "command": "clarinet check"
+        }},
+        {{
+            "label": "test contracts",
+            "group": "test",
+            "type": "shell",
+            "command": "clarinet test"
+        }}
+    ]
+}}
+"#
+        );
+        let name = format!("tasks.json");
         let path = format!(
             "{}/{}/.vscode/{}",
             self.project_path, self.project_name, name

--- a/src/generate/project.rs
+++ b/src/generate/project.rs
@@ -25,6 +25,7 @@ impl GetChangesForNewProject {
         self.create_environment_testnet_toml();
         self.create_environment_devnet_toml();
         self.create_vscode_directory();
+        self.create_vscode_settings_json();
         self.create_gitignore();
         self.changes.clone()
     }
@@ -75,6 +76,9 @@ impl GetChangesForNewProject {
     fn create_vscode_directory(&mut self) {
         self.changes
             .push(self.get_changes_for_new_root_dir(format!(".vscode")));
+    }
+
+    fn create_vscode_settings_json(&mut self) {
         let content = format!(
             r#"
 {{


### PR DESCRIPTION
This PR adds `tasks.json` file generation during new project creation.

Right now generated `tasks.json` file contains only 2 tasks. First executes `clarinet check`, and second one `clarinet test`.

close #154 