### PR TITLE
feat: improve deployment plans

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -377,11 +377,11 @@ jobs:
             platform: darwin
             target: aarch64-apple-darwin
             architecture: arm64
-          # - os: ubuntu-latest
-          #   platform: linux
-          #   target: x86_64-unknown-linux-musl
-          #   architecture: x64
-          #   libc: musl
+          - os: ubuntu-latest
+            platform: linux
+            target: x86_64-unknown-linux-musl
+            architecture: x64
+            libc: musl
 
     steps:
       - name: Configure git to use LF (Windows)

--- a/components/chainhook-types-rs/src/rosetta.rs
+++ b/components/chainhook-types-rs/src/rosetta.rs
@@ -561,6 +561,13 @@ impl StacksNetwork {
         }
     }
 
+    pub fn either_testnet_or_mainnet(&self) -> bool {
+        match self {
+            StacksNetwork::Mainnet | StacksNetwork::Testnet => true,
+            _ => false,
+        }
+    }
+
     pub fn is_devnet(&self) -> bool {
         match self {
             StacksNetwork::Devnet => true,

--- a/components/clarinet-cli/examples/counter/Clarinet.toml
+++ b/components/clarinet-cli/examples/counter/Clarinet.toml
@@ -3,7 +3,6 @@ name = "counter"
 authors = []
 description = ""
 telemetry = false
-cache_dir = "./.requirements"
 
 [contracts.counter]
 path = "contracts/counter.clar"

--- a/components/clarinet-cli/src/deployments/types.rs
+++ b/components/clarinet-cli/src/deployments/types.rs
@@ -21,6 +21,10 @@ impl DeploymentSynthesis {
                     TransactionSpecification::ContractPublish(tx) => {
                         total_cost += tx.cost;
                     }
+                    TransactionSpecification::StxTransfer(tx) => {
+                        total_cost += tx.cost;
+                        total_cost += tx.mstx_amount;
+                    }
                     _ => {}
                 }
             }
@@ -30,7 +34,6 @@ impl DeploymentSynthesis {
             Ok(res) => res,
             Err(err) => panic!("unable to serialize deployment {}", err),
         };
-
         return DeploymentSynthesis {
             total_cost,
             blocks_count,

--- a/components/clarinet-cli/src/runner/api_v1.rs
+++ b/components/clarinet-cli/src/runner/api_v1.rs
@@ -687,15 +687,11 @@ fn mine_block(state: &mut OpState, args: MineBlockArgs) -> Result<String, AnyErr
                         execution.events,
                     ));
                 } else if let Some(ref args) = tx.transfer_stx {
-                    let snippet = format!(
-                        "(stx-transfer? u{} tx-sender '{})",
-                        args.amount, args.recipient
-                    );
-                    let execution = match session.eval(snippet.clone(), None, false) {
+                    let execution = match session.stx_transfer(args.amount, &args.recipient) {
                         Ok(res) => res,
                         Err(diagnostics) => {
                             let mut message =
-                                format!("{}: {}", red!("STX transfer runtime error"), snippet);
+                                format!("{}: {}", red!("STX transfer runtime error"), tx.sender);
                             if let Some(diag) = diagnostics.last() {
                                 message = format!("{} -> {}", message, diag.message);
                             }

--- a/components/clarinet-deployments/src/lib.rs
+++ b/components/clarinet-deployments/src/lib.rs
@@ -138,6 +138,12 @@ pub fn update_session_with_contracts_executions(
                 | TransactionSpecification::ContractPublish(_) => {
                     panic!("emulated-contract-call and emulated-contract-publish are the only operations admitted in simnet deployments")
                 }
+                TransactionSpecification::StxTransfer(tx) => {
+                    let default_tx_sender = session.get_tx_sender();
+                    session.set_tx_sender(tx.expected_sender.to_string());
+                    let _ = session.stx_transfer(tx.mstx_amount, &tx.recipient.to_string());
+                    session.set_tx_sender(default_tx_sender);
+                }
                 TransactionSpecification::EmulatedContractPublish(tx) => {
                     let default_tx_sender = session.get_tx_sender();
                     session.set_tx_sender(tx.emulated_sender.to_string());

--- a/components/clarinet-deployments/src/onchain/mod.rs
+++ b/components/clarinet-deployments/src/onchain/mod.rs
@@ -254,7 +254,7 @@ pub fn update_deployment_costs(
                             tx.cost = fee;
                         }
                         Err(e) => {
-                            println!("unable to estimate fee for transaction");
+                            println!("unable to estimate fee for transaction: {}", e.to_string());
                             continue;
                         }
                     };
@@ -285,7 +285,7 @@ pub fn update_deployment_costs(
                             tx.cost = fee;
                         }
                         Err(e) => {
-                            println!("unable to estimate fee for transaction");
+                            println!("unable to estimate fee for transaction: {}", e.to_string());
                             continue;
                         }
                     };

--- a/components/clarinet-deployments/src/onchain/mod.rs
+++ b/components/clarinet-deployments/src/onchain/mod.rs
@@ -601,7 +601,7 @@ pub fn apply_on_chain_deployment(
                     ongoing_batch.insert(res.txid, tracker);
                 }
                 Err(e) => {
-                    let message = format!("unable to post transaction ({:?})", e);
+                    let message = format!("unable to post transaction\n{:?}", e);
                     tracker.status = TransactionStatus::Error(message.clone());
 
                     let _ = deployment_event_tx

--- a/components/clarinet-deployments/src/types.rs
+++ b/components/clarinet-deployments/src/types.rs
@@ -1,4 +1,5 @@
 use clarinet_files::FileLocation;
+use clarity_repl::clarity::util::hash::{hex_bytes, to_hex};
 use clarity_repl::clarity::vm::analysis::ContractAnalysis;
 use clarity_repl::clarity::vm::ast::ContractAST;
 use clarity_repl::clarity::vm::diagnostic::Diagnostic;
@@ -53,6 +54,20 @@ pub enum TransactionSpecificationFile {
     EmulatedContractPublish(EmulatedContractPublishSpecificationFile),
     RequirementPublish(RequirementPublishSpecificationFile),
     BtcTransfer(BtcTransferSpecificationFile),
+    StxTransfer(StxTransferSpecificationFile),
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct StxTransferSpecificationFile {
+    pub expected_sender: String,
+    pub recipient: String,
+    pub mstx_amount: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub memo: Option<String>,
+    pub cost: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub anchor_block_only: Option<bool>,
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
@@ -147,6 +162,69 @@ pub enum TransactionSpecification {
     EmulatedContractCall(EmulatedContractCallSpecification),
     EmulatedContractPublish(EmulatedContractPublishSpecification),
     BtcTransfer(BtcTransferSpecification),
+    StxTransfer(StxTransferSpecification),
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct StxTransferSpecification {
+    pub expected_sender: StandardPrincipalData,
+    pub recipient: PrincipalData,
+    pub mstx_amount: u64,
+    pub memo: [u8; 34],
+    pub cost: u64,
+    pub anchor_block_only: bool,
+}
+
+impl StxTransferSpecification {
+    pub fn from_specifications(
+        specs: &StxTransferSpecificationFile,
+    ) -> Result<StxTransferSpecification, String> {
+        let expected_sender = match PrincipalData::parse_standard_principal(&specs.expected_sender)
+        {
+            Ok(res) => res,
+            Err(_) => {
+                return Err(format!(
+                    "unable to parse expected sender '{}' as a valid Stacks address",
+                    specs.expected_sender
+                ))
+            }
+        };
+
+        let recipient = match PrincipalData::parse(&specs.recipient) {
+            Ok(res) => res,
+            Err(_) => {
+                return Err(format!(
+                    "unable to parse recipient '{}' as a valid Stacks address",
+                    specs.expected_sender
+                ))
+            }
+        };
+
+        let mut memo = [0u8; 34];
+        if let Some(ref hex_memo) = specs.memo {
+            if !hex_memo.is_empty() && !hex_memo.starts_with("0x") {
+                return Err(format!(
+                    "unable to parse memo (up to 34 bytes, starting with '0x')",
+                ));
+            }
+            match hex_bytes(&hex_memo[2..]) {
+                Ok(ref mut bytes) => {
+                    bytes.resize(34, 0);
+                    memo.copy_from_slice(&bytes);
+                }
+                Err(_) => return Err(format!("unable to parse memo (up to 34 bytes)",)),
+            }
+        }
+
+        Ok(StxTransferSpecification {
+            expected_sender,
+            recipient,
+            memo,
+            mstx_amount: specs.mstx_amount,
+            cost: specs.cost,
+            anchor_block_only: specs.anchor_block_only.unwrap_or(true),
+        })
+    }
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -582,7 +660,11 @@ impl DeploymentSpecification {
                                     contracts.insert(contract_id, (spec.source.clone(), spec.location.clone()));
                                     TransactionSpecification::EmulatedContractPublish(spec)
                                 }
-                                _ => {
+                                TransactionSpecificationFile::StxTransfer(spec) => {
+                                    let spec = StxTransferSpecification::from_specifications(spec)?;
+                                    TransactionSpecification::StxTransfer(spec)
+                                }
+                                TransactionSpecificationFile::BtcTransfer(_) | TransactionSpecificationFile::ContractCall(_) | TransactionSpecificationFile::ContractPublish(_) | TransactionSpecificationFile::RequirementPublish(_) => {
                                     return Err(format!("{} only supports transactions of type 'emulated-contract-call' and 'emulated-contract-publish", specs.network.to_lowercase()))
                                 }
                             };
@@ -627,7 +709,11 @@ impl DeploymentSpecification {
                                     let spec = BtcTransferSpecification::from_specifications(spec)?;
                                     TransactionSpecification::BtcTransfer(spec)
                                 }
-                                _ => {
+                                TransactionSpecificationFile::StxTransfer(spec) => {
+                                    let spec = StxTransferSpecification::from_specifications(spec)?;
+                                    TransactionSpecification::StxTransfer(spec)
+                                }
+                                TransactionSpecificationFile::EmulatedContractCall(_) | TransactionSpecificationFile::EmulatedContractPublish(_) => {
                                     return Err(format!("{} only supports transactions of type 'contract-call' and 'contract-publish'", specs.network.to_lowercase()))
                                 }
                             };
@@ -877,6 +963,20 @@ impl TransactionPlanSpecification {
                             recipient: tx.recipient.clone(),
                             sats_amount: tx.sats_amount,
                             sats_per_byte: tx.sats_per_byte,
+                        })
+                    }
+                    TransactionSpecification::StxTransfer(tx) => {
+                        TransactionSpecificationFile::StxTransfer(StxTransferSpecificationFile {
+                            expected_sender: tx.expected_sender.to_address(),
+                            recipient: tx.recipient.to_string(),
+                            mstx_amount: tx.mstx_amount,
+                            memo: if tx.memo == [0; 34] {
+                                None
+                            } else {
+                                Some(format!("0x{}", to_hex(&tx.memo)))
+                            },
+                            cost: tx.cost,
+                            anchor_block_only: Some(tx.anchor_block_only),
                         })
                     }
                 };

--- a/components/clarinet-files/src/network_manifest.rs
+++ b/components/clarinet-files/src/network_manifest.rs
@@ -255,11 +255,7 @@ impl NetworkManifest {
 
         let mut network_manifest_file: NetworkManifestFile =
             toml::from_slice(&content.as_bytes()).unwrap();
-        Ok(NetworkManifest::from_network_manifest_file(
-            &mut network_manifest_file,
-            networks,
-            None,
-        ))
+        NetworkManifest::from_network_manifest_file(&mut network_manifest_file, networks, None)
     }
 
     pub fn from_location(
@@ -270,18 +266,18 @@ impl NetworkManifest {
         let network_manifest_file_content = location.read_content()?;
         let mut network_manifest_file: NetworkManifestFile =
             toml::from_slice(&network_manifest_file_content[..]).unwrap();
-        Ok(NetworkManifest::from_network_manifest_file(
+        NetworkManifest::from_network_manifest_file(
             &mut network_manifest_file,
             networks,
             cache_location,
-        ))
+        )
     }
 
     pub fn from_network_manifest_file(
         network_manifest_file: &mut NetworkManifestFile,
         networks: &(BitcoinNetwork, StacksNetwork),
         cache_location: Option<&FileLocation>,
-    ) -> NetworkManifest {
+    ) -> Result<NetworkManifest, String> {
         let stacks_node_rpc_address = match (
             &network_manifest_file.network.node_rpc_address,
             &network_manifest_file.network.stacks_node_rpc_address,
@@ -321,12 +317,11 @@ impl NetworkManifest {
                                     match Mnemonic::parse_in_normalized(Language::English, words) {
                                         Ok(result) => result.to_string(),
                                         Err(e) => {
-                                            println!(
-                                                "Error: mnemonic for wallet '{}' invalid: {}",
+                                            return Err(format!(
+                                                "mnemonic for wallet '{}' invalid: {}",
                                                 account_name,
                                                 e.to_string()
-                                            );
-                                            std::process::exit(1);
+                                            ));
                                         }
                                     }
                                 }
@@ -599,7 +594,7 @@ impl NetworkManifest {
             devnet,
         };
 
-        config
+        Ok(config)
     }
 }
 

--- a/components/clarity-repl/src/repl/session.rs
+++ b/components/clarity-repl/src/repl/session.rs
@@ -486,6 +486,15 @@ impl Session {
         self.run_snippet(output, self.show_costs, &snippet.to_string());
     }
 
+    pub fn stx_transfer(
+        &mut self,
+        amount: u64,
+        recipient: &str,
+    ) -> Result<ExecutionResult, Vec<Diagnostic>> {
+        let snippet = format!("(stx-transfer? u{} tx-sender '{})", amount, recipient);
+        self.eval(snippet.clone(), None, false)
+    }
+
     pub fn deploy_contract(
         &mut self,
         contract: &ClarityContract,


### PR DESCRIPTION
With this PR, we're adding some new features to deployment plans:
- ability to add `stx-transfer` steps (simnet/devnet/testnet/mainnet)
- better error handling (eliminating the `Generic` error that developers are facing today).
- ability to get costs being computed, using the `v2/fees/transaction` endpoint 