### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ phrases and initial balances. Initial balances are in microSTX.
 Clarinet can handle adding a new contract and its configuration to your project with the following command:
 
 ```bash
-$ clarinet contracts new bbtc
+$ clarinet contract new bbtc
 ```
 
 Clarinet will add 2 files to your project, the contract file in the `contracts` directory, and the contract test file


### PR DESCRIPTION
Seems that "contracts" should only be "contract" here.