### PR TITLE
Tweaks on stacks-devnet-js lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,21 @@ Blockstack. Smart contracts allow developers to encode essential business logic 
 
 ![screenshot](docs/images/demo.gif)
 
+### Screencasts
+
+A serie of short tutorials is available as a playlist of screencasts on Youtube, covering the following subjects:
+
+- [What is Clarinet?](https://youtu.be/a451iFQfZOE)
+- [Create a new project](https://youtu.be/BPB_gM960BA)
+- [Add a public function in a Clarity contract](https://youtu.be/fjQLmpMSws8)
+- [Invoking a function from the console](https://youtu.be/MGljkGjsSco)
+- [Write unit tests using Typescript](https://youtu.be/YxWk804IdXU)
+- [A simple CI with Clarinet and Github](https://youtu.be/5w-QTGq8W5I)
+- [Execute tests and check code covereage](https://youtu.be/jZ_XUqfbCqg)
+- [Introduction to smart contract integration with Clarinet](https://youtu.be/pucJ_tOC3pk)
+- [Setup a React project interacting with Clarinet](https://youtu.be/b7iipqzTUH8)
+- [Setup an intgration test environment with stacks-devnet-js](https://youtu.be/BqeL17m1dZk)
+
 ## Installation
 
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ development, testing and deployment. Clarinet consists of a Clarity REPL and a t
 together allow you to rapidly develop and test a Clarity smart contract, with the need to deploy the contract to a local
 devnet or testnet.
 
-Clarity is a **decidable** smart contract language that optimizes for predictability and security, designed by
-Blockstack. Smart contracts allow developers to encode essential business logic on a blockchain.
+Clarity is a **decidable** smart contract language that optimizes for predictability and security, designed for
+the Stacks blockchain. Smart contracts allow developers to encode essential business logic on a blockchain.
 
 ![screenshot](docs/images/demo.gif)
 

--- a/node-bindings/README.md
+++ b/node-bindings/README.md
@@ -1,0 +1,67 @@
+# stacks-devnet-js
+
+`stacks-devnet-js` is a node library, designed to let developers write integration tests for decentralized protocols built on top of the Stacks blockchain.
+It is implemented as a dynamic library that can be loaded by Node, and will let you orchestrate a Stacks Devnet network, locally, using Docker.
+
+### Installation
+
+```bash
+// Yarn
+yarn add dev @hirosystems/stacks-devnet-js
+
+// NPM
+npm install --save-dev @hirosystems/stacks-devnet-js
+```
+
+If any error occurs during the installation of this package, feel free to open an issue on this repository. 
+
+
+### Usage
+
+```typescript
+import {
+  makeSTXTokenTransfer,
+  broadcastTransaction,
+  AnchorMode,
+} from '@stacks/transactions';
+import { StacksTestnet }from '@stacks/network';
+import { StacksDevnetOrchestrator } from "stacks-devnet-js";
+import BigNum from 'bn.js';
+
+const orchestrator = new StacksDevnetOrchestrator({
+  path: "../protocol/Clarinet.toml",
+  logs: false,
+});
+
+beforeAll(() => orchestrator.start())
+afterAll(() => orchestrator.stop())
+
+test('Block height changes when blocks are mined', async () => {
+    const network = new StacksTestnet({ url: orchestrator.getStacksNodeUrl() });
+
+    // Let's wait for our Genesis block
+    var block = orchestrator.waitForStacksBlock();
+
+    // Build a transaction
+    const txOptions = {
+      recipient: 'ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5',
+      amount: new BigNum(12345),
+      senderKey: '753b7cc01a1a2e86221266a154af739463fce51219d97e4f856cd7200c3bd2a601',
+      network,
+      memo: 'test memo',
+      nonce: new BigNum(0), // set a nonce manually if you don't want builder to fetch from a Stacks node
+      fee: new BigNum(200), // set a tx fee if you don't want the builder to estimate
+      anchorMode: AnchorMode.OnChainOnly
+    };
+    const transaction = await makeSTXTokenTransfer(txOptions);
+
+    // Broadcast transaction to our Devnet stacks node
+    await broadcastTransaction(transaction, network);
+    
+    // Wait for the next block
+    block = orchestrator.waitForStacksBlock();
+
+    // Ensure that the transaction was included in the block
+    console.log(`Next Block: ${JSON.stringify(block)}`);
+})
+```

--- a/node-bindings/README.md
+++ b/node-bindings/README.md
@@ -6,10 +6,10 @@ It is implemented as a dynamic library that can be loaded by Node, and will let 
 ### Installation
 
 ```bash
-// Yarn
+# Yarn
 yarn add dev @hirosystems/stacks-devnet-js
 
-// NPM
+# NPM
 npm install --save-dev @hirosystems/stacks-devnet-js
 ```
 
@@ -65,3 +65,11 @@ test('Block height changes when blocks are mined', async () => {
     console.log(`Next Block: ${JSON.stringify(block)}`);
 })
 ```
+
+### Screencasts
+
+A serie of short tutorials is available as a playlist of screencasts on Youtube, covering the following subjects:
+
+- [Introduction to smart contract integration with Clarinet](https://youtu.be/pucJ_tOC3pk)
+- [Setup a React project interacting with Clarinet](https://youtu.be/b7iipqzTUH8)
+- [Setup an intgration test environment with stacks-devnet-js](https://youtu.be/BqeL17m1dZk)

--- a/node-bindings/lib/index.ts
+++ b/node-bindings/lib/index.ts
@@ -294,7 +294,7 @@ export interface ClarinetManifest {
    */
   accounts?: Account[];
   /**
-   * Blockchains that utilize a username model (where the address is not a derivative of a cryptographic public key) should specify the public key(s) owned by the address in metadata.
+   * Devnet config values that will be overriding any values present in the Devnet.toml file.
    * @type {DevnetConfig}
    * @memberof ClarinetManifest
    */

--- a/node-bindings/package.json
+++ b/node-bindings/package.json
@@ -3,10 +3,11 @@
   "version": "0.20.0",
   "description": "stacks-devnet-js is a library for writing end to end tests for protocols interacting with the Stacks blockchain and the Bitcoin blockchain.",
   "author": "Ludo Galabru",
+  "repository": "https://github.com/hirosystems/clarinet/tree/main/node-bindings",
   "license": "GPL-3.0",
   "main": "dist/index.js",
   "files": [
-    "lib"
+    "dist"
   ],
   "scripts": {
     "build": "tsc --build && cargo-cp-artifact -nc native/index.node -- cargo build --message-format=json-render-diagnostics",


### PR DESCRIPTION
This PR is adding a README to the stacks-devnet-js lib and fixing a deployment issue - the `dist` folder should be deployed to NPM, not the `lib`. 