### PR TITLE
release: v0.21.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -719,21 +719,18 @@ dependencies = [
 
 [[package]]
 name = "clarity-repl"
-version = "0.19.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8178916fdf07c088db18414fd6070f3498780bb58e4f73fa9a0589e6e45fd585"
+checksum = "c1483f3421cc90e13ec2b2b8148a7760d99a5d0e0a795dcb206c5bfed6cc1e53"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
- "getrandom 0.2.3",
  "integer-sqrt",
  "lazy_static",
  "libsecp256k1 0.5.0",
  "pico-args 0.4.2",
  "prettytable-rs",
  "rand 0.7.3",
- "rand_pcg 0.3.1",
- "rand_seeder",
  "regex",
  "reqwest",
  "ripemd160",
@@ -2083,10 +2080,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
  "cfg-if 1.0.0",
- "js-sys",
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -3505,7 +3500,7 @@ dependencies = [
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc 0.2.0",
- "rand_pcg 0.2.1",
+ "rand_pcg",
 ]
 
 [[package]]
@@ -3589,24 +3584,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
 dependencies = [
  "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_pcg"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
-dependencies = [
- "rand_core 0.6.3",
-]
-
-[[package]]
-name = "rand_seeder"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612dd698949d531335b4c29d1c64fb11942798decfc08abc218578942e66d7d0"
-dependencies = [
- "rand_core 0.6.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ deno_core = { path = "./vendor/deno/core", optional = true }
 deno_runtime = { path = "./vendor/deno/runtime", optional = true }
 deno = { path = "./vendor/deno/cli", optional = true }
 # clarity_repl = { package = "clarity-repl", path = "../../clarity-repl", features = ["cli"] }
-clarity_repl = { package = "clarity-repl", version = "=0.19.0" }
+clarity_repl = { package = "clarity-repl", version = "=0.18.0" }
 bip39 = { version = "1.0.1", default-features = false }
 aes = "0.7.5"
 base64 = "0.13.0"


### PR DESCRIPTION
fix: rollback to clarity-repl v0.18.0 - it looks like v0.19.0 is not completely ready for prime time.
