### PR TITLE
docs: change clarinet deploy to clarinet contract publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,7 +420,7 @@ You can use Clarinet to deploy your contracts to the public Testnet environment 
 evaluation on a blockchain. Use the following command:
 
 ```bash
-$ clarinet deploy --testnet
+$ clarinet contract publish --testnet
 ```
 
 ### Use Clarinet in your CI workflow as a GitHub Action

--- a/src/frontend/cli.rs
+++ b/src/frontend/cli.rs
@@ -985,13 +985,13 @@ fn display_deploy_hint() {
         yellow!("Once your contracts are ready to be deployed, you can run the following:")
     );
 
-    println!("{}", blue!("  $ clarinet deploy --testnet"));
+    println!("{}", blue!("  $ clarinet contract publish --testnet"));
     println!(
         "{}",
         yellow!("    Deploy all contracts to the testnet network.\n")
     );
 
-    println!("{}", blue!("  $ clarinet deploy --mainnet"));
+    println!("{}", blue!("  $ clarinet contract publish --mainnet"));
     println!(
         "{}",
         yellow!("    Deploy all contracts to the mainnet network.\n")


### PR DESCRIPTION
- `clarinet deploy` doesn't seem to exist any more, and seems to have been replaced by `clarinet contract publish`
- this PR updates the README + some CLI output to use the updated command