### PR TITLE
ci: run brew update prior to bump

### DIFF
--- a/.github/workflows/pkg-version-bump.yaml
+++ b/.github/workflows/pkg-version-bump.yaml
@@ -30,6 +30,7 @@ jobs:
           git config --global user.name "${GIT_USER_NAME}"
           git config --global user.email "${GIT_USER_EMAIL}"
 
+          brew update
           brew bump-formula-pr \
             --no-browse \
             --no-audit \


### PR DESCRIPTION
Run `brew update` to avoid conflicts when running `brew bump-formula-pr`. See https://github.com/Homebrew/homebrew-core/pull/95059