### PR TITLE
Migrate LSP into clarinet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,9 +14,9 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.16.0"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61f2b7f93d2c7d2b08263acaa4a363b3e276806c68af6134c44f523bf1aacd"
+checksum = "e7a2e47a1fbe209ee101dd6d61285226744c6c8d3c21c8dc878ba6cb9f467f3a"
 dependencies = [
  "gimli",
 ]
@@ -71,9 +71,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.18"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
 dependencies = [
  "memchr",
 ]
@@ -216,6 +216,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "auto_impl"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42cbf586c80ada5e5ccdecae80d3ef0854f224e2dd74435f8d87e6831b8d0a38"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2 1.0.29",
+ "quote 1.0.9",
+ "syn 1.0.74",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -223,9 +235,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backtrace"
-version = "0.3.61"
+version = "0.3.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7a905d892734eea339e896738c14b9afce22b5318f64b951e70bf3844419b01"
+checksum = "4717cfcbfaa661a0fd48f8453951837ae7e8f81e481fbb136e3202d72805a744"
 dependencies = [
  "addr2line",
  "cc",
@@ -382,6 +394,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "bitvec"
+version = "0.19.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55f93d0ef3363c364d5976646a38f04cf67cfe1d4c8d160cdea02cab2c116b33"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "blake2b_simd"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -509,9 +533,9 @@ checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
 name = "bstr"
-version = "0.2.16"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90682c8d613ad3373e66de8c6411e0ae2ab2571e879d2efbf73558cc66f21279"
+checksum = "a40b47ad93e1a5404e6c18dec46b628214fee441c70f4ab5d6942142cc268a3d"
 dependencies = [
  "lazy_static",
  "memchr",
@@ -694,6 +718,7 @@ dependencies = [
  "tiny-hderive",
  "tokio",
  "toml",
+ "tower-lsp",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
@@ -1871,6 +1896,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "funty"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
+
+[[package]]
 name = "futures"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2045,9 +2076,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.25.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0a01e0497841a3b2db4f8afa483cce65f7e96a3498bd6c541734792aeac8fe7"
+checksum = "0e4075386626662786ddb0ec9081e7c7eeb1ba31951f447ca780ef9f5d568189"
 
 [[package]]
 name = "glob"
@@ -2599,6 +2630,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "lsp-types"
+version = "0.89.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "852e0dedfd52cc32325598b2631e0eba31b7b708959676a9f837042f276b09a2"
+dependencies = [
+ "bitflags",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "url",
+]
+
+[[package]]
 name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2621,9 +2665,9 @@ checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
 name = "memchr"
-version = "2.4.0"
+version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
+checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
 name = "memoffset"
@@ -2797,6 +2841,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c5c51b9083a3c620fa67a2a635d1ce7d95b897e957d6b28ff9a5da960a103a6"
+dependencies = [
+ "bitvec",
+ "funty",
+ "memchr",
+ "version_check",
+]
+
+[[package]]
 name = "notify"
 version = "5.0.0-pre.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2912,12 +2968,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.26.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c55827317fb4c08822499848a14237d2874d6f139828893017237e7ab93eb386"
-dependencies = [
- "memchr",
-]
+checksum = "1a5b3dd1c072ee7963717671d1ca129f1048fda25edea6b752bfc71ac8854170"
 
 [[package]]
 name = "once_cell"
@@ -3340,6 +3393,12 @@ checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2 1.0.29",
 ]
+
+[[package]]
+name = "radium"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
 
 [[package]]
 name = "radix_fmt"
@@ -4017,6 +4076,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98d0516900518c29efa217c298fa1f4e6c6ffc85ae29fd7f4ee48f176e1a9ed5"
+dependencies = [
+ "proc-macro2 1.0.29",
+ "quote 1.0.9",
+ "syn 1.0.74",
 ]
 
 [[package]]
@@ -4915,6 +4985,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "tempfile"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5221,6 +5297,40 @@ name = "tower-layer"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343bc9466d3fe6b0f960ef45960509f84480bf4fd96f92901afe7ff3df9d3a62"
+
+[[package]]
+name = "tower-lsp"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "701465c44f9e5655785b1420f3dea1d33d15f2fea2e0a65d25c4fd91ec0e6238"
+dependencies = [
+ "async-trait",
+ "auto_impl",
+ "bytes",
+ "dashmap",
+ "futures",
+ "log",
+ "lsp-types",
+ "nom",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-util",
+ "tower-lsp-macros",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-lsp-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb72acc00b574cffa151d0725b3b26404554b371b4c6e059c58eb23f9f097140"
+dependencies = [
+ "heck",
+ "proc-macro2 1.0.29",
+ "quote 1.0.9",
+ "syn 1.0.74",
+]
 
 [[package]]
 name = "tower-service"
@@ -5832,6 +5942,12 @@ checksum = "ff4fb510bbfe5b8992ff15f77a2e6fe6cf062878f0eda00c0f44963a807ca5dc"
 dependencies = [
  "toml",
 ]
+
+[[package]]
+name = "wyz"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "xtask"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ tracing-appender = "0.1"
 ctrlc = "3.1.9"
 strum = { version = "0.22", features = ["derive"] }
 bitcoincore-rpc = "0.14.0"
-tower-lsp = "0.14.0"
+tower-lsp = { version = "0.14.0", optional = true }
 
 [dependencies.tui]
 version = "0.15.0"
@@ -97,7 +97,7 @@ path = "src/bin.rs"
 
 [features]
 default = ["cli"]
-cli = ["swc_common", "deno", "deno_runtime", "deno_core", "clap"]
+cli = ["swc_common", "deno", "deno_runtime", "deno_core", "clap", "tower-lsp"]
 
 [workspace]
 members = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ deno_core = { path = "./vendor/deno/core", optional = true }
 deno_runtime = { path = "./vendor/deno/runtime", optional = true }
 deno = { path = "./vendor/deno/cli", optional = true }
 # clarity_repl = { package = "clarity-repl", path = "../../clarity-repl", features = ["cli"] }
-clarity_repl = { package = "clarity-repl", version = "=0.16.0" }
+clarity_repl = { package = "clarity-repl", version = "=0.18.0" }
 bip39 = { version = "1.0.1", default-features = false }
 aes = "0.6.0"
 base64 = "0.13.0"
@@ -69,6 +69,7 @@ tracing-appender = "0.1"
 ctrlc = "3.1.9"
 strum = { version = "0.22", features = ["derive"] }
 bitcoincore-rpc = "0.14.0"
+tower-lsp = "0.14.0"
 
 [dependencies.tui]
 version = "0.15.0"

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -15,11 +15,11 @@ extern crate serde_json;
 #[macro_use]
 mod macros;
 
-mod lsp;
 mod frontend;
 mod generate;
 mod indexer;
 mod integrate;
+mod lsp;
 mod poke;
 mod publish;
 mod runnner;

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -15,6 +15,7 @@ extern crate serde_json;
 #[macro_use]
 mod macros;
 
+mod lsp;
 mod frontend;
 mod generate;
 mod indexer;

--- a/src/frontend/cli.rs
+++ b/src/frontend/cli.rs
@@ -9,10 +9,10 @@ use crate::generate::{
     changes::{Changes, TOMLEdition},
 };
 use crate::integrate::{self, DevnetOrchestrator};
+use crate::lsp::run_lsp;
 use crate::poke::load_session;
 use crate::publish::{publish_all_contracts, Network};
 use crate::runnner::run_scripts;
-use crate::lsp::run_lsp;
 use crate::types::{ProjectManifest, ProjectManifestFile, RequirementConfig};
 use clarity_repl::repl;
 
@@ -56,7 +56,7 @@ enum Command {
     Integrate(Integrate),
     /// Start a LSP session
     #[clap(name = "lsp")]
-    LSP,    
+    LSP,
 }
 
 #[derive(Clap, PartialEq, Clone, Debug)]
@@ -422,9 +422,7 @@ pub fn main() {
                 display_deploy_hint();
             }
         }
-        Command::LSP => {
-            run_lsp()
-        }
+        Command::LSP => run_lsp(),
     };
 }
 

