### PR TITLE
feat: stacks-devnet-js support for linux-musl (non-glibc, e.g. alpine)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -134,45 +134,24 @@ jobs:
           - os: ubuntu-latest
             platform: linux
             target: x86_64-unknown-linux-gnu
-            linker_package:
-            cc: ""
             architecture: x64
-          # To be uncommented later when adding new distros
-          # - os: ubuntu-latest
-          #   platform: linux
-          #   target: aarch64-unknown-linux-gnu
-          #   linker_package: gcc-aarch64-linux-gnu
-          #   cc: aarch64-linux-gnu-gcc
-          #   architecture: arm64
-          # - os: ubuntu-latest
-          #   platform: linux
-          #   target: armv7-unknown-linux-gnueabihf
-          #   linker_package: gcc-arm-linux-gnueabihf
-          #   cc: arm-linux-gnueabihf-gcc
-          #   architecture: armv7l
-          # - os: ubuntu-latest
-          #   platform: linux
-          #   target: x86_64-unknown-linux-musl
-          #   linker_package:
-          #   cc: musl-gcc
-          #   architecture: x64
+            libc: glibc
+          - os: ubuntu-latest
+            platform: linux
+            target: x86_64-unknown-linux-musl
+            architecture: x64
+            libc: musl
           - os: windows-latest
             platform: windows
             target: x86_64-pc-windows-msvc
-            linker_package:
-            cc: ""
             architecture: x64
           - os: macos-latest
             platform: darwin
             target: x86_64-apple-darwin
-            linker_package:
-            cc: ""
             architecture: x64
           - os: macos-latest
             platform: darwin
             target: aarch64-apple-darwin
-            linker_package:
-            cc: ""
             architecture: arm64
 
     steps:
@@ -196,6 +175,7 @@ jobs:
           override: true
 
       - name: Install and cache Node
+        if: matrix.target != 'x86_64-unknown-linux-musl'
         uses: actions/setup-node@v2
         with:
           node-version: '14'
@@ -223,11 +203,6 @@ jobs:
             target/${{ matrix.target }}/release/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-      # To be uncommented later when adding new distros
-      # - name: Install ${{ matrix.platform }}-${{ matrix.architecture }} linker
-      #   if: ${{ matrix.platform }}-${{ matrix.architecture }} == 'linux-arm64' || ${{ matrix.platform }}-${{ matrix.architecture }} == 'linux-armv7' || ${{ matrix.platform }}-${{ matrix.architecture }} == 'linux-musl-x64'
-      #   run: sudo apt-get update && sudo apt-get install -y ${{ matrix.linker_package }}
-
       # Set environment variables required from cross compiling from macos-x86_64 to macos-arm64
       - name: Configure macos-arm64 cross compile config
         if: matrix.target == 'aarch64-apple-darwin'
@@ -235,7 +210,22 @@ jobs:
           echo "SDKROOT=$(xcrun -sdk macosx --show-sdk-path)" >> $GITHUB_ENV
           echo "MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx --show-sdk-platform-version)" >> $GITHUB_ENV
 
+      - name: Configure artifact names (libc)
+        if: ${{ matrix.libc }}
+        shell: bash
+        run: |
+          echo "SHORT_TARGET_NAME=${{ matrix.platform }}-${{ matrix.architecture }}-${{ matrix.libc }}" >> $GITHUB_ENV
+          echo "PRE_GYP_TARGET_NAME=${{ matrix.platform }}-${{ matrix.architecture }}-${{ matrix.libc }}" >> $GITHUB_ENV
+
+      - name: Configure artifact names (not libc)
+        if: ${{ ! matrix.libc }}
+        shell: bash
+        run: |
+          echo "SHORT_TARGET_NAME=${{ matrix.platform }}-${{ matrix.architecture }}" >> $GITHUB_ENV
+          echo "PRE_GYP_TARGET_NAME=${{ matrix.platform }}-${{ matrix.architecture }}-unknown" >> $GITHUB_ENV
+
       - name: Build - Cargo
+        if: matrix.target != 'x86_64-unknown-linux-musl'
         run: cargo build --release --features=telemetry --locked --target ${{ matrix.target }}
         # To be uncommented later when adding new distros
         # env:
@@ -248,10 +238,24 @@ jobs:
         #   CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER: ${{ matrix.cc }}
 
       - name: Build - Node
