### PR TITLE
Fix: deno expect events

### DIFF
--- a/components/clarinet-deno/index.test.ts
+++ b/components/clarinet-deno/index.test.ts
@@ -185,3 +185,60 @@ Deno.test("types.tuple", () => {
   assertStrictEquals(types.tuple({ id: 1 }), "{ id: 1 }");
   assertObjectMatch(types.tuple({ id: 1 }).expectTuple(), { id: "1" });
 });
+
+Deno.test("expectPrintEvent", () => {
+  const events = [
+    {
+      type: "contract_event",
+      contract_event: {
+        contract_identifier:
+          "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.my-contract",
+        topic: "print",
+        value: '"hello"',
+      },
+    },
+    {
+      type: "stx_transfer_event",
+      stx_transfer_event: {
+        sender: "ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5",
+        recipient: "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM",
+        amount: "1000",
+        memo: "",
+      },
+    },
+  ];
+
+  events.expectPrintEvent(
+    "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.my-contract",
+    '"hello"'
+  );
+});
+
+Deno.test("expectSTXTransferEvent", () => {
+  const events = [
+    {
+      type: "contract_event",
+      contract_event: {
+        contract_identifier:
+          "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.my-contract",
+        topic: "print",
+        value: '"hello"',
+      },
+    },
+    {
+      type: "stx_transfer_event",
+      stx_transfer_event: {
+        sender: "ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5",
+        recipient: "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM",
+        amount: "1000",
+        memo: "",
+      },
+    },
+  ];
+
+  events.expectSTXTransferEvent(
+    1000,
+    "ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5",
+    "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM"
+  );
+});

--- a/components/clarinet-deno/index.ts
+++ b/components/clarinet-deno/index.ts
@@ -679,8 +679,9 @@ String.prototype.expectTuple = function () {
 };
 
 Array.prototype.expectSTXTransferEvent = function (amount, sender, recipient) {
-  for (const { stx_transfer_event } of this) {
+  for (const event of this) {
     try {
+      const { stx_transfer_event } = event;
       return {
         amount: stx_transfer_event.amount.expectInt(amount),
         sender: stx_transfer_event.sender.expectPrincipal(sender),
@@ -699,8 +700,9 @@ Array.prototype.expectFungibleTokenTransferEvent = function (
   recipient,
   assetId
 ) {
-  for (const { ft_transfer_event } of this) {
+  for (const event of this) {
     try {
+      const { ft_transfer_event } = event;
       if (!ft_transfer_event.asset_identifier.endsWith(assetId)) continue;
 
       return {
@@ -725,8 +727,9 @@ Array.prototype.expectFungibleTokenMintEvent = function (
   recipient,
   assetId
 ) {
-  for (const { ft_mint_event } of this) {
+  for (const event of this) {
     try {
+      const { ft_mint_event } = event;
       if (!ft_mint_event.asset_identifier.endsWith(assetId)) continue;
 
       return {
@@ -746,8 +749,9 @@ Array.prototype.expectFungibleTokenBurnEvent = function (
   sender,
   assetId
 ) {
-  for (const { ft_burn_event } of this) {
+  for (const event of this) {
     try {
+      const { ft_burn_event } = event;
       if (!ft_burn_event.asset_identifier.endsWith(assetId)) continue;
 
       return {
@@ -763,8 +767,9 @@ Array.prototype.expectFungibleTokenBurnEvent = function (
 };
 
 Array.prototype.expectPrintEvent = function (contractIdentifier, value) {
-  for (const { contract_event } of this) {
+  for (const event of this) {
     try {
+      const { contract_event } = event;
       if (!contract_event.topic.endsWith("print")) continue;
       if (!contract_event.value.endsWith(value)) continue;
 
@@ -791,8 +796,9 @@ Array.prototype.expectNonFungibleTokenTransferEvent = function (
   assetAddress,
   assetId
 ) {
-  for (const { nft_transfer_event } of this) {
+  for (const event of this) {
     try {
+      const { nft_transfer_event } = event;
       if (nft_transfer_event.value !== tokenId) continue;
       if (nft_transfer_event.asset_identifier !== `${assetAddress}::${assetId}`)
         continue;
@@ -816,8 +822,9 @@ Array.prototype.expectNonFungibleTokenMintEvent = function (
   assetAddress,
   assetId
 ) {
-  for (const { nft_mint_event } of this) {
+  for (const event of this) {
     try {
+      const { nft_mint_event } = event;
       if (nft_mint_event.value !== tokenId) continue;
       if (nft_mint_event.asset_identifier !== `${assetAddress}::${assetId}`)
         continue;


### PR DESCRIPTION
Fixes a regression introduced in #618.
Because the "events" array can contain anything (not just the expected event type) events should not be destructured outside of the `try catch`.

Note: further improvements should be expected in `expect<Event>` methods as part of #627 to make error messages easier to understand.