### PR TITLE
fix: fix coverage tracking

### DIFF
--- a/components/clarity-repl/src/repl/session.rs
+++ b/components/clarity-repl/src/repl/session.rs
@@ -586,9 +586,7 @@ impl Session {
             }
         };
         self.set_tx_sender(initial_tx_sender);
-        // if let Some(coverage) = result.coverage.take() {
-        //     self.coverage_reports.push(coverage);
-        // }
+        self.coverage_reports.push(coverage);
         if let Some(ref cost) = execution.cost {
             self.costs_reports.push(CostsReport {
                 test_name,


### PR DESCRIPTION
It seems these lines were commented out during the merge and never put back. This simple fix should be all we need.

Fixes: #591