### PR TITLE
docs: clarify develop vs main branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,7 +56,7 @@ jobs:
         run: cargo install cargo-audit
 
       - name: Run audit
-        run: cargo audit --ignore RUSTSEC-2021-0076 --ignore RUSTSEC-2021-0079 --ignore RUSTSEC-2021-0078 --ignore RUSTSEC-2021-0093 --ignore RUSTSEC-2020-0159 --ignore RUSTSEC-2021-0119 --ignore RUSTSEC-2020-0071
+        run: cargo audit --ignore RUSTSEC-2021-0076 --ignore RUSTSEC-2021-0079 --ignore RUSTSEC-2021-0078 --ignore RUSTSEC-2021-0093 --ignore RUSTSEC-2020-0159 --ignore RUSTSEC-2021-0119 --ignore RUSTSEC-2020-0071 --ignore RUSTSEC-2022-0006
 
       - name: Run rustfmt
         run: cargo fmt --all -- --check

--- a/README.md
+++ b/README.md
@@ -84,6 +84,18 @@ cd clarinet
 cargo install --path . --locked
 ```
 
+By default, you will be in our development branch, `develop`, with code that has not been released yet. If you plan to submit any changes to the code, then this is the right branch for you. If you just want the latest stable version, switch to the main branch:
+
+```bash
+git checkout main
+```
+
+If you have previously checked out the source, ensure you have the latest code (including submodules) before building using:
+```
+git pull
+git submodule update --recursive
+```
+
 ## Getting started with Clarinet
 
 The following sections describe how to create a new project in Clarinet and populate it with smart contracts. Clarinet


### PR DESCRIPTION
Since the default branch is `develop`, when users clone the repo, it
will be in this branch by default. This change clarifies in the README
that if they want the latest stable code, they should switch to the
`main` branch.

Add information about updated the deno submodule when pulling into a
previously checked out repo.

Resolves: #231 