### PR TITLE
fix: native lsp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -704,6 +704,7 @@ dependencies = [
  "clarinet-utils",
  "clarity-lsp",
  "clarity-repl",
+ "crossbeam-channel",
  "crossterm 0.22.1",
  "ctrlc",
  "deno",
@@ -923,9 +924,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.4"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
+checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",

--- a/components/clarinet-cli/Cargo.toml
+++ b/components/clarinet-cli/Cargo.toml
@@ -88,6 +88,7 @@ clarinet_utils = { package = "clarinet-utils", path = "../clarinet-utils" }
 num_cpus = "1.13.1"
 mio = "=0.8.2"
 similar = "2.1.0"
+crossbeam-channel = "0.5.6"
 
 [dependencies.tui]
 version = "0.18.0"

--- a/components/clarinet-cli/src/lsp/mod.rs
+++ b/components/clarinet-cli/src/lsp/mod.rs
@@ -1,15 +1,11 @@
 mod native_bridge;
 
-use clarinet_files::FileLocation;
-use clarity_lsp::backend::{self, LspRequestAsync, LspRequestSync, LspResponse};
-use clarity_lsp::lsp_types::MessageType;
-use clarity_lsp::state::{build_state, EditorState, ProtocolState};
-use clarity_lsp::types::CompletionItemKind;
 use clarity_lsp::utils;
 use clarity_repl::clarity::diagnostic::{Diagnostic as ClarityDiagnostic, Level as ClarityLevel};
 use native_bridge::LspNativeBridge;
 
-use std::sync::mpsc::{self, Receiver, Sender};
+use crossbeam_channel::unbounded;
+use std::sync::mpsc;
 use tokio;
 use tower_lsp::lsp_types::{
     Diagnostic, DiagnosticSeverity, Documentation, MarkupContent, MarkupKind, Position, Range,
@@ -35,12 +31,20 @@ async fn do_run_lsp() -> Result<(), String> {
     let stdin = tokio::io::stdin();
     let stdout = tokio::io::stdout();
 
-    let (tx, rx) = mpsc::channel();
+    let (notification_tx, notification_rx) = unbounded();
+    let (request_tx, request_rx) = unbounded();
+    let (response_tx, response_rx) = mpsc::channel();
     std::thread::spawn(move || {
-        crate::utils::nestable_block_on(backend::start_language_server(rx, tx, None));
+        crate::utils::nestable_block_on(native_bridge::start_language_server(
+            notification_rx,
+            request_rx,
+            response_tx,
+        ));
     });
 
-    let (service, messages) = LspService::new(|client| LspNativeBridge::new(client, tx));
+    let (service, messages) = LspService::new(|client| {
+        LspNativeBridge::new(client, request_tx, notification_tx, response_rx)
+    });
     Server::new(stdin, stdout)
         .interleave(messages)
         .serve(service)
@@ -163,11 +167,20 @@ pub fn clarity_diagnostic_to_tower_lsp_type(
 
 #[test]
 fn test_opening_counter_contract_should_return_fresh_analysis() {
+    use crossbeam_channel::unbounded;
     use std::sync::mpsc::channel;
+    use clarity_lsp::backend::{LspNotification, LspResponse};
+    use clarinet_files::FileLocation;
 
-    let (tx, rx) = mpsc::channel();
+    let (notification_tx, notification_rx) = unbounded();
+    let (_request_tx, request_rx) = unbounded();
+    let (response_tx, response_rx) = channel();
     std::thread::spawn(move || {
-        crate::utils::nestable_block_on(backend::start_language_server(rx, None));
+        crate::utils::nestable_block_on(native_bridge::start_language_server(
+            notification_rx,
+            request_rx,
+            response_tx,
+        ));
     });
 
     let contract_location = {
@@ -178,11 +191,8 @@ fn test_opening_counter_contract_should_return_fresh_analysis() {
         counter_path.push("counter.clar");
         FileLocation::from_path(counter_path)
     };
-    let (response_tx, response_rx) = channel();
-    let _ = tx.send(LspRequestAsync::ContractOpened(
-        contract_location.clone(),
-        response_tx.clone(),
-    ));
+
+    let _ = notification_tx.send(LspNotification::ContractOpened(contract_location.clone()));
     let response = response_rx.recv().expect("Unable to get response");
 
     // the counter project should emit 2 warnings and 2 notes coming from counter.clar
@@ -191,21 +201,27 @@ fn test_opening_counter_contract_should_return_fresh_analysis() {
     assert_eq!(diags.len(), 4);
 
     // re-opening this contract should not trigger a full analysis
-    let _ = tx.send(LspRequestAsync::ContractOpened(
-        contract_location,
-        response_tx,
-    ));
+    let _ = notification_tx.send(LspNotification::ContractOpened(contract_location));
     let response = response_rx.recv().expect("Unable to get response");
     assert_eq!(response, LspResponse::default());
 }
 
 #[test]
 fn test_opening_counter_manifest_should_return_fresh_analysis() {
+    use crossbeam_channel::unbounded;
     use std::sync::mpsc::channel;
+    use clarity_lsp::backend::{LspNotification, LspResponse};
+    use clarinet_files::FileLocation;
 
-    let (tx, rx) = mpsc::channel();
+    let (notification_tx, notification_rx) = unbounded();
+    let (_request_tx, request_rx) = unbounded();
+    let (response_tx, response_rx) = channel();
     std::thread::spawn(move || {
-        crate::utils::nestable_block_on(backend::start_language_server(rx, None));
+        crate::utils::nestable_block_on(native_bridge::start_language_server(
+            notification_rx,
+            request_rx,
+            response_tx,
+        ));
     });
 
     let manifest_location = {
@@ -216,11 +232,7 @@ fn test_opening_counter_manifest_should_return_fresh_analysis() {
         FileLocation::from_path(manifest_path)
     };
 
-    let (response_tx, response_rx) = channel();
-    let _ = tx.send(LspRequestAsync::ManifestOpened(
-        manifest_location.clone(),
-        response_tx.clone(),
-    ));
+    let _ = notification_tx.send(LspNotification::ManifestOpened(manifest_location.clone()));
     let response = response_rx.recv().expect("Unable to get response");
 
     // the counter project should emit 2 warnings and 2 notes coming from counter.clar
@@ -229,21 +241,27 @@ fn test_opening_counter_manifest_should_return_fresh_analysis() {
     assert_eq!(diags.len(), 4);
 
     // re-opening this manifest should not trigger a full analysis
-    let _ = tx.send(LspRequestAsync::ManifestOpened(
-        manifest_location,
-        response_tx,
-    ));
+    let _ = notification_tx.send(LspNotification::ManifestOpened(manifest_location));
     let response = response_rx.recv().expect("Unable to get response");
     assert_eq!(response, LspResponse::default());
 }
 
 #[test]
 fn test_opening_simple_nft_manifest_should_return_fresh_analysis() {
+    use crossbeam_channel::unbounded;
     use std::sync::mpsc::channel;
+    use clarity_lsp::backend::LspNotification;
+    use clarinet_files::FileLocation;
 
-    let (tx, rx) = mpsc::channel();
+    let (notification_tx, notification_rx) = unbounded();
+    let (_request_tx, request_rx) = unbounded();
+    let (response_tx, response_rx) = channel();
     std::thread::spawn(move || {
-        crate::utils::nestable_block_on(backend::start_language_server(rx, None));
+        crate::utils::nestable_block_on(native_bridge::start_language_server(
+            notification_rx,
+            request_rx,
+            response_tx,
+        ));
     });
 
     let mut manifest_location = std::env::current_dir().expect("Unable to get current dir");
@@ -251,11 +269,9 @@ fn test_opening_simple_nft_manifest_should_return_fresh_analysis() {
     manifest_location.push("simple-nft");
     manifest_location.push("Clarinet.toml");
 
-    let (response_tx, response_rx) = channel();
-    let _ = tx.send(LspRequestAsync::ManifestOpened(
-        FileLocation::from_path(manifest_location),
-        response_tx.clone(),
-    ));
+    let _ = notification_tx.send(LspNotification::ManifestOpened(FileLocation::from_path(
+        manifest_location,
+    )));
     let response = response_rx.recv().expect("Unable to get response");
 
     // the counter project should emit 2 warnings and 2 notes coming from counter.clar

--- a/components/clarinet-cli/src/lsp/mod.rs
+++ b/components/clarinet-cli/src/lsp/mod.rs
@@ -167,10 +167,10 @@ pub fn clarity_diagnostic_to_tower_lsp_type(
 
 #[test]
 fn test_opening_counter_contract_should_return_fresh_analysis() {
+    use clarinet_files::FileLocation;
+    use clarity_lsp::backend::{LspNotification, LspResponse};
     use crossbeam_channel::unbounded;
     use std::sync::mpsc::channel;
-    use clarity_lsp::backend::{LspNotification, LspResponse};
-    use clarinet_files::FileLocation;
 
     let (notification_tx, notification_rx) = unbounded();
     let (_request_tx, request_rx) = unbounded();
@@ -208,10 +208,10 @@ fn test_opening_counter_contract_should_return_fresh_analysis() {
 
 #[test]
 fn test_opening_counter_manifest_should_return_fresh_analysis() {
+    use clarinet_files::FileLocation;
+    use clarity_lsp::backend::{LspNotification, LspResponse};
     use crossbeam_channel::unbounded;
     use std::sync::mpsc::channel;
-    use clarity_lsp::backend::{LspNotification, LspResponse};
-    use clarinet_files::FileLocation;
 
     let (notification_tx, notification_rx) = unbounded();
     let (_request_tx, request_rx) = unbounded();
@@ -248,10 +248,10 @@ fn test_opening_counter_manifest_should_return_fresh_analysis() {
 
 #[test]
 fn test_opening_simple_nft_manifest_should_return_fresh_analysis() {
+    use clarinet_files::FileLocation;
+    use clarity_lsp::backend::LspNotification;
     use crossbeam_channel::unbounded;
     use std::sync::mpsc::channel;
-    use clarity_lsp::backend::LspNotification;
-    use clarinet_files::FileLocation;
 
     let (notification_tx, notification_rx) = unbounded();
     let (_request_tx, request_rx) = unbounded();

--- a/components/clarity-lsp/src/vscode_bridge.rs
+++ b/components/clarity-lsp/src/vscode_bridge.rs
@@ -1,5 +1,5 @@
 extern crate console_error_panic_hook;
-use crate::backend::{process_command, process_command_sync, LspRequestAsync, LspRequestSync};
+use crate::backend::{process_notification, process_request, LspNotification, LspRequest};
 use crate::state::EditorState;
 use crate::utils::log;
 use crate::utils::{
@@ -68,9 +68,9 @@ impl LspVscodeBridge {
                 log!("> opened: {}", &uri);
 
                 let command = if let Some(contract_location) = get_contract_location(&uri) {
-                    LspRequestAsync::ContractOpened(contract_location)
+                    LspNotification::ContractOpened(contract_location)
                 } else if let Some(manifest_location) = get_manifest_location(&uri) {
-                    LspRequestAsync::ManifestOpened(manifest_location)
+                    LspNotification::ManifestOpened(manifest_location)
                 } else {
                     log!("Unsupported file opened");
                     return Promise::resolve(&JsValue::null());
@@ -121,9 +121,9 @@ impl LspVscodeBridge {
                 log!("> saved: {}", uri);
 
                 let command = if let Some(contract_location) = get_contract_location(uri) {
-                    LspRequestAsync::ContractChanged(contract_location)
+                    LspNotification::ContractChanged(contract_location)
                 } else if let Some(manifest_location) = get_manifest_location(uri) {
-                    LspRequestAsync::ManifestChanged(manifest_location)
+                    LspNotification::ManifestChanged(manifest_location)
                 } else {
                     log!("Unsupported file opened");
                     return Promise::resolve(&JsValue::null());
@@ -184,12 +184,12 @@ impl LspVscodeBridge {
                 let file_url = params.text_document_position.text_document.uri;
 
                 let command = match get_contract_location(&file_url) {
-                    Some(location) => LspRequestSync::GetIntellisense(location),
+                    Some(location) => LspRequest::GetIntellisense(location),
                     _ => return JsValue::null(),
                 };
 
                 let result = match self.editor_state.try_read() {
-                    Ok(editor_state) => process_command_sync(command, &editor_state),
+                    Ok(editor_state) => process_request(command, &editor_state),
                     Err(_) => return JsValue::null(),
                 };
 


### PR DESCRIPTION
@hugocaillard Here is a fix for the native LSP, along with a renaming suggestion (`RequestAsync` -> `Notification` and `RequestSync` -> `Request`, so we stick with the LSP terminology).
Feel free to merge / cherry-pick and update your PR :).
Except for the struct renaming, all the changes won't be impacting your work, and self contained in the `clarinet-cli` component.