### PR TITLE
fix: fix serialization of REPL settings

### DIFF
--- a/src/types/project_manifest.rs
+++ b/src/types/project_manifest.rs
@@ -33,6 +33,7 @@ pub struct ProjectManifest {
     pub project: ProjectConfig,
     #[serde(serialize_with = "toml::ser::tables_last")]
     pub contracts: BTreeMap<String, ContractConfig>,
+    #[serde(rename = "repl")]
     pub repl_settings: repl::Settings,
 }
 


### PR DESCRIPTION
In commit cfe7af3a, the new `ProjectConfig` does not serialize the REPL
settings with the correct names to be deserialized later. This struct
gets serialized by `execute_changes`.