### PR TITLE
Fix alias for clarinet deployment

### DIFF
--- a/src/frontend/cli.rs
+++ b/src/frontend/cli.rs
@@ -105,7 +105,7 @@ enum Requirements {
 }
 
 #[derive(Subcommand, PartialEq, Clone, Debug)]
-#[clap(bin_name = "deployment", aliases = &["deployments"])]
+#[clap(bin_name = "deployment", aliases = &["deployment"])]
 enum Deployments {
     /// Check deployments format
     #[clap(name = "check", bin_name = "check")]


### PR DESCRIPTION
When I run the commands in README I get an error eg:

```
$ clarinet deployment generate --mainnet
error: The subcommand 'deployment' wasn't recognized

        Did you mean 'deployments' or 'deployments'?
...
```

This commit updates the alias for `deployments` to `deployment` so that these commands work