### PR TITLE
fix: cleaner path in lsp notifications

### DIFF
--- a/components/clarinet-files/src/lib.rs
+++ b/components/clarinet-files/src/lib.rs
@@ -301,13 +301,12 @@ impl FileLocation {
         Ok(network_manifest_location)
     }
 
-    pub fn get_relative_location_from_manifest(
+    pub fn get_relative_path_from_base(
         &self,
-        manifest_location: &FileLocation,
+        base_location: &FileLocation,
     ) -> Result<String, String> {
-        let base = self.get_root_location_from_manifest_location(manifest_location)?;
         let file = self.to_string();
-        Ok(file[(base.to_string().len() + 1)..].to_string())
+        Ok(file[(base_location.to_string().len() + 1)..].to_string())
     }
 
     pub fn get_relative_location(&self) -> Result<String, String> {

--- a/components/clarinet-files/src/lib.rs
+++ b/components/clarinet-files/src/lib.rs
@@ -307,7 +307,7 @@ impl FileLocation {
     ) -> Result<String, String> {
         let base = self.get_root_location_from_manifest_location(manifest_location)?;
         let file = self.to_string();
-        Ok(file[(base.to_string().len())..].to_string())
+        Ok(file[(base.to_string().len() + 1)..].to_string())
     }
 
     pub fn get_relative_location(&self) -> Result<String, String> {

--- a/components/clarinet-files/src/lib.rs
+++ b/components/clarinet-files/src/lib.rs
@@ -176,35 +176,6 @@ impl FileLocation {
         Ok(())
     }
 
-    pub fn get_project_root_location(&self) -> Result<FileLocation, String> {
-        let mut project_root_location = self.clone();
-        match project_root_location.borrow_mut() {
-            FileLocation::FileSystem { path } => {
-                let mut manifest_found = false;
-                while path.pop() {
-                    path.push("Clarinet.toml");
-                    if FileLocation::fs_exists(path) {
-                        path.pop();
-                        manifest_found = true;
-                        break;
-                    }
-                    path.pop();
-                }
-
-                match manifest_found {
-                    true => Ok(project_root_location),
-                    false => Err(format!(
-                        "unable to find root location from {}",
-                        self.to_string()
-                    )),
-                }
-            }
-            _ => {
-                unimplemented!();
-            }
-        }
-    }
-
     pub async fn get_project_manifest_location(
         &self,
         file_accessor: Option<&Box<dyn FileAccessor>>,
@@ -242,6 +213,59 @@ impl FileLocation {
         }
     }
 
+    pub fn get_project_root_location(&self) -> Result<FileLocation, String> {
+        let mut project_root_location = self.clone();
+        match project_root_location.borrow_mut() {
+            FileLocation::FileSystem { path } => {
+                let mut manifest_found = false;
+                while path.pop() {
+                    path.push("Clarinet.toml");
+                    if FileLocation::fs_exists(path) {
+                        path.pop();
+                        manifest_found = true;
+                        break;
+                    }
+                    path.pop();
+                }
+
+                match manifest_found {
+                    true => Ok(project_root_location),
+                    false => Err(format!(
+                        "unable to find root location from {}",
+                        self.to_string()
+                    )),
+                }
+            }
+            _ => {
+                unimplemented!();
+            }
+        }
+    }
+
+    pub fn get_root_location_from_manifest_location(
+        &self,
+        manifest_location: &FileLocation,
+    ) -> Result<FileLocation, String> {
+        let mut project_root_location = manifest_location.clone();
+
+        match project_root_location.borrow_mut() {
+            FileLocation::FileSystem { path } => {
+                let mut parent = path.clone();
+                parent.pop();
+                parent.pop();
+            }
+            FileLocation::Url { url } => {
+                let mut segments = url
+                    .path_segments_mut()
+                    .map_err(|_| format!("unable to mutate url"))?;
+                segments.pop();
+                segments.pop();
+            }
+        };
+
+        Ok(project_root_location)
+    }
+
     pub fn get_parent_location(&self) -> Result<FileLocation, String> {
         let mut parent_location = self.clone();
         match &mut parent_location {
@@ -275,6 +299,15 @@ impl FileLocation {
             StacksNetwork::Mainnet => "Mainnet.toml",
         })?;
         Ok(network_manifest_location)
+    }
+
+    pub fn get_relative_location_from_manifest(
+        &self,
+        manifest_location: &FileLocation,
+    ) -> Result<String, String> {
+        let base = self.get_root_location_from_manifest_location(manifest_location)?;
+        let file = self.to_string();
+        Ok(file[(base.to_string().len())..].to_string())
     }
 
     pub fn get_relative_location(&self) -> Result<String, String> {

--- a/components/clarinet-files/src/lib.rs
+++ b/components/clarinet-files/src/lib.rs
@@ -242,30 +242,6 @@ impl FileLocation {
         }
     }
 
-    pub fn get_root_location_from_manifest_location(
-        &self,
-        manifest_location: &FileLocation,
-    ) -> Result<FileLocation, String> {
-        let mut project_root_location = manifest_location.clone();
-
-        match project_root_location.borrow_mut() {
-            FileLocation::FileSystem { path } => {
-                let mut parent = path.clone();
-                parent.pop();
-                parent.pop();
-            }
-            FileLocation::Url { url } => {
-                let mut segments = url
-                    .path_segments_mut()
-                    .map_err(|_| format!("unable to mutate url"))?;
-                segments.pop();
-                segments.pop();
-            }
-        };
-
-        Ok(project_root_location)
-    }
-
     pub fn get_parent_location(&self) -> Result<FileLocation, String> {
         let mut parent_location = self.clone();
         match &mut parent_location {


### PR DESCRIPTION
Avoid showing the full vfs path of a contract in the lsp notifications.

#### Before
Web
<img width="450" alt="Screenshot 2022-09-13 at 15 06 51" src="https://user-images.githubusercontent.com/911307/189917916-6df43ac8-bd9c-48f7-bb38-068ae2cdbdb1.png">
Desktop
<img width="465" alt="Screenshot 2022-09-13 at 15 07 37" src="https://user-images.githubusercontent.com/911307/189917911-a0d2ab55-78bb-4429-a72d-d35a676a8806.png">

#### After
Web & Dekstop

<img width="480" alt="Screenshot 2022-09-13 at 15 43 51" src="https://user-images.githubusercontent.com/911307/189918046-9cb0e55a-0e27-4042-8be5-b69a545560c1.png">


`get_relative_location` couldn't be used because it calls `get_project_root_location` that only work on native fs path (not on urls) https://github.com/hirosystems/clarinet/blob/e4c3a4122e13aa7272f46323e54f417cf292f9ec/components/clarinet-files/src/lib.rs#L208

So I took advantage of the `contracts_lookup` prop to retrieve the manifest location.
In the future, we probably want to call more `get_relative_location_from_manifest` and `get_root_location_from_manifest_location` (instead of the non-`from-manifest` ones that call the native FS)