### PR TITLE
fixed links to documentation inside the application

### DIFF
--- a/src/frontend/cli.rs
+++ b/src/frontend/cli.rs
@@ -785,7 +785,7 @@ fn display_deploy_hint() {
     );
     println!(
         "{}",
-        yellow!("Find more information on the DevNet here: https://docs.hiro.so/smart-contracts/devnet")
+        yellow!("Find more information on the DevNet here: https://docs.hiro.so/smart-contracts/devnet/")
     );
     display_hint_footer();
 }

--- a/src/frontend/cli.rs
+++ b/src/frontend/cli.rs
@@ -694,7 +694,7 @@ fn display_post_check_hint() {
         "{}",
         yellow!("    Run all run tests in the ./tests folder.\n")
     );
-    println!("{}", yellow!("Find more information on testing with Clarinet here: https://docs.hiro.so/docs/smart-contracts/clarinet#testing-with-the-test-harness"));
+    println!("{}", yellow!("Find more information on testing with Clarinet here: https://docs.hiro.so/smart-contracts/clarinet#testing-with-the-test-harness"));
     display_hint_footer();
 }
 
@@ -717,7 +717,7 @@ fn display_post_poke_hint() {
         yellow!("    Check contract syntax for all files in ./contracts.\n")
     );
 
-    println!("{}", yellow!("Find more information on writing contracts with Clarinet here: https://docs.hiro.so/docs/smart-contracts/clarinet#developing-a-clarity-smart-contract"));
+    println!("{}", yellow!("Find more information on writing contracts with Clarinet here: https://docs.hiro.so/smart-contracts/clarinet#developing-a-clarity-smart-contract"));
     display_hint_footer();
 }
 
@@ -755,7 +755,7 @@ fn display_tests_pro_tips_hint() {
         yellow!("    Deploy all contracts to a local dockerized blockchain setup (Devnet).\n")
     );
 
-    println!("{}", yellow!("Find more information on testing with Clarinet here: https://docs.hiro.so/docs/smart-contracts/clarinet#testing-with-clarinet"));
+    println!("{}", yellow!("Find more information on testing with Clarinet here: https://docs.hiro.so/smart-contracts/clarinet#testing-with-clarinet"));
     display_hint_footer();
 }
 
@@ -785,7 +785,7 @@ fn display_deploy_hint() {
     );
     println!(
         "{}",
-        yellow!("Find more information on the DevNet here: https://docs.hiro.so/docs/smart-contracts/devnet")
+        yellow!("Find more information on the DevNet here: https://docs.hiro.so/smart-contracts/devnet")
     );
     display_hint_footer();
 }


### PR DESCRIPTION
Using the clarinet application you sometimes get links to documentation that are broken.
Fixed the links to the working ones.