### PR TITLE
docs: improve billboard example

### DIFF
--- a/examples/billboard/tests/billboard_test.ts
+++ b/examples/billboard/tests/billboard_test.ts
@@ -4,6 +4,7 @@ import { assertEquals } from 'https://deno.land/std@0.90.0/testing/asserts.ts';
 Clarinet.test({
     name: "A quick demo on how to assert expectations",
     async fn(chain: Chain, accounts: Map<string, Account>) {
+        let deployer = accounts.get('deployer')!;
         let wallet_1 = accounts.get('wallet_1')!;
 
         let assetMaps = chain.getAssetsMaps();
@@ -27,8 +28,8 @@ Clarinet.test({
         
         let [event] = block.receipts[0].events;
         let {sender, recipient, amount} = event.stx_transfer_event;
-        sender.expectPrincipal("ST1J4G6RR643BCG8G8SR6M2D9Z9KXT2NJDRK3FBTK");
-        recipient.expectPrincipal("ST1HTBVD3JG9C05J7HBJTHGR0GGW7KXW28M5JS8QE.billboard");
+        sender.expectPrincipal(wallet_1.address);
+        recipient.expectPrincipal(`${deployer.address}.billboard`);
         amount.expectInt(100);
 
         assetMaps = chain.getAssetsMaps();


### PR DESCRIPTION
The addresses were hard-coded into the test, and it is not obvious to
new developers where those are coming from. This change uses the account
names to get the addresses instead.

See hirosystems/docs#67