### PR TITLE
Don't attempt to sign Windows executable on merge to develop

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -266,7 +266,7 @@ jobs:
 
       - name: Build Installer (Windows)
         if: matrix.os == 'windows-latest'
-        run: cargo wix -v --no-build --nocapture
+        run: cargo wix -v --no-build --nocapture -p clarinet
 
       - name: Code sign installer (Windows)
         if: matrix.os == 'windows-latest'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -245,7 +245,7 @@ jobs:
           npm run build-${{ matrix.platform }}-${{ matrix.architecture }}
 
       - name: Code sign bin (Windows)
-        if: matrix.os == 'windows-latest'
+        if: startsWith(github.ref, 'refs/tags/v') && matrix.os == 'windows-latest'
         run: |
           $certificate_file_name = "${env:TEMP}\certificate.pfx"
 
@@ -269,7 +269,7 @@ jobs:
         run: cargo wix -v --no-build --nocapture -p clarinet
 
       - name: Code sign installer (Windows)
-        if: matrix.os == 'windows-latest'
+        if: startsWith(github.ref, 'refs/tags/v') && matrix.os == 'windows-latest'
         run: |
           $certificate_file_name = "${env:TEMP}\certificate.pfx"
 


### PR DESCRIPTION
Testing a change in the CI script to avoid an error from code-signing in Windows from outside developers.