### PR TITLE
fix: crash on `clarinet new contract`

### DIFF
--- a/src/frontend/cli.rs
+++ b/src/frontend/cli.rs
@@ -715,7 +715,8 @@ fn execute_changes(changes: Vec<Changes>) {
     }
 
     if let Some(config) = shared_config {
-        let toml = toml::to_string(&config).unwrap();
+        let toml_value = toml::Value::try_from(&config).unwrap();
+        let toml = format!("{}", toml_value);
         let mut file = File::create(path).unwrap();
         file.write_all(&toml.as_bytes()).unwrap();
         file.sync_all().unwrap();


### PR DESCRIPTION
After the addition of `repl` in `ProjectManifest` in a5695025, calling
`toml::to_string` on this struct caused a `ValueAfterTable` error. This
problem is handled in the display of the value, so this alternative
method of generating the string avoids the problem.

This is a quick fix, but this code will soon be changed to solve #246.