### PR TITLE
Compatibility with clarity-repl v0.17.0+

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -344,7 +344,7 @@ jobs:
             ./target/${{ matrix.target }}/release/clarinet test --manifest-path ${testdir}/Clarinet.toml
           }
 
-      - name: Upload Artifacts to GH release (Not Windows)
+      - name: Upload Cargo Artifact to GH release (Not Windows)
         uses: svenstaro/upload-release-action@v2
         if: startsWith(github.ref, 'refs/tags/v') && matrix.os != 'windows-latest'
         with:
@@ -352,12 +352,20 @@ jobs:
           file: clarinet-${{ matrix.platform }}-${{ matrix.architecture }}.tar.gz
           tag: ${{ github.ref }}
 
-      - name: Upload Artifacts to GH release (Windows)
+      - name: Upload Cargo Artifact to GH release (Windows)
         uses: svenstaro/upload-release-action@v2
         if: startsWith(github.ref, 'refs/tags/v') && matrix.os == 'windows-latest'
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: clarinet-${{ matrix.platform }}-${{ matrix.architecture }}.msi
+          tag: ${{ github.ref }}
+
+      - name: Upload Node Artifact to GH release
+        uses: svenstaro/upload-release-action@v2
+        if: startsWith(github.ref, 'refs/tags/v')
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: stacks-devnet-js-${{ matrix.platform }}-${{ matrix.architecture }}.tar.gz
           tag: ${{ github.ref }}
 
       # Cleans the `./target` dir after the build such that only dependencies are cached on CI

--- a/.github/workflows/pkg-version-bump.yaml
+++ b/.github/workflows/pkg-version-bump.yaml
@@ -33,7 +33,7 @@ jobs:
           brew bump-formula-pr \
             --no-browse \
             --no-audit \
-            --tag "${TAG}"
+            --tag "${TAG}" \
             ${{ github.event.repository.name }}
 
   winget:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -377,9 +377,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "blake2b_simd"
@@ -705,9 +705,9 @@ dependencies = [
 
 [[package]]
 name = "clarity-repl"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab9a91d7ef8169adf9cf5dfd0e58907453d67e3180bb2a481864b8fc2cb63fa"
+checksum = "a96af7d108e64c2842d4786184973c1e768e38930f8f18c6f8840378dbc1e575"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
@@ -2473,9 +2473,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.98"
+version = "0.2.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
+checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
 
 [[package]]
 name = "libloading"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ deno_core = { path = "./vendor/deno/core", optional = true }
 deno_runtime = { path = "./vendor/deno/runtime", optional = true }
 deno = { path = "./vendor/deno/cli", optional = true }
 # clarity_repl = { package = "clarity-repl", path = "../../clarity-repl", features = ["cli"] }
-clarity_repl = { package = "clarity-repl", version = "=0.16.0" }
+clarity_repl = { package = "clarity-repl", version = "=0.17.0" }
 bip39 = { version = "1.0.1", default-features = false }
 aes = "0.6.0"
 base64 = "0.13.0"

--- a/src/runnner/deno.rs
+++ b/src/runnner/deno.rs
@@ -1213,7 +1213,11 @@ fn mine_block(state: &mut OpState, args: Value, _: ()) -> Result<String, AnyErro
                         continue;
                     }
                 };
-                receipts.push((execution.result, execution.events));
+                let result = match execution.result {
+                    Some(output) => format!("{}", output),
+                    _ => unreachable!("Value empty")
+                };
+                receipts.push((result, execution.events));
             } else {
                 session.set_tx_sender(tx.sender.clone());
                 if let Some(ref args) = tx.deploy_contract {
@@ -1225,7 +1229,11 @@ fn mine_block(state: &mut OpState, args: Value, _: ()) -> Result<String, AnyErro
                             Some(name.into()),
                         )
                         .unwrap(); // todo(ludo)
-                    receipts.push((execution.result, execution.events));
+                    let result = match execution.result {
+                        Some(output) => format!("{}", output),
+                        _ => unreachable!("Value empty")
+                    };
+                    receipts.push((result, execution.events));
                 } else if let Some(ref args) = tx.transfer_stx {
                     let snippet = format!(
                         "(stx-transfer? u{} tx-sender '{})",
@@ -1234,7 +1242,11 @@ fn mine_block(state: &mut OpState, args: Value, _: ()) -> Result<String, AnyErro
                     let execution = session
                         .interpret(snippet, None, true, Some(name.into()))
                         .unwrap(); // todo(ludo)
-                    receipts.push((execution.result, execution.events));
+                    let result = match execution.result {
+                        Some(output) => format!("{}", output),
+                        _ => unreachable!("Value empty")
+                    };
+                    receipts.push((result, execution.events));
                 }
                 session.set_tx_sender(initial_tx_sender.clone());
             }
@@ -1302,8 +1314,11 @@ fn call_read_only_fn(state: &mut OpState, args: Value, _: ()) -> Result<String, 
                 "readonly-calls".into(),
             )
             .unwrap(); // todo(ludo)
-
-        Ok((execution.result, execution.events))
+        let result = match execution.result {
+            Some(output) => format!("{}", output),
+            _ => unreachable!("Value empty")
+        };
+        Ok((result, execution.events))
     })?;
     Ok(json!({
       "session_id": args.session_id,

--- a/src/runnner/deno.rs
+++ b/src/runnner/deno.rs
@@ -1215,7 +1215,7 @@ fn mine_block(state: &mut OpState, args: Value, _: ()) -> Result<String, AnyErro
                 };
                 let result = match execution.result {
                     Some(output) => format!("{}", output),
-                    _ => unreachable!("Value empty")
+                    _ => unreachable!("Value empty"),
                 };
                 receipts.push((result, execution.events));
             } else {
@@ -1231,7 +1231,7 @@ fn mine_block(state: &mut OpState, args: Value, _: ()) -> Result<String, AnyErro
                         .unwrap(); // todo(ludo)
                     let result = match execution.result {
                         Some(output) => format!("{}", output),
-                        _ => unreachable!("Value empty")
+                        _ => unreachable!("Value empty"),
                     };
                     receipts.push((result, execution.events));
                 } else if let Some(ref args) = tx.transfer_stx {
@@ -1244,7 +1244,7 @@ fn mine_block(state: &mut OpState, args: Value, _: ()) -> Result<String, AnyErro
                         .unwrap(); // todo(ludo)
                     let result = match execution.result {
                         Some(output) => format!("{}", output),
-                        _ => unreachable!("Value empty")
+                        _ => unreachable!("Value empty"),
                     };
                     receipts.push((result, execution.events));
                 }
@@ -1316,7 +1316,7 @@ fn call_read_only_fn(state: &mut OpState, args: Value, _: ()) -> Result<String, 
             .unwrap(); // todo(ludo)
         let result = match execution.result {
             Some(output) => format!("{}", output),
-            _ => unreachable!("Value empty")
+            _ => unreachable!("Value empty"),
         };
         Ok((result, execution.events))
     })?;


### PR DESCRIPTION
In clarity-repl v0.17.0, we updated the type of `result` in the `ExecutionResult` data structure - from String to ClarityValue.
The interface Deno/Rust in Clarinet is still expecting a Clarity value formatted as a string, and was acting strangely in presence of a ClarityValue. This PR is fixing this issue. 
