### PR TITLE
fix: update to clarity-repl 0.22.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -719,9 +719,9 @@ dependencies = [
 
 [[package]]
 name = "clarity-repl"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fffe6671f38773d6073ccf579cdc4a16b4ab7189c1fdf61c5068c696b91e73"
+checksum = "b581621ab215ae79e204d87d2af14fd72382dc4d5ece0b60f89d57da8586e262"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ deno_core = { path = "./vendor/deno/core", optional = true }
 deno_runtime = { path = "./vendor/deno/runtime", optional = true }
 deno = { path = "./vendor/deno/cli", optional = true }
 # clarity_repl = { package = "clarity-repl", path = "../../clarity-repl", features = ["cli"] }
-clarity_repl = { package = "clarity-repl", version = "=0.22.0" }
+clarity_repl = { package = "clarity-repl", version = "=0.22.1" }
 bip39 = { version = "1.0.1", default-features = false }
 aes = "0.7.5"
 base64 = "0.13.0"


### PR DESCRIPTION
This version fixes the problem where warnings from analysis of contracts
are not printed to the screen (ex. when using `clarinet check`).