### PR TITLE
fix: code coverage not including initial executions

### DIFF
--- a/src/deployment/mod.rs
+++ b/src/deployment/mod.rs
@@ -166,7 +166,7 @@ pub fn setup_session_with_deployment(
     let mut session = initiate_session_from_deployment(&manifest);
     update_session_with_genesis_accounts(&mut session, deployment);
     let results =
-        update_session_with_contracts_executions(&mut session, deployment, contracts_asts);
+        update_session_with_contracts_executions(&mut session, deployment, contracts_asts, false);
     (session, results)
 }
 
@@ -203,6 +203,7 @@ pub fn update_session_with_contracts_executions(
     session: &mut Session,
     deployment: &DeploymentSpecification,
     contracts_asts: Option<HashMap<QualifiedContractIdentifier, ContractAST>>,
+    code_coverage_enabled: bool,
 ) -> BTreeMap<QualifiedContractIdentifier, Result<ExecutionResult, Vec<Diagnostic>>> {
     let mut results = BTreeMap::new();
     for batch in deployment.plan.batches.iter() {
@@ -233,7 +234,10 @@ pub fn update_session_with_contracts_executions(
                             Some(tx.contract_name.to_string()),
                             None,
                             false,
-                            None,
+                            match code_coverage_enabled {
+                                true => Some("__analysis__".to_string()),
+                                false => None,
+                            },
                         ),
                     };
                     results.insert(contract_id, result);

--- a/src/runnner/api_v1.rs
+++ b/src/runnner/api_v1.rs
@@ -257,7 +257,7 @@ pub fn load_deployment(state: &mut OpState, args: Value, _: ()) -> Result<String
         .expect("unable to retrieve session");
 
     // Execute deployment on session
-    let results = update_session_with_contracts_executions(session, &deployment, None);
+    let results = update_session_with_contracts_executions(session, &deployment, None, true);
     let mut serialized_contracts = vec![];
     for (contract_id, result) in results.into_iter() {
         match result {

--- a/src/runnner/mod.rs
+++ b/src/runnner/mod.rs
@@ -60,6 +60,7 @@ impl DeploymentCache {
             &mut session,
             &deployment,
             Some(contracts_asts),
+            true,
         );
 
         let mut contracts_artifacts = HashMap::new();


### PR DESCRIPTION
Regression introduced in v0.31.0
<img width="803" alt="Screen Shot 2022-05-25 at 14 10 59" src="https://user-images.githubusercontent.com/87777/170336778-47c952b7-2cf6-4063-a267-073a88712e5d.png">

To be fixed in v0.31.1
<img width="814" alt="Screen Shot 2022-05-25 at 14 11 05" src="https://user-images.githubusercontent.com/87777/170336852-c17b7789-b00e-4744-8317-30136fbe0478.png">

