### PR TITLE
fix: few fixes before release the extension

### DIFF
--- a/components/clarinet-deployments/src/lib.rs
+++ b/components/clarinet-deployments/src/lib.rs
@@ -528,7 +528,10 @@ pub async fn generate_default_deployment(
         contract_location.append_path(&contract_config.expect_contract_path_as_str())?;
         let source = sources
             .get(&contract_location.to_string())
-            .ok_or(format!("source not found for {}", name))?
+            .ok_or(format!(
+                "Invalid Clarinet.toml, source file not found for: {}",
+                name
+            ))?
             .clone();
 
         let contract_id = QualifiedContractIdentifier::new(sender.clone(), contract_name.clone());

--- a/components/clarinet-deployments/src/lib.rs
+++ b/components/clarinet-deployments/src/lib.rs
@@ -463,7 +463,7 @@ pub async fn generate_default_deployment(
 
     let base_location = manifest.location.clone().get_parent_location()?;
 
-    let mut sources: HashMap<String, String> = match file_accessor {
+    let sources: HashMap<String, String> = match file_accessor {
         None => {
             let mut sources = HashMap::new();
             for (_, contract_config) in manifest.contracts.iter() {
@@ -527,8 +527,9 @@ pub async fn generate_default_deployment(
         let mut contract_location = base_location.clone();
         contract_location.append_path(&contract_config.expect_contract_path_as_str())?;
         let source = sources
-            .remove(&contract_location.to_string())
-            .ok_or(format!("source not found for {}", name))?;
+            .get(&contract_location.to_string())
+            .ok_or(format!("source not found for {}", name))?
+            .clone();
 
         let contract_id = QualifiedContractIdentifier::new(sender.clone(), contract_name.clone());
 

--- a/components/clarinet-files/src/network_manifest.rs
+++ b/components/clarinet-files/src/network_manifest.rs
@@ -30,7 +30,7 @@ pub const DEFAULT_HYPERCHAIN_MNEMONIC: &str = "female adjust gallery certain vis
 pub const DEFAULT_DOCKER_SOCKET: &str = "unix:///var/run/docker.sock";
 #[cfg(windows)]
 pub const DEFAULT_DOCKER_SOCKET: &str = "npipe:////./pipe/docker_engine";
-#[cfg(macos)]
+#[cfg(target_family = "wasm")]
 pub const DEFAULT_DOCKER_SOCKET: &str = "/var/run/docker.sock";
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/components/clarity-vscode/client/src/common.ts
+++ b/components/clarity-vscode/client/src/common.ts
@@ -44,15 +44,10 @@ export async function initClient(
     config = workspace.getConfiguration("obscurity-web-extension");
   });
 
-  // vscode.commands.executeCommand(
-  //   "obscurity-web-extension.clarityInsightsView.focus",
-  // );
-
   /* clariy lsp */
   async function changeSelectionHandler(
     e: vscode.TextEditorSelectionChangeEvent,
   ) {
-    if (!config.panels["insights-panel"]) return;
     if (!e?.textEditor?.document) return;
     const path = e.textEditor.document.uri.toString();
     const { line, character } = e.selections[0].active;
@@ -79,15 +74,17 @@ export async function initClient(
   try {
     await client.start();
 
-    if (window.activeTextEditor) {
-      const { document } = window.activeTextEditor;
-      if (document.languageId !== "clarity") return;
-      insightsViewProvider.fileName = document;
-    }
+    if (config.panels["insights-panel"]) {
+      if (window.activeTextEditor) {
+        const { document } = window.activeTextEditor;
+        if (document.languageId !== "clarity") return;
+        insightsViewProvider.fileName = document;
+      }
 
-    context.subscriptions.push(
-      window.onDidChangeTextEditorSelection(changeSelectionHandler),
-    );
+      context.subscriptions.push(
+        window.onDidChangeTextEditorSelection(changeSelectionHandler),
+      );
+    }
   } catch (err) {
     if (err.message === "worker timeout") {
       vscode.window.showWarningMessage(

--- a/components/clarity-vscode/package.json
+++ b/components/clarity-vscode/package.json
@@ -5,7 +5,7 @@
   "author": "Hiro Systems",
   "publisher": "hugoclrd",
   "license": "GPL-3.0-only",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "workspaces": [
     "client",
     "server",

--- a/components/clarity-vscode/package.json
+++ b/components/clarity-vscode/package.json
@@ -5,7 +5,7 @@
   "author": "Hiro Systems",
   "publisher": "hugoclrd",
   "license": "GPL-3.0-only",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "workspaces": [
     "client",
     "server",

--- a/components/clarity-vscode/package.json
+++ b/components/clarity-vscode/package.json
@@ -5,7 +5,7 @@
   "author": "Hiro Systems",
   "publisher": "hugoclrd",
   "license": "GPL-3.0-only",
-  "version": "0.2.5",
+  "version": "0.2.7",
   "workspaces": [
     "client",
     "server",
@@ -39,9 +39,8 @@
     "vscode": "^1.43.0"
   },
   "activationEvents": [
-    "onDebug",
-    "onLanguage:clarity",
-    "onLanguage:toml"
+    "workspaceContains:Clarinet.toml",
+    "onLanguage:clarity"
   ],
   "main": "./client/dist/clientNode.js",
   "browser": "./client/dist/clientBrowser.js",
@@ -62,11 +61,6 @@
             ],
             "default": "verbose",
             "description": "Traces the communication between VS Code and the web-extension language server."
-          },
-          "obscurity-web-extension.panels.insights-panel": {
-            "type": "boolean",
-            "scope": "window",
-            "default": false
           }
         }
       }
@@ -106,7 +100,8 @@
         {
           "id": "clarityPanel",
           "title": "Clarity",
-          "icon": "assets/images/file-icon/clar-darktheme.svg"
+          "icon": "assets/images/file-icon/clar-darktheme.svg",
+          "when": "config.obscurity-web-extension.panels.insights-panel"
         }
       ]
     },

--- a/components/clarity-vscode/server/src/common.ts
+++ b/components/clarity-vscode/server/src/common.ts
@@ -6,8 +6,8 @@ import {
 } from "vscode-languageserver";
 import type { ServerCapabilities, Connection } from "vscode-languageserver";
 
-// this type is the same for the browser and node
-import type { LspVscodeBridge } from "./clarity-lsp-node";
+// this type is the same for the browser and node but node isn't alwasy built in dev
+import type { LspVscodeBridge } from "./clarity-lsp-browser";
 
 export function initConnection(
   connection: Connection,
@@ -30,7 +30,11 @@ export function initConnection(
   async function consumeNotification() {
     const notification = notifications[notifications.length - 1];
     if (!notifications) return;
-    await bridge.onNotification(...notification);
+    try {
+      await bridge.onNotification(...notification);
+    } catch (err) {
+      console.warn(err);
+    }
     notifications.pop();
     if (notifications.length > 0) consumeNotification();
   }

--- a/components/clarity-vscode/test-data/missing-contract/Clarinet.toml
+++ b/components/clarity-vscode/test-data/missing-contract/Clarinet.toml
@@ -1,0 +1,25 @@
+[project]
+name = "missing-contract"
+authors = []
+description = ""
+telemetry = false
+requirements = []
+boot_contracts = ["pox", "costs-v2", "bns"]
+
+[project.cache_location]
+path = "./.requirements"
+[contracts.counter]
+path = "contracts/counter.clar"
+
+[repl]
+costs_version = 2
+parser_version = 2
+
+[repl.analysis]
+passes = ["check_checker"]
+
+[repl.analysis.check_checker]
+strict = false
+trusted_sender = false
+trusted_caller = false
+callee_filter = false

--- a/components/clarity-vscode/test-data/missing-contract/settings/Devnet.toml
+++ b/components/clarity-vscode/test-data/missing-contract/settings/Devnet.toml
@@ -1,0 +1,40 @@
+[network]
+name = "devnet"
+deployment_fee_rate = 10
+
+[accounts.deployer]
+mnemonic = "twice kind fence tip hidden tilt action fragile skin nothing glory cousin green tomorrow spring wrist shed math olympic multiply hip blue scout claw"
+balance = 100_000_000_000_000
+
+[accounts.wallet_1]
+mnemonic = "sell invite acquire kitten bamboo drastic jelly vivid peace spawn twice guilt pave pen trash pretty park cube fragile unaware remain midnight betray rebuild"
+balance = 100_000_000_000_000
+
+[accounts.faucet]
+mnemonic = "shadow private easily thought say logic fault paddle word top book during ignore notable orange flight clock image wealth health outside kitten belt reform"
+balance = 100_000_000_000_000
+
+[devnet]
+disable_stacks_explorer = false
+disable_stacks_api = false
+
+[[devnet.pox_stacking_orders]]
+start_at_cycle = 3
+duration = 12
+wallet = "wallet_1"
+slots = 2
+btc_address = "mr1iPkD9N3RJZZxXRk7xF9d36gffa6exNC"
+
+[[devnet.pox_stacking_orders]]
+start_at_cycle = 3
+duration = 12
+wallet = "wallet_2"
+slots = 1
+btc_address = "muYdXKmX9bByAueDe6KFfHd5Ff1gdN9ErG"
+
+[[devnet.pox_stacking_orders]]
+start_at_cycle = 3
+duration = 12
+wallet = "wallet_3"
+slots = 1
+btc_address = "mvZtbibDAAA3WLpY7zXXFqRa3T4XSknBX7"

--- a/components/clarity-vscode/web-extension.code-workspace
+++ b/components/clarity-vscode/web-extension.code-workspace
@@ -7,6 +7,7 @@
   "settings": {
     "typescript.tsc.autoDetect": "off",
     "rust-analyzer.cargo.features": ["clarity-lsp/wasm", "clarity/wasm"],
-    "rust-analyzer.cargo.noDefaultFeatures": true
+    "rust-analyzer.cargo.noDefaultFeatures": true,
+    "rust-analyzer.debug.openDebugPane": true
   }
 }


### PR DESCRIPTION
- Removed the clarity insights options from the config so it's not visible to the users (but the code is still here)
- Fix an issue that make the extension crash when opening a toml file that is not a Clarinet.toml
- Extension won't activate on any toml any way
- Remove useless logs
- Better error message when file is missing