### PR TITLE
fix: use `PathBuf` for paths

### DIFF
--- a/src/frontend/dap.rs
+++ b/src/frontend/dap.rs
@@ -32,12 +32,12 @@ pub fn run_dap() -> Result<(), String> {
 
             for contract in &session.settings.initial_contracts {
                 dap.path_to_contract_id.insert(
-                    contract.path.clone(),
+                    PathBuf::from(&contract.path),
                     contract.get_contract_identifier(false).unwrap(),
                 );
                 dap.contract_id_to_path.insert(
                     contract.get_contract_identifier(false).unwrap(),
-                    contract.path.clone(),
+                    PathBuf::from(&contract.path),
                 );
             }
 


### PR DESCRIPTION
This change corresponds with hirosystems/clarity-repl@2f1b676 to
switch from using a `String` to using a `PathBuf` for storing the
contract path so that it can be properly compared on Windows.