--- a/src/frontend/cli.rs
+++ b/src/frontend/cli.rs
@@ -12,6 +12,7 @@ use crate::integrate::{self, DevnetOrchestrator};
 use crate::poke::load_session;
 use crate::publish::{publish_all_contracts, Network};
 use crate::runnner::run_scripts;
+use crate::lsp::run_lsp;
 use crate::types::{ProjectManifest, ProjectManifestFile, RequirementConfig};
 use clarity_repl::repl;
 
@@ -53,6 +54,9 @@ enum Command {
     /// Work on contracts integration
     #[clap(name = "integrate")]
     Integrate(Integrate),
+    /// Start a LSP session
+    #[clap(name = "lsp")]
+    LSP,    
 }
 
 #[derive(Clap, PartialEq, Clone, Debug)]
@@ -404,6 +408,9 @@ pub fn main() {
             if hints_enabled {
                 display_deploy_hint();
             }
+        }
+        Command::LSP => {
+            run_lsp()
         }
     };
 }

--- a/src/lsp/clarity_language_backend.rs
+++ b/src/lsp/clarity_language_backend.rs
@@ -1,0 +1,541 @@
+use clarity_repl::clarity::analysis::ContractAnalysis;
+use clarity_repl::clarity::ast::ContractAST;
+use clarity_repl::repl::{Session, SessionSettings};
+use tokio;
+
+use serde_json::Value;
+use tower_lsp::jsonrpc::Result;
+use tower_lsp::lsp_types::*;
+use tower_lsp::{async_trait, Client, LanguageServer, LspService, Server};
+
+use clarity_repl::clarity::analysis::AnalysisDatabase;
+use clarity_repl::clarity::costs::LimitedCostTracker;
+use clarity_repl::clarity::types::{QualifiedContractIdentifier, StandardPrincipalData};
+use clarity_repl::clarity::{analysis, ast};
+use clarity_repl::{clarity, repl};
+use sha2::Digest;
+use std::borrow::BorrowMut;
+use std::collections::HashMap;
+use std::fs::{self, File};
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use std::sync::{Arc, Mutex, RwLock};
+
+use crate::poke::load_session_settings;
+use crate::publish::Network;
+use super::utils;
+
+#[derive(Debug)]
+enum Symbol {
+    PublicFunction,
+    ReadonlyFunction,
+    PrivateFunction,
+    ImportedTrait,
+    LocalVariable,
+    Constant,
+    DataMap,
+    DataVar,
+    FungibleToken,
+    NonFungibleToken,
+}
+
+#[derive(Debug)]
+pub struct CompletionMaps {
+    pub inter_contract: Vec<CompletionItem>,
+    pub intra_contract: Vec<CompletionItem>,
+}
+
+#[derive(Debug)]
+pub struct ContractState {
+    analysis: ContractAnalysis,
+    intellisense: CompletionMaps,
+    session: Session,
+    // TODO(lgalabru)
+    // hash: Vec<u8>,
+    // symbols: HashMap<String, Symbol>,
+}
+
+type Logs = Vec<String>;
+
+#[derive(Debug)]
+pub struct ClarityLanguageBackend {
+    clarinet_toml_path: RwLock<Option<PathBuf>>,
+    contracts: RwLock<HashMap<Url, ContractState>>,
+    client: Client,
+    native_functions: Vec<CompletionItem>,
+}
+
+impl ClarityLanguageBackend {
+    pub fn new(client: Client) -> Self {
+        Self {
+            clarinet_toml_path: RwLock::new(None),
+            contracts: RwLock::new(HashMap::new()),
+            client,
+            native_functions: utils::build_default_native_keywords_list(),
+        }
+    }
+
+    pub fn run_full_analysis(
+        &self,
+    ) -> std::result::Result<(Vec<(Url, Diagnostic)>, Logs), (String, Logs)> {
+        let mut logs = vec![];
+        logs.push("Full analysis will start".into());
+
+        // Retrieve ./Clarinet.toml and settings/Development.toml paths
+        let settings = match self.get_config_files_paths() {
+            Err(message) => return Err((message, logs)),
+            Ok(Some(clarinet_toml_path)) => {
+                // Read these 2 files and build a SessionSetting
+                match load_session_settings(clarinet_toml_path, &Network::Devnet) {
+                    Err(message) => return Err((message, logs)),
+                    Ok((settings, _)) => settings,
+                }
+            }
+            Ok(None) => SessionSettings::default(),
+        };
+
+        // Build a blank Session: we will be evaluating the contracts one by one
+        let mut incremental_session = repl::Session::new(settings.clone());
+        let mut collected_diagnostics = vec![];
+        let mainnet = false;
+
+        for (i, contract) in settings.initial_contracts.iter().enumerate() {
+            let contract_path =
+                PathBuf::from_str(&contract.path).expect("Expect url to be well formatted");
+            let contract_url =
+                Url::from_file_path(contract_path).expect("Expect url to be well formatted");
+            let contract_id = contract
+                .get_contract_identifier(mainnet)
+                .expect("Expect contract to be named");
+            let code = fs::read_to_string(&contract.path).expect("Expect file to be readable");
+
+            logs.push(format!("Analysis #{}: {}", i, contract_id.to_string()));
+
+            // Before doing anything, keep a clone of the session before inserting anything in the datastore.
+            let session = incremental_session.clone();
+
+            // Extract the AST, and try to move to the next contract if we throw an error:
+            // we're trying to get as many errors as possible
+            let mut ast = match incremental_session
+                .interpreter
+                .build_ast(contract_id.clone(), code.clone())
+            {
+                Ok(ast) => ast,
+                Err((_, Some(diagnostic))) => {
+                    collected_diagnostics.push((
+                        contract_url.clone(),
+                        utils::convert_clarity_diagnotic_to_lsp_diagnostic(diagnostic),
+                    ));
+                    continue;
+                }
+                _ => {
+                    logs.push("Unable to get ast".into());
+                    continue;
+                }
+            };
+
+            // Run the analysis, and try to move to the next contract if we throw an error:
+            // we're trying to get as many errors as possible
+            let analysis = match incremental_session
+                .interpreter
+                .run_analysis(contract_id.clone(), &mut ast)
+            {
+                Ok(analysis) => analysis,
+                Err((_, Some(diagnostic))) => {
+                    collected_diagnostics.push((
+                        contract_url.clone(),
+                        utils::convert_clarity_diagnotic_to_lsp_diagnostic(diagnostic),
+                    ));
+                    continue;
+                }
+                _ => {
+                    logs.push("Unable to get diagnostic".into());
+                    continue;
+                }
+            };
+
+            // Executing the contract will also save the contract into the Datastore. This is required
+            // for the next contracts, that could depend on the current contract.
+            let _ = incremental_session.interpreter.execute(
+                contract_id.clone(),
+                &mut ast,
+                code.clone(),
+                analysis.clone(),
+                false,
+                None,
+            );
+
+            // We have a legit contract, let's extract some Intellisense data that will be served for
+            // auto-completion requests
+            let intellisense = utils::build_intellisense(&analysis);
+
+            let contract_state = ContractState {
+                analysis,
+                session,
+                intellisense,
+            };
+
+            if let Ok(ref mut contracts_writer) = self.contracts.write() {
+                contracts_writer.insert(contract_url, contract_state);
+            } else {
+                logs.push(format!("Unable to acquire write lock"));
+            }
+        }
+        return Ok((collected_diagnostics, logs));
+    }
+
+    pub fn run_single_analysis(
+        &self,
+        url: Url,
+    ) -> std::result::Result<(Vec<(Url, Diagnostic)>, Logs), (String, Logs)> {
+        let mut logs = vec![];
+        let settings = SessionSettings::default();
+        let mut incremental_session = repl::Session::new(settings.clone());
+        let mut collected_diagnostics = vec![];
+        let mainnet = false;
+
+        let contract_path = url.to_file_path().expect("Expect url to be well formatted");
+        let code = fs::read_to_string(&contract_path).expect("Expect file to be readable");
+
+        let contract_id = QualifiedContractIdentifier::transient();
+
+        logs.push(format!("Analysis: {}", contract_id.to_string()));
+
+        // Before doing anything, keep a clone of the session before inserting anything in the datastore.
+        let session = incremental_session.clone();
+
+        // Extract the AST, and try to move to the next contract if we throw an error:
+        // we're trying to get as many errors as possible
+        let mut ast = match incremental_session
+            .interpreter
+            .build_ast(contract_id.clone(), code.clone())
+        {
+            Ok(ast) => ast,
+            Err((_, Some(diagnostic))) => {
+                collected_diagnostics.push((
+                    url.clone(),
+                    utils::convert_clarity_diagnotic_to_lsp_diagnostic(diagnostic),
+                ));
+                return Ok((collected_diagnostics, logs));
+            }
+            _ => {
+                logs.push("Unable to get ast".into());
+                return Ok((collected_diagnostics, logs));
+            }
+        };
+
+        // Run the analysis, and try to move to the next contract if we throw an error:
+        // we're trying to get as many errors as possible
+        let analysis = match incremental_session
+            .interpreter
+            .run_analysis(contract_id.clone(), &mut ast)
+        {
+            Ok(analysis) => analysis,
+            Err((_, Some(diagnostic))) => {
+                collected_diagnostics.push((
+                    url.clone(),
+                    utils::convert_clarity_diagnotic_to_lsp_diagnostic(diagnostic),
+                ));
+                return Ok((collected_diagnostics, logs));
+            }
+            _ => {
+                logs.push("Unable to get diagnostic".into());
+                return Ok((collected_diagnostics, logs));
+            }
+        };
+
+        // We have a legit contract, let's extract some Intellisense data that will be served for
+        // auto-completion requests
+        let intellisense = utils::build_intellisense(&analysis);
+
+        let contract_state = ContractState {
+            analysis,
+            session,
+            intellisense,
+        };
+
+        if let Ok(ref mut contracts_writer) = self.contracts.write() {
+            contracts_writer.insert(url, contract_state);
+        } else {
+            logs.push(format!("Unable to acquire write lock"));
+        }
+
+        return Ok((collected_diagnostics, logs));
+    }
+
+    fn get_contracts_urls(&self) -> Vec<Url> {
+        let contracts_reader = self.contracts.read().unwrap();
+        contracts_reader.keys().map(|u| u.clone()).collect()
+    }
+
+    fn get_config_files_paths(&self) -> std::result::Result<Option<(PathBuf)>, String> {
+        match self.clarinet_toml_path.read() {
+            Ok(clarinet_toml_path) => {
+                match clarinet_toml_path.as_ref() {
+                    Some(clarinet_toml_path) => Ok(Some(
+                        clarinet_toml_path.clone(),
+                    )),
+                    _ => Ok(None),
+                }
+            }
+            _ => return Err("Unable to acquire locks".into()),
+        }
+    }
+
+    fn is_clarinet_workspace(&self) -> bool {
+        match self.get_config_files_paths() {
+            Ok(Some(clarinet_toml_path)) => true,
+            _ => false,
+        }
+    }
+}
+
+impl ClarityLanguageBackend {
+    async fn handle_diagnostics(
+        &self,
+        diagnostics: Option<Vec<(Url, Diagnostic)>>,
+        logs: Vec<String>,
+    ) {
+        // let (diagnostics, messages) = self.run_incremental_analysis(None);
+        for m in logs.iter() {
+            self.client.log_message(MessageType::Info, m).await;
+        }
+
+        if let Some(diagnostics) = diagnostics {
+            // Note: None != Some(vec![]): When we pass None, it means that we were unable to get some
+            // diagnostics, so don't flush the current diagnostics.
+            for url in self.get_contracts_urls().into_iter() {
+                self.client.publish_diagnostics(url, vec![], None).await;
+            }
+
+            if !diagnostics.is_empty() {
+                let erroring_files = diagnostics
+                    .iter()
+                    .map(|(url, _)| {
+                        url.to_file_path()
+                            .unwrap()
+                            .file_name()
+                            .unwrap()
+                            .to_str()
+                            .unwrap()
+                            .to_string()
+                    })
+                    .collect::<Vec<_>>();
+                self.client
+                    .show_message(
+                        MessageType::Error,
+                        format!(
+                            "Errors detected in following contracts: {}",
+                            erroring_files.join(", ")
+                        ),
+                    )
+                    .await;
+            }
+            for (url, diagnostic) in diagnostics.into_iter() {
+                self.client
+                    .publish_diagnostics(url, vec![diagnostic], None)
+                    .await;
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl LanguageServer for ClarityLanguageBackend {
+    async fn initialize(&self, params: InitializeParams) -> Result<InitializeResult> {
+        let mut manifest_file_path = None;
+
+        // Are we looking at a workspace that would include a Clarinet project?
+        if let Some(workspace_folders) = params.workspace_folders {
+            for folder in workspace_folders.iter() {
+                let root_path = folder
+                    .uri
+                    .to_file_path()
+                    .expect("Unable to turn URL into path");
+
+                let mut clarinet_toml_path = root_path.clone();
+                clarinet_toml_path.push("Clarinet.toml");
+
+                if clarinet_toml_path.exists() {
+                    manifest_file_path = Some(clarinet_toml_path);
+                    break;
+                }
+            }
+        }
+
+        match (&manifest_file_path, params.root_uri) {
+            (None, Some(root_uri)) => {
+                // Are we looking at a folder that would include a Clarinet project?
+                let root_path = root_uri
+                    .to_file_path()
+                    .expect("Unable to turn URL into path");
+
+                let mut clarinet_toml_path = root_path.clone();
+                clarinet_toml_path.push("Clarinet.toml");
+
+                if clarinet_toml_path.exists() {
+                    manifest_file_path = Some(clarinet_toml_path);
+                }
+            }
+            _ => {}
+        }
+
+        if let Some(clarinet_toml_path) = manifest_file_path {
+            let mut clarinet_toml_path_writer = self.clarinet_toml_path.write().unwrap();
+            *clarinet_toml_path_writer = Some(clarinet_toml_path.clone());
+        }
+
+        Ok(InitializeResult {
+            server_info: None,
+            capabilities: ServerCapabilities {
+                text_document_sync: Some(TextDocumentSyncCapability::Kind(
+                    TextDocumentSyncKind::Full,
+                )),
+                completion_provider: Some(CompletionOptions {
+                    resolve_provider: Some(false),
+                    trigger_characters: None,
+                    all_commit_characters: None,
+                    work_done_progress_options: Default::default(),
+                }),
+                type_definition_provider: None,
+                hover_provider: Some(HoverProviderCapability::Simple(false)),
+                declaration_provider: Some(DeclarationCapability::Simple(false)),
+                ..ServerCapabilities::default()
+            },
+        })
+    }
+
+    async fn initialized(&self, params: InitializedParams) {
+        // If we're not in a Clarinet workspace, don't try to be smart.
+        if !self.is_clarinet_workspace() {
+            return;
+        }
+
+        match self.run_full_analysis() {
+            Ok((diagnostics, logs)) => {
+                self.handle_diagnostics(Some(diagnostics), logs).await;
+            }
+            Err((message, logs)) => {
+                self.handle_diagnostics(None, logs).await;
+                self.client.log_message(MessageType::Error, message).await;
+            }
+        };
+    }
+
+    async fn shutdown(&self) -> Result<()> {
+        Ok(())
+    }
+
+    async fn execute_command(&self, _: ExecuteCommandParams) -> Result<Option<Value>> {
+        Ok(None)
+    }
+
+    async fn completion(&self, params: CompletionParams) -> Result<Option<CompletionResponse>> {
+        let mut keywords = self.native_functions.clone();
+        let contract_uri = params.text_document_position.text_document.uri;
+
+        let (mut contract_keywords, mut contract_calls) = {
+            let contracts_reader = self.contracts.read().unwrap();
+            let contract_keywords = match contracts_reader.get(&contract_uri) {
+                Some(entry) => entry.intellisense.intra_contract.clone(),
+                _ => vec![],
+            };
+            let mut contract_calls = vec![];
+            for (url, contract_state) in contracts_reader.iter() {
+                if !contract_uri.eq(url) {
+                    contract_calls.append(&mut contract_state.intellisense.inter_contract.clone());
+                }
+            }
+            (contract_keywords, contract_calls)
+        };
+
+        keywords.append(&mut contract_keywords);
+        keywords.append(&mut contract_calls);
+
+        // Little big detail: should we wrap the inserted_text with braces?
+        let should_wrap = {
+            // let line = params.text_document_position.position.line;
+            // let char = params.text_document_position.position.character;
+            // let doc = params.text_document_position.text_document.uri;
+            //
+            // TODO(lgalabru): from there, we'd need to get the prior char
+            // and see if a parenthesis was opened. If not, we need to wrap.
+            // The LSP would need to update its local document cache, via
+            // the did_change method.
+            true
+        };
+        if should_wrap {
+            for item in keywords.iter_mut() {
+                match item.kind {
+                    Some(CompletionItemKind::Event)
+                    | Some(CompletionItemKind::Function)
+                    | Some(CompletionItemKind::Module)
+                    | Some(CompletionItemKind::Class)
+                    | Some(CompletionItemKind::Method) => {
+                        item.insert_text = Some(format!("({})", item.insert_text.take().unwrap()));
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        Ok(Some(CompletionResponse::from(keywords)))
+    }
+
+    async fn did_open(&self, _: DidOpenTextDocumentParams) {}
+
+    // async fn did_change(&self, changes: DidChangeTextDocumentParams) {
+    //     if let Some(change) = changes.content_changes.last() {
+    //         self.client.log_message(MessageType::Info, change.text.clone()).await;
+    //     }
+    // }
+
+    async fn did_save(&self, params: DidSaveTextDocumentParams) {
+        let results = match self.is_clarinet_workspace() {
+            true => self.run_full_analysis(),
+            false => self.run_single_analysis(params.text_document.uri),
+        };
+
+        match results {
+            Ok((diagnostics, logs)) => {
+                self.handle_diagnostics(Some(diagnostics), logs).await;
+            }
+            Err((message, logs)) => {
+                self.handle_diagnostics(None, logs).await;
+                self.client.log_message(MessageType::Error, message).await;
+            }
+        };
+    }
+
+    async fn did_close(&self, _: DidCloseTextDocumentParams) {}
+
+    // fn symbol(&self, params: WorkspaceSymbolParams) -> Self::SymbolFuture {
+    //     Box::new(future::ok(None))
+    // }
+
+    // fn goto_declaration(&self, _: TextDocumentPositionParams) -> Self::DeclarationFuture {
+    //     Box::new(future::ok(None))
+    // }
+
+    // fn goto_definition(&self, _: TextDocumentPositionParams) -> Self::DefinitionFuture {
+    //     Box::new(future::ok(None))
+    // }
+
+    // fn goto_type_definition(&self, _: TextDocumentPositionParams) -> Self::TypeDefinitionFuture {
+    //     Box::new(future::ok(None))
+    // }
+
+    // fn hover(&self, _: TextDocumentPositionParams) -> Self::HoverFuture {
+    //     // todo(ludo): to implement
+    //     let result = Hover {
+    //         contents: HoverContents::Scalar(MarkedString::String("".to_string())),
+    //         range: None,
+    //     };
+    //     Box::new(future::ok(None))
+    // }
+
+    // fn document_highlight(&self, _: TextDocumentPositionParams) -> Self::HighlightFuture {
+    //     Box::new(future::ok(None))
+    // }
+}

--- a/src/lsp/mod.rs
+++ b/src/lsp/mod.rs
@@ -7,7 +7,7 @@ use tower_lsp::{LspService, Server};
 
 pub fn run_lsp() {
     match block_on(do_run_lsp()) {
-        Err(e) => std::process::exit(1),
+        Err(_e) => std::process::exit(1),
         _ => {}
     };
 }

--- a/src/lsp/mod.rs
+++ b/src/lsp/mod.rs
@@ -1,0 +1,33 @@
+mod clarity_language_backend;
+mod utils;
+
+use clarity_language_backend::ClarityLanguageBackend;
+use tokio;
+use tower_lsp::{LspService, Server};
+
+pub fn run_lsp() {
+    match block_on(do_run_lsp()) {
+        Err(e) => std::process::exit(1),
+        _ => {}
+    };
+}
+
+pub fn block_on<F, R>(future: F) -> R
+where
+    F: std::future::Future<Output = R>,
+{
+    let rt = crate::utils::create_basic_runtime();
+    rt.block_on(future)
+}
+
+async fn do_run_lsp() -> Result<(), String> {
+    let stdin = tokio::io::stdin();
+    let stdout = tokio::io::stdout();
+
+    let (service, messages) = LspService::new(|client| ClarityLanguageBackend::new(client));
+    Server::new(stdin, stdout)
+        .interleave(messages)
+        .serve(service)
+        .await;
+    Ok(())
+}

--- a/src/lsp/utils.rs
+++ b/src/lsp/utils.rs
@@ -1,0 +1,337 @@
+use clarity_repl::clarity::analysis::ContractAnalysis;
+use clarity_repl::clarity::diagnostic::Diagnostic as ClarityDiagnostic;
+use clarity_repl::clarity::docs::{
+    make_api_reference, make_define_reference, make_keyword_reference,
+};
+use clarity_repl::clarity::functions::define::DefineFunctions;
+use clarity_repl::clarity::functions::NativeFunctions;
+use clarity_repl::clarity::types::{BlockInfoProperty, FunctionType};
+use clarity_repl::clarity::variables::NativeVariables;
+use tower_lsp::lsp_types::Diagnostic as LspDiagnostic;
+use tower_lsp::lsp_types::*;
+
+use super::clarity_language_backend::CompletionMaps;
+
+pub fn convert_clarity_diagnotic_to_lsp_diagnostic(diagnostic: ClarityDiagnostic) -> LspDiagnostic {
+    let range = match diagnostic.spans.len() {
+        0 => Range::default(),
+        _ => Range {
+            start: Position {
+                line: diagnostic.spans[0].start_line - 1,
+                character: diagnostic.spans[0].start_column,
+            },
+            end: Position {
+                line: diagnostic.spans[0].end_line - 1,
+                character: diagnostic.spans[0].end_column,
+            },
+        },
+    };
+    // TODO(lgalabru): add hint for contracts not found errors
+    LspDiagnostic {
+        range,
+        severity: Some(DiagnosticSeverity::Error),
+        code: None,
+        code_description: None,
+        source: Some("clarity".to_string()),
+        message: diagnostic.message,
+        related_information: None,
+        tags: None,
+        data: None,
+    }
+}
+
+fn build_intellisense_args(signature: &FunctionType) -> Vec<String> {
+    let mut args = vec![];
+    match signature {
+        FunctionType::Fixed(function) => {
+            for (i, arg) in function.args.iter().enumerate() {
+                args.push(format!("${{{}:{}:{}}}", i + 1, arg.name, arg.signature));
+            }
+        }
+        _ => {}
+    }
+    args
+}
+
+pub fn build_intellisense(analysis: &ContractAnalysis) -> CompletionMaps {
+    let mut intra_contract = vec![];
+    let mut inter_contract = vec![];
+
+    for (name, signature) in analysis.public_function_types.iter() {
+        let insert_text = format!("{} {}", name, build_intellisense_args(signature).join(" "));
+        intra_contract.push(CompletionItem {
+            label: name.to_string(),
+            kind: Some(CompletionItemKind::Module),
+            detail: None,
+            documentation: None,
+            deprecated: None,
+            preselect: None,
+            sort_text: None,
+            filter_text: None,
+            insert_text: Some(insert_text),
+            insert_text_format: Some(InsertTextFormat::Snippet),
+            insert_text_mode: None,
+            text_edit: None,
+            additional_text_edits: None,
+            command: None,
+            commit_characters: None,
+            data: None,
+            tags: None,
+        });
+
+        let label = format!(
+            "contract-call::{}::{}",
+            analysis.contract_identifier.name.to_string(),
+            name.to_string()
+        );
+        let insert = format!("{} {}", name, build_intellisense_args(signature).join(" "));
+        let insert_text = format!(
+            "contract-call? .{} {} {}",
+            analysis.contract_identifier.name.to_string(),
+            name.to_string(),
+            build_intellisense_args(signature).join(" ")
+        );
+        inter_contract.push(CompletionItem {
+            label,
+            kind: Some(CompletionItemKind::Event),
+            detail: None,
+            documentation: None,
+            deprecated: None,
+            preselect: None,
+            sort_text: None,
+            filter_text: None,
+            insert_text: Some(insert_text),
+            insert_text_format: Some(InsertTextFormat::Snippet),
+            insert_text_mode: None,
+            text_edit: None,
+            additional_text_edits: None,
+            command: None,
+            commit_characters: None,
+            data: None,
+            tags: None,
+        });
+    }
+
+    for (name, signature) in analysis.read_only_function_types.iter() {
+        let insert_text = format!("{} {}", name, build_intellisense_args(signature).join(" "));
+        intra_contract.push(CompletionItem {
+            label: name.to_string(),
+            kind: Some(CompletionItemKind::Module),
+            detail: None,
+            documentation: None,
+            deprecated: None,
+            preselect: None,
+            sort_text: None,
+            filter_text: None,
+            insert_text: Some(insert_text),
+            insert_text_format: Some(InsertTextFormat::Snippet),
+            insert_text_mode: None,
+            text_edit: None,
+            additional_text_edits: None,
+            command: None,
+            commit_characters: None,
+            data: None,
+            tags: None,
+        });
+
+        let label = format!(
+            "contract-call::{}::{}",
+            analysis.contract_identifier.name.to_string(),
+            name.to_string()
+        );
+        let insert_text = format!(
+            "contract-call? .{} {} {}",
+            analysis.contract_identifier.name.to_string(),
+            name.to_string(),
+            build_intellisense_args(signature).join(" ")
+        );
+        inter_contract.push(CompletionItem {
+            label,
+            kind: Some(CompletionItemKind::Event),
+            detail: None,
+            documentation: None,
+            deprecated: None,
+            preselect: None,
+            sort_text: None,
+            filter_text: None,
+            insert_text: Some(insert_text),
+            insert_text_format: Some(InsertTextFormat::Snippet),
+            insert_text_mode: None,
+            text_edit: None,
+            additional_text_edits: None,
+            command: None,
+            commit_characters: None,
+            data: None,
+            tags: None,
+        });
+    }
+
+    for (name, signature) in analysis.private_function_types.iter() {
+        let insert_text = format!("{} {}", name, build_intellisense_args(signature).join(" "));
+        intra_contract.push(CompletionItem {
+            label: name.to_string(),
+            kind: Some(CompletionItemKind::Module),
+            detail: None,
+            documentation: None,
+            deprecated: None,
+            preselect: None,
+            sort_text: None,
+            filter_text: None,
+            insert_text: Some(insert_text),
+            insert_text_format: Some(InsertTextFormat::Snippet),
+            insert_text_mode: None,
+            text_edit: None,
+            additional_text_edits: None,
+            command: None,
+            commit_characters: None,
+            data: None,
+            tags: None,
+        });
+    }
+
+    CompletionMaps {
+        inter_contract,
+        intra_contract,
+    }
+}
+
+pub fn build_default_native_keywords_list() -> Vec<CompletionItem> {
+    let native_functions: Vec<CompletionItem> = NativeFunctions::ALL
+        .iter()
+        .map(|func| {
+            let api = make_api_reference(&func);
+            CompletionItem {
+                label: api.name.to_string(),
+                kind: Some(CompletionItemKind::Function),
+                detail: Some(api.name.to_string()),
+                documentation: Some(Documentation::MarkupContent(MarkupContent {
+                    kind: MarkupKind::Markdown,
+                    value: api.description.to_string(),
+                })),
+                deprecated: None,
+                preselect: None,
+                sort_text: None,
+                filter_text: None,
+                insert_text: Some(api.snippet.clone()),
+                insert_text_format: Some(InsertTextFormat::Snippet),
+                insert_text_mode: None,
+                text_edit: None,
+                additional_text_edits: None,
+                command: None,
+                commit_characters: None,
+                data: None,
+                tags: None,
+            }
+        })
+        .collect();
+
+    let define_functions: Vec<CompletionItem> = DefineFunctions::ALL
+        .iter()
+        .map(|func| {
+            let api = make_define_reference(&func);
+            CompletionItem {
+                label: api.name.to_string(),
+                kind: Some(CompletionItemKind::Class),
+                detail: Some(api.name.to_string()),
+                documentation: Some(Documentation::MarkupContent(MarkupContent {
+                    kind: MarkupKind::Markdown,
+                    value: api.description.to_string(),
+                })),
+                deprecated: None,
+                preselect: None,
+                sort_text: None,
+                filter_text: None,
+                insert_text: Some(api.snippet.clone()),
+                insert_text_format: Some(InsertTextFormat::Snippet),
+                insert_text_mode: None,
+                text_edit: None,
+                additional_text_edits: None,
+                command: None,
+                commit_characters: None,
+                data: None,
+                tags: None,
+            }
+        })
+        .collect();
+
+    let native_variables: Vec<CompletionItem> = NativeVariables::ALL
+        .iter()
+        .map(|var| {
+            let api = make_keyword_reference(&var);
+            CompletionItem {
+                label: api.name.to_string(),
+                kind: Some(CompletionItemKind::Field),
+                detail: Some(api.name.to_string()),
+                documentation: Some(Documentation::MarkupContent(MarkupContent {
+                    kind: MarkupKind::Markdown,
+                    value: api.description.to_string(),
+                })),
+                deprecated: None,
+                preselect: None,
+                sort_text: None,
+                filter_text: None,
+                insert_text: Some(api.snippet.to_string()),
+                insert_text_format: Some(InsertTextFormat::PlainText),
+                insert_text_mode: None,
+                text_edit: None,
+                additional_text_edits: None,
+                command: None,
+                commit_characters: None,
+                data: None,
+                tags: None,
+            }
+        })
+        .collect();
+
+    let block_properties: Vec<CompletionItem> = BlockInfoProperty::ALL_NAMES
+        .to_vec()
+        .iter()
+        .map(|func| CompletionItem::new_simple(func.to_string(), "".to_string()))
+        .collect();
+
+    let types = vec![
+        "uint",
+        "int",
+        "bool",
+        "list",
+        "tuple",
+        "buff",
+        "string-ascii",
+        "string-utf8",
+        "option",
+        "response",
+    ]
+    .iter()
+    .map(|var| CompletionItem {
+        label: var.to_string(),
+        kind: Some(CompletionItemKind::TypeParameter),
+        detail: None,
+        documentation: None,
+        deprecated: None,
+        preselect: None,
+        sort_text: None,
+        filter_text: None,
+        insert_text: Some(var.to_string()),
+        insert_text_format: Some(InsertTextFormat::PlainText),
+        insert_text_mode: None,
+        text_edit: None,
+        additional_text_edits: None,
+        command: None,
+        commit_characters: None,
+        data: None,
+        tags: None,
+    })
+    .collect();
+
+    let items = vec![
+        native_functions,
+        define_functions,
+        native_variables,
+        block_properties,
+        types,
+    ]
+    .into_iter()
+    .flatten()
+    .collect::<Vec<CompletionItem>>();
+    items
+}

--- a/src/lsp/utils.rs
+++ b/src/lsp/utils.rs
@@ -84,7 +84,7 @@ pub fn build_intellisense(analysis: &ContractAnalysis) -> CompletionMaps {
             analysis.contract_identifier.name.to_string(),
             name.to_string()
         );
-        let insert = format!("{} {}", name, build_intellisense_args(signature).join(" "));
+        let _insert = format!("{} {}", name, build_intellisense_args(signature).join(" "));
         let insert_text = format!(
             "contract-call? .{} {} {}",
             analysis.contract_identifier.name.to_string(),

--- a/src/poke/mod.rs
+++ b/src/poke/mod.rs
@@ -4,11 +4,11 @@ use clarity_repl::{repl, Terminal};
 use std::fs;
 use std::path::PathBuf;
 
-pub fn load_session(
+
+pub fn load_session_settings(
     manifest_path: PathBuf,
-    start_repl: bool,
     env: &Network,
-) -> Result<(repl::Session, ChainConfig), String> {
+) -> Result<(repl::SessionSettings, ChainConfig), String> {
     let mut settings = repl::SessionSettings::default();
 
     let mut project_path = manifest_path.clone();
@@ -101,6 +101,18 @@ pub fn load_session(
     ];
     settings.initial_deployer = initial_deployer;
     settings.costs_version = project_config.project.costs_version;
+
+    Ok((settings, chain_config))
+}
+
+
+pub fn load_session(
+    manifest_path: PathBuf,
+    start_repl: bool,
+    env: &Network,
+) -> Result<(repl::Session, ChainConfig), String> {
+
+    let (settings, chain_config) = load_session_settings(manifest_path, env)?;
 
     let session = if start_repl {
         let mut terminal = Terminal::new(settings.clone());

--- a/src/poke/mod.rs
+++ b/src/poke/mod.rs
@@ -4,7 +4,6 @@ use clarity_repl::{repl, Terminal};
 use std::fs;
 use std::path::PathBuf;
 
-
 pub fn load_session_settings(
     manifest_path: PathBuf,
     env: &Network,
@@ -109,13 +108,11 @@ pub fn load_session_settings(
     Ok((settings, chain_config))
 }
 
-
 pub fn load_session(
     manifest_path: PathBuf,
     start_repl: bool,
     env: &Network,
 ) -> Result<(repl::Session, ChainConfig, Option<String>), String> {
-
     let (settings, chain_config) = load_session_settings(manifest_path, env)?;
 
     let (session, output) = if start_repl {


### PR DESCRIPTION
Something that has been in the back of my mind for sometimes now.
With this PR, the idea is to move the Clarity LSP Rust implementation to Clarinet. There are several good reasons to make that move:
- The LSP is clearly a second class citizen today. By moving this feature to this repo, it would become top of mind,
- We want to leverage the amazing pipeline that we have in place in this repo. Apple M1 users are struggling with the LSP, which is something that we solved with this repo, thanks to brew.
- https://github.com/hirosystems/clarity-lsp is going to be re-purposed as a web extension soon, that can be loaded in vscode.dev / github.dev. However, we want to keep this feature available for Vim / Emacs / etc, and Clarinet is a good candidate for hosting this feature.
