### PR TITLE
feat: allow empty console

### DIFF
--- a/src/poke/mod.rs
+++ b/src/poke/mod.rs
@@ -132,3 +132,13 @@ pub fn load_session(
     };
     Ok((session, chain_config, project_config, output))
 }
+
+pub fn load_empty_session() -> (Option<repl::Session>, ProjectManifest) {
+    let settings = repl::SessionSettings::default();
+    let manifest = ProjectManifest::default();
+
+    let mut terminal = Terminal::new(settings);
+    terminal.start();
+
+    (Some(terminal.session), manifest)
+}


### PR DESCRIPTION
Resolves #355 by allowing `clarinet console` to run even if a `Clarinet.toml` file is missing. No contracts loaded in this case.

![image](https://user-images.githubusercontent.com/287532/169760414-f0c1e65b-6fdd-4b44-a429-7676344f4c70.png)