+        if: matrix.target != 'x86_64-unknown-linux-musl'
         working-directory: node-bindings
         run: |
           npm install --ignore-scripts
-          npm run build-${{ matrix.platform }}-${{ matrix.architecture }}
+          npm run build-${{ env.SHORT_TARGET_NAME }}
+
+      - name: Build - Node (linux-musl)
+        if: matrix.target == 'x86_64-unknown-linux-musl'
+        uses: docker://rust:alpine3.15
+        env:
+          RUSTFLAGS: -C target-feature=-crt-static
+        with:
+          entrypoint: /bin/sh
+          args: -c "
+            cd node-bindings &&
+            apk add alpine-sdk nodejs npm git &&
+            npm install --ignore-scripts &&
+            npm run build-${{ env.SHORT_TARGET_NAME }}"
 
       - name: Code sign bin (Windows)
         if: startsWith(github.ref, 'refs/tags/v') && matrix.os == 'windows-latest'
@@ -299,42 +303,42 @@ jobs:
 
       # Don't compress for Windows because winget can't yet unzip files
       - name: Compress cargo artifact (Not Windows)
-        if: matrix.os != 'windows-latest'
-        run: tar -C target/${{ matrix.target }}/release -zcvf clarinet-${{ matrix.platform }}-${{ matrix.architecture }}.tar.gz clarinet
+        if: matrix.os != 'windows-latest' && matrix.target != 'x86_64-unknown-linux-musl'
+        run: tar -C target/${{ matrix.target }}/release -zcvf clarinet-${{ env.SHORT_TARGET_NAME }}.tar.gz clarinet
 
       - name: Rename cargo artifact (Windows)
         if: matrix.os == 'windows-latest'
         shell: bash
