### PR TITLE
fail gracefully on Clarinet.toml errors

### DIFF
--- a/src/types/project_manifest.rs
+++ b/src/types/project_manifest.rs
@@ -77,7 +77,11 @@ impl ProjectManifest {
             match toml::from_slice(&project_manifest_file_buffer[..]) {
                 Ok(s) => s,
                 Err(_e) => {
-                    println!("{}\n{:?}", red!("Error: there is an issue with the Clarinet.toml file"), _e);
+                    println!(
+                        "{}\n{:?}",
+                        red!("Error: there is an issue with the Clarinet.toml file"),
+                        _e
+                    );
                     std::process::exit(1);
                 }
             };

--- a/src/types/project_manifest.rs
+++ b/src/types/project_manifest.rs
@@ -77,7 +77,7 @@ impl ProjectManifest {
             match toml::from_slice(&project_manifest_file_buffer[..]) {
                 Ok(s) => s,
                 Err(_e) => {
-                    println!("Error: there is an issue with the Clarinet.toml file");
+                    println!("{}\n{:?}", red!("Error: there is an issue with the Clarinet.toml file"), _e);
                     std::process::exit(1);
                 }
             };

--- a/src/types/project_manifest.rs
+++ b/src/types/project_manifest.rs
@@ -72,8 +72,16 @@ impl ProjectManifest {
         project_manifest_file_reader
             .read_to_end(&mut project_manifest_file_buffer)
             .unwrap();
+
         let project_manifest_file: ProjectManifestFile =
-            toml::from_slice(&project_manifest_file_buffer[..]).unwrap();
+            match toml::from_slice(&project_manifest_file_buffer[..]) {
+                Ok(s) => s,
+                Err(_e) => {
+                    println!("Error: there is an issue with the Clarinet.toml file");
+                    std::process::exit(1);
+                }
+            };
+
         ProjectManifest::from_project_manifest_file(project_manifest_file)
     }
 


### PR DESCRIPTION
Implementation of an enhancement described by the issue #174 .

The `clarinet check` feature will show an error message if there is something wrong with the `Clarinet.toml` file:

`Error: there is an issue with the Clarinet.toml file`