### PR TITLE
fix: use `clarinet@0.31.0` lib in generated tests

### DIFF
--- a/src/generate/contract.rs
+++ b/src/generate/contract.rs
@@ -72,7 +72,7 @@ impl GetChangesForNewContract {
     fn create_template_test(&mut self) {
         let content = format!(
             r#"
-import {{ Clarinet, Tx, Chain, Account, types }} from 'https://deno.land/x/clarinet@v0.28.0/index.ts';
+import {{ Clarinet, Tx, Chain, Account, types }} from 'https://deno.land/x/clarinet@v0.31.0/index.ts';
 import {{ assertEquals }} from 'https://deno.land/std@0.90.0/testing/asserts.ts';
 
 Clarinet.test({{


### PR DESCRIPTION
Resolves: #381