### PR TITLE
fix: propagate the eval hooks passed to `eval`

### DIFF
--- a/components/clarity-repl/src/repl/session.rs
+++ b/components/clarity-repl/src/repl/session.rs
@@ -642,7 +642,7 @@ impl Session {
         let contract_identifier =
             contract.expect_resolved_contract_identifier(Some(&self.interpreter.get_tx_sender()));
 
-        let result = self.interpreter.run(&contract, cost_track, Some(vec![]));
+        let result = self.interpreter.run(&contract, cost_track, eval_hooks);
 
         match result {
             Ok(result) => {


### PR DESCRIPTION
This was accidentally removed during some merging, and it prevents the debuggers from working.