-        run: mv target/wix/*.msi clarinet-${{ matrix.platform }}-${{ matrix.architecture }}.msi
+        run: mv target/wix/*.msi clarinet-${{ env.SHORT_TARGET_NAME }}.msi
 
       - name: Compress node artifact
         shell: bash
-        run: tar -C node-bindings -zcvf stacks-devnet-js-${{ matrix.platform }}-${{ matrix.architecture }}.tar.gz native/index.node
+        run: tar -C node-bindings -zcvf stacks-devnet-js-${{ env.PRE_GYP_TARGET_NAME }}.tar.gz native/index.node
 
       # Separate uploads to prevent paths from being preserved
       - name: Upload cargo artifacts (Not Windows)
-        if: matrix.os != 'windows-latest'
+        if: matrix.os != 'windows-latest' && matrix.target != 'x86_64-unknown-linux-musl'
         uses: actions/upload-artifact@v2
         with:
-          name: clarinet-${{ matrix.platform }}-${{ matrix.architecture }}
-          path: clarinet-${{ matrix.platform }}-${{ matrix.architecture }}.tar.gz
+          name: clarinet-${{ env.SHORT_TARGET_NAME }}
+          path: clarinet-${{ env.SHORT_TARGET_NAME }}.tar.gz
 
       - name: Upload cargo artifact (Windows)
         if: matrix.os == 'windows-latest'
         uses: actions/upload-artifact@v2
         with:
-          name: clarinet-${{ matrix.platform }}-${{ matrix.architecture }}
-          path: clarinet-${{ matrix.platform }}-${{ matrix.architecture }}.msi
+          name: clarinet-${{ env.SHORT_TARGET_NAME }}
+          path: clarinet-${{ env.SHORT_TARGET_NAME }}.msi
 
       - name: Upload node artifact
         uses: actions/upload-artifact@v2
         with:
-          name: stacks-devnet-js-${{ matrix.platform }}-${{ matrix.architecture }}
-          path: stacks-devnet-js-${{ matrix.platform }}-${{ matrix.architecture }}.tar.gz
+          name: stacks-devnet-js-${{ env.PRE_GYP_TARGET_NAME }}
+          path: stacks-devnet-js-${{ env.PRE_GYP_TARGET_NAME }}.tar.gz
 
       - name: Unit Tests - Cargo
         # can't easily run mac-arm64 tests in GH without native runners for that arch
-        if: matrix.target != 'aarch64-apple-darwin'
+        if: matrix.target != 'aarch64-apple-darwin' && matrix.target != 'x86_64-unknown-linux-musl'
         run: cargo test --release --locked --target ${{ matrix.target }}
 
       # - name: Unit Tests - Node
@@ -343,7 +347,7 @@ jobs:
 
       - name: Functional Tests (Not Windows)
         # can't easily run mac-arm64 tests in GH without native runners for that arch
-        if: matrix.os != 'windows-latest' && matrix.target != 'aarch64-apple-darwin' 
+        if: matrix.os != 'windows-latest' && matrix.target != 'aarch64-apple-darwin' && matrix.target != 'x86_64-unknown-linux-musl'
         run: |
           for testdir in $(ls examples); do
             ./target/${{ matrix.target }}/release/clarinet test --manifest-path examples/${testdir}/Clarinet.toml
@@ -358,10 +362,10 @@ jobs:
 
       - name: Upload Cargo Artifact to GH release (Not Windows)
         uses: svenstaro/upload-release-action@v2
-        if: startsWith(github.ref, 'refs/tags/v') && matrix.os != 'windows-latest'
+        if: startsWith(github.ref, 'refs/tags/v') && matrix.os != 'windows-latest' && matrix.target != 'x86_64-unknown-linux-musl'
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: clarinet-${{ matrix.platform }}-${{ matrix.architecture }}.tar.gz
+          file: clarinet-${{ env.SHORT_TARGET_NAME }}.tar.gz
           tag: ${{ github.ref }}
 
       - name: Upload Cargo Artifact to GH release (Windows)
@@ -369,7 +373,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v') && matrix.os == 'windows-latest'
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: clarinet-${{ matrix.platform }}-${{ matrix.architecture }}.msi
+          file: clarinet-${{ env.SHORT_TARGET_NAME }}.msi
           tag: ${{ github.ref }}
 
       - name: Upload Node Artifact to GH release
@@ -377,7 +381,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v')
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: stacks-devnet-js-${{ matrix.platform }}-${{ matrix.architecture }}.tar.gz
+          file: stacks-devnet-js-${{ env.PRE_GYP_TARGET_NAME }}.tar.gz
           tag: ${{ github.ref }}
 
       # Cleans the `./target` dir after the build such that only dependencies are cached on CI

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -739,8 +739,7 @@ dependencies = [
 [[package]]
 name = "clarity-repl"
 version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b581621ab215ae79e204d87d2af14fd72382dc4d5ece0b60f89d57da8586e262"
+source = "git+https://github.com/hirosystems/clarity-repl?branch=develop#2a38bee12234ab50b1f79f914794fec95332915f"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
@@ -805,22 +804,6 @@ dependencies = [
  "time 0.2.27",
  "version_check",
 ]
-
-[[package]]
-name = "core-foundation"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a89e2ae426ea83155dccf10c0fa6b1463ef6d5fcb44cee0b224a408fa640a62"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
 
 [[package]]
 name = "cpufeatures"
@@ -1853,21 +1836,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2314,19 +2282,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "webpki",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper",
- "native-tls",
- "tokio",
- "tokio-native-tls",
 ]
 
 [[package]]
@@ -2831,24 +2786,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8d96b2e1c8da3957d58100b09f102c6d9cfdfced01b7ec5a8974044bb09dbd4"
-dependencies = [
- "lazy_static",
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "neon"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3093,39 +3030,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
-name = "openssl"
-version = "0.10.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "549430950c79ae24e6d02e0b7404534ecf311d94cc9f861e9e4020187d13d885"
-dependencies = [
- "bitflags",
- "cfg-if 1.0.0",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.65"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a7907e3bfa08bb85105209cdfcb6c63d109f8f6c1ed6ca318fff5c1853fbc1d"
-dependencies = [
- "autocfg",
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "os_pipe"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3335,12 +3239,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "pkg-config"
-version = "0.3.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "pmutil"
@@ -3773,13 +3671,11 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "ipnet",
  "js-sys",
  "lazy_static",
  "log",
  "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "rustls",
@@ -3787,7 +3683,6 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "url",
@@ -4064,16 +3959,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "schannel"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
-dependencies = [
- "lazy_static",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "scoped-tls"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4112,29 +3997,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "827cb7cce42533829c792fc51b82fbf18b125b45a702ef2c8be77fce65463a7b"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "security-framework"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23a2ac85147a3a11d77ecf1bc7166ec0b92febfa4461c37944e180f319ece467"
-dependencies = [
- "bitflags",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e4effb91b4b8b6fb7732e670b6cee160278ff8e6bf485c7805d9e319d76e284"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -5352,16 +5214,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5835,12 +5687,6 @@ dependencies = [
  "getrandom 0.2.3",
  "serde",
 ]
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vec_map"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -738,8 +738,9 @@ dependencies = [
 
 [[package]]
 name = "clarity-repl"
-version = "0.22.1"
-source = "git+https://github.com/hirosystems/clarity-repl?branch=develop#2a38bee12234ab50b1f79f914794fec95332915f"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60401e39af201cd76a53a8c0caf7dd8496e7d4336e903cc17b856d942d707dbc"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,8 @@ deno_core = { path = "./vendor/deno/core", optional = true }
 deno_runtime = { path = "./vendor/deno/runtime", optional = true }
 deno = { path = "./vendor/deno/cli", optional = true }
 # clarity_repl = { package = "clarity-repl", path = "../../clarity-repl", features = ["cli"] }
-clarity_repl = { package = "clarity-repl", version = "=0.22.1" }
+# clarity_repl = { package = "clarity-repl", version = "=0.22.0" }
+clarity-repl = { git = "https://github.com/hirosystems/clarity-repl", branch = "develop" }
 bip39 = { version = "1.0.1", default-features = false }
 aes = "0.7.5"
 base64 = "0.13.0"
@@ -54,7 +55,7 @@ pin-project = "1.0.5"
 indexmap = { version = "1.6.1", features = ["serde"] }
 shell-escape = "0.1.5"
 tiny-hderive = "0.3.0"
-reqwest = { version = "0.11", features = ["blocking", "json", "rustls"] }
+reqwest = { version = "0.11", default-features = false, features = ["blocking", "json", "rustls-tls"] }
 swc_common = { version = "0.10.20", features = ["sourcemap"], optional = true }
 bollard = "0.11.0"
 rocket = { version = "=0.5.0-rc.1", features = ["json"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,7 @@ deno_core = { path = "./vendor/deno/core", optional = true }
 deno_runtime = { path = "./vendor/deno/runtime", optional = true }
 deno = { path = "./vendor/deno/cli", optional = true }
 # clarity_repl = { package = "clarity-repl", path = "../../clarity-repl", features = ["cli"] }
-# clarity_repl = { package = "clarity-repl", version = "=0.22.0" }
-clarity-repl = { git = "https://github.com/hirosystems/clarity-repl", branch = "develop" }
+clarity_repl = { package = "clarity-repl", version = "=0.23.0" }
 bip39 = { version = "1.0.1", default-features = false }
 aes = "0.7.5"
 base64 = "0.13.0"

--- a/node-bindings/package.json
+++ b/node-bindings/package.json
@@ -13,7 +13,8 @@
     "build": "tsc --build && cargo-cp-artifact -nc native/index.node -- cargo build --message-format=json-render-diagnostics",
     "build-debug": "npm run build --",
     "build-release": "npm run build -- --release",
-    "build-linux-x64": "npm run build-release -- --target x86_64-unknown-linux-gnu",
+    "build-linux-x64-glibc": "npm run build-release -- --target x86_64-unknown-linux-gnu",
+    "build-linux-x64-musl": "npm run build-release -- --target x86_64-unknown-linux-musl",
     "build-windows-x64": "npm run build-release -- --target x86_64-pc-windows-msvc",
     "build-darwin-x64": "npm run build-release -- --target x86_64-apple-darwin",
     "build-darwin-arm64": "npm run build-release -- --target aarch64-apple-darwin",
@@ -39,7 +40,7 @@
     "module_name": "index",
     "host": "https://github.com/hirosystems/clarinet/releases/download/",
     "remote_path": "v{version}",
-    "package_name": "stacks-devnet-js-{platform}-{arch}.tar.gz",
+    "package_name": "stacks-devnet-js-{platform}-{arch}-{libc}.tar.gz",
     "module_path": "./native",
     "pkg_path": "."
   }


### PR DESCRIPTION
Build `stacks-devnet-js` for linux-x64-musl.


Also fixes https://github.com/hirosystems/clarinet/issues/263