### PR TITLE
feat: allow to use any arbitrary deployer address

### DIFF
--- a/src/generate/contract.rs
+++ b/src/generate/contract.rs
@@ -122,6 +122,7 @@ Clarinet.test({{
         let contract_config = ContractConfig {
             depends_on: deps,
             path: format!("contracts/{}", contract_file_name),
+            deployer: None
         };
         let mut contracts_to_add = HashMap::new();
         contracts_to_add.insert(self.contract_name.clone(), contract_config);

--- a/src/poke/mod.rs
+++ b/src/poke/mod.rs
@@ -25,7 +25,7 @@ pub fn load_session_settings(
     let mut project_config = ProjectManifest::from_path(&manifest_path);
     let chain_config = ChainConfig::from_path(&chain_config_path, env);
 
-    let mut deployer_address = None;
+    let mut default_deployer_address = None;
     let mut initial_deployer = None;
 
     settings.node = chain_config
@@ -49,7 +49,7 @@ pub fn load_session_settings(
         };
         if name == "deployer" {
             initial_deployer = Some(account.clone());
-            deployer_address = Some(account.address.clone());
+            default_deployer_address = Some(account.address.clone());
         }
         settings.initial_accounts.push(account);
     }
@@ -69,13 +69,18 @@ pub fn load_session_settings(
             }
         };
 
+        let deployer_address = match &config.deployer {
+            Some(deployer_address) => Some(deployer_address.to_string()),
+            None => default_deployer_address.clone(),
+        };
+
         settings
             .initial_contracts
             .push(repl::settings::InitialContract {
                 code: code,
                 path: contract_path.to_str().unwrap().into(),
                 name: Some(name.clone()),
-                deployer: deployer_address.clone(),
+                deployer: deployer_address,
             });
     }
 

--- a/src/runnner/deno.rs
+++ b/src/runnner/deno.rs
@@ -161,7 +161,7 @@ mod sessions {
             let project_config = ProjectManifest::from_path(manifest_path);
             let chain_config = ChainConfig::from_path(&chain_config_path, &Network::Devnet);
 
-            let mut deployer_address = None;
+            let mut default_deployer_address = None;
             let mut initial_deployer = None;
 
             for (name, account) in chain_config.accounts.iter() {
@@ -174,7 +174,7 @@ mod sessions {
                 };
                 if name == "deployer" {
                     initial_deployer = Some(account.clone());
-                    deployer_address = Some(account.address.clone());
+                    default_deployer_address = Some(account.address.clone());
                 }
                 settings.initial_accounts.push(account);
             }
@@ -211,13 +211,18 @@ mod sessions {
 
                 let code = fs::read_to_string(&contract_path).unwrap();
 
+                let deployer_address = match &config.deployer {
+                    Some(deployer_address) => Some(deployer_address.to_string()),
+                    None => default_deployer_address.clone(),
+                };
+
                 settings
                     .initial_contracts
                     .push(repl::settings::InitialContract {
                         code: code,
                         path: contract_path.to_str().unwrap().into(),
                         name: Some(name.clone()),
-                        deployer: deployer_address.clone(),
+                        deployer: deployer_address,
                     });
             }
             settings.initial_deployer = initial_deployer;

--- a/src/types/project_manifest.rs
+++ b/src/types/project_manifest.rs
@@ -57,6 +57,7 @@ pub struct RequirementConfig {
 pub struct ContractConfig {
     pub path: String,
     pub depends_on: Vec<String>,
+    pub deployer: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -191,9 +192,14 @@ impl ProjectManifest {
                                     .collect::<Vec<String>>(),
                                 _ => continue,
                             };
+                            let deployer = match contract_settings.get("deployer") {
+                                Some(Value::String(deployer)) => Some(deployer.to_string()),
+                                None => None,
+                                _ => continue,
+                            };
                             config_contracts.insert(
                                 contract_name.to_string(),
-                                ContractConfig { path, depends_on },
+                                ContractConfig { path, depends_on, deployer },
                             );
                         }
                         _ => {}


### PR DESCRIPTION
This PR introduces extra configuration option, that allows developers to manually select deployer address.

I decided to start with very naive implementation, in which all we have to do is add `deployer` with any valid address ie.

```toml
[contracts.sip-010-trait-ft-standard]
path = "contracts/external/sip-10-ft-standard.clar"
deployer = "SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE"
depends_on = []
```

I was thinking about using accounts defined in `Devnet.toml`, `Mainnet.toml` and `Testnet.toml` config files, but at this moment I don't have clear vision how it should work, especially when we use `deploy` command.

@MarvinJanssen, @friedger @whoabuddy @lgalabru @obycode @philipdesmedt @fiftyeightandeight what's your opinion about this? 

---
fix #142