### PR TITLE
feat: added ignore and only options to clarinet test

### DIFF
--- a/deno/index.ts
+++ b/deno/index.ts
@@ -186,6 +186,8 @@ type PreSetupFunction = () => Array<Tx>;
 
 interface UnitTestOptions {
   name: string;
+  only?: true;
+  ignore? :true;
   preSetup?: PreSetupFunction;
   fn: TestFunction;
 }
@@ -214,6 +216,8 @@ export class Clarinet {
   static test(options: UnitTestOptions) {
     Deno.test({
       name: options.name,
+      only: options.only,
+      ignore: options.ignore,
       async fn() {
         (Deno as any).core.ops();
 


### PR DESCRIPTION
pass the option `only: true` to `Clarinet.test({})` to run only this test
pass the option `ignore: true` to `Clarinet.test({})` to ignore the test
