### PR TITLE
refactor: improve "expectTuple" signature

### DIFF
--- a/deno/index.ts
+++ b/deno/index.ts
@@ -371,7 +371,7 @@ declare global {
     expectUtf8(value: String): String;
     expectPrincipal(value: String): String;
     expectList(): Array<String>;
-    expectTuple(): Object;
+    expectTuple(): Record<string, string>;
   }
 
   interface Array<T> {
@@ -602,7 +602,7 @@ String.prototype.expectTuple = function () {
     elements.push(remainder);
   }
 
-  let tuple: { [key: string]: String } = {};
+  let tuple: Record<string, string> = {};
   for (let element of elements) {
     for (var i = 0; i < element.length; i++) {
       if (element.charAt(i) === ":") {


### PR DESCRIPTION
Currently the signature of `expectTuple()` signature is: `expectTuple(): Object;`. So with the following code, TypeScript throws this error: `Property 'str' does not exist on type 'Object'.`

```ts
// test-tuple.clar: (define-read-only (test-tuple) { str: u"hello world" })
Clarinet.test({
  name: 'test expectTuple response',
  fn(chain: Chain, accounts: Map<string, Account>) {
    const { address } = accounts.get('wallet_1')!
    const { receipts } = chain.mineBlock([
      Tx.contractCall('test-tuple', 'test-tuple', [], address),
    ])

    const tuple = receipts[0].result.expectTuple()
    assertExists(tuple.str)
    tuple.str.expectUtf8('hello world')
  },
})
```

Indeed, `Object` (as in `ObjectConstructor`), does not have a property called `str`.
Possible fixes, `expectTuple` could return:
-  `{ [key: string]: string }` ❌ not the cleanest
- `object` ❌ deno says: "This type is tricky to use so should be avoided if possible"
- `Record<string, string>` ✅ recommended instead of `object`

With `Record<string, string>` the snippet above is now valid and we can write clean TS code 👍 

