### PR TITLE
Feat: lsp current editor state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,18 +261,6 @@ dependencies = [
 
 [[package]]
 name = "auto_impl"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42cbf586c80ada5e5ccdecae80d3ef0854f224e2dd74435f8d87e6831b8d0a38"
-dependencies = [
- "proc-macro-error",
- "proc-macro2 1.0.46",
- "quote 1.0.21",
- "syn 1.0.101",
-]
-
-[[package]]
-name = "auto_impl"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7862e21c893d65a1650125d157eaeec691439379a1cee17ee49031b79236ada4"
@@ -528,18 +516,6 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitvec"
-version = "0.19.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55f93d0ef3363c364d5976646a38f04cf67cfe1d4c8d160cdea02cab2c116b33"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
 
 [[package]]
 name = "blake2b_simd"
@@ -1168,7 +1144,7 @@ dependencies = [
  "clarity-repl",
  "console_error_panic_hook",
  "js-sys",
- "lsp-types 0.93.1",
+ "lsp-types",
  "serde",
  "serde-wasm-bindgen",
  "wasm-bindgen",
@@ -1635,16 +1611,6 @@ dependencies = [
  "darling_core",
  "quote 1.0.21",
  "syn 1.0.101",
-]
-
-[[package]]
-name = "dashmap"
-version = "4.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e77a43b28d0668df09411cb0bc9a8c2adc40f9a048afe863e05fd43251e8e39c"
-dependencies = [
- "cfg-if",
- "num_cpus",
 ]
 
 [[package]]
@@ -2614,12 +2580,6 @@ name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
-name = "funty"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "futures"
@@ -3596,19 +3556,6 @@ dependencies = [
 
 [[package]]
 name = "lsp-types"
-version = "0.89.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852e0dedfd52cc32325598b2631e0eba31b7b708959676a9f837042f276b09a2"
-dependencies = [
- "bitflags",
- "serde",
- "serde_json",
- "serde_repr",
- "url",
-]
-
-[[package]]
-name = "lsp-types"
 version = "0.93.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3bcfee315dde785ba887edb540b08765fd7df75a7d948844be6bf5712246734"
@@ -3912,18 +3859,6 @@ dependencies = [
  "path-clean",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "nom"
-version = "6.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7413f999671bd4745a7b624bd370a569fb6bc574b23c83a3c5ed2e453f3d5e2"
-dependencies = [
- "bitvec",
- "funty",
- "memchr",
- "version_check",
 ]
 
 [[package]]
@@ -4637,12 +4572,6 @@ checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2 1.0.46",
 ]
-
-[[package]]
-name = "radium"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
 
 [[package]]
 name = "radix_fmt"
@@ -6645,7 +6574,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9413ed145b0c3e693d18760a72c72bb7ac3e522edbb88bfe0c6c161a7b148281"
 dependencies = [
  "ahash",
- "dashmap 5.4.0",
+ "dashmap",
  "indexmap",
  "once_cell",
  "rustc-hash",
@@ -6688,7 +6617,7 @@ checksum = "c6b0516e231008722175bc0841bf4f3fdcfd3276ca0bf4878d6e87af5c50f324"
 dependencies = [
  "ahash",
  "base64 0.13.0",
- "dashmap 5.4.0",
+ "dashmap",
  "indexmap",
  "once_cell",
  "regex",
@@ -6783,7 +6712,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9b192a3b556cf0a81b4dcb8fa35374d306cd46f806dce937599b40e2d945e51"
 dependencies = [
  "ahash",
- "auto_impl 0.5.0",
+ "auto_impl",
  "petgraph",
  "swc_fast_graph",
  "tracing",
@@ -6862,12 +6791,6 @@ name = "take_mut"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
-
-[[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
@@ -7219,34 +7142,54 @@ dependencies = [
 ]
 
 [[package]]
-name = "tower-lsp"
-version = "0.14.1"
+name = "tower"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "701465c44f9e5655785b1420f3dea1d33d15f2fea2e0a65d25c4fd91ec0e6238"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
- "async-trait",
- "auto_impl 0.4.1",
- "bytes",
- "dashmap 4.0.2",
- "futures",
- "log",
- "lsp-types 0.89.2",
- "nom",
- "serde",
- "serde_json",
- "tokio",
- "tokio-util 0.6.10",
- "tower-lsp-macros",
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tower-layer",
  "tower-service",
 ]
 
 [[package]]
-name = "tower-lsp-macros"
-version = "0.4.1"
+name = "tower-layer"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb72acc00b574cffa151d0725b3b26404554b371b4c6e059c58eb23f9f097140"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+
+[[package]]
+name = "tower-lsp"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43e094780b4447366c59f79acfd65b1375ecaa84e61dddbde1421aa506334024"
 dependencies = [
- "heck 0.3.3",
+ "async-trait",
+ "auto_impl",
+ "bytes",
+ "dashmap",
+ "futures",
+ "httparse",
+ "log",
+ "lsp-types",
+ "memchr",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-util 0.7.2",
+ "tower",
+ "tower-lsp-macros",
+]
+
+[[package]]
+name = "tower-lsp-macros"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ebd99eec668d0a450c177acbc4d05e0d0d13b1f8d3db13cd706c52cbec4ac04"
+dependencies = [
  "proc-macro2 1.0.46",
  "quote 1.0.21",
  "syn 1.0.101",
@@ -7979,12 +7922,6 @@ checksum = "b68db261ef59e9e52806f688020631e987592bd83619edccda9c47d42cde4f6c"
 dependencies = [
  "toml 0.5.9",
 ]
-
-[[package]]
-name = "wyz"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "xattr"

--- a/components/clarinet-cli/Cargo.toml
+++ b/components/clarinet-cli/Cargo.toml
@@ -136,7 +136,7 @@ strum = { version = "0.23.0", features = ["derive"] }
 bitcoin = "0.28.1"
 segment = { version = "0.1.2", optional = true }
 mac_address = { version = "1.1.2", optional = true }
-tower-lsp = { version = "0.14.0", optional = true }
+tower-lsp = { version = "0.17.0", optional = true }
 hex = "0.4.3"
 serde_yaml = "0.8.23"
 chainhook_event_observer = { package = "chainhook-event-observer", default-features = false, path = "../chainhook-event-observer" }

--- a/components/clarinet-cli/src/generate/contract.rs
+++ b/components/clarinet-cli/src/generate/contract.rs
@@ -86,8 +86,8 @@ Clarinet.test({{
     name: "Ensure that <...>",
     async fn(chain: Chain, accounts: Map<string, Account>) {{
         let block = chain.mineBlock([
-            /* 
-             * Add transactions with: 
+            /*
+             * Add transactions with:
              * Tx.contractCall(...)
             */
         ]);
@@ -95,8 +95,8 @@ Clarinet.test({{
         assertEquals(block.height, 2);
 
         block = chain.mineBlock([
-            /* 
-             * Add transactions with: 
+            /*
+             * Add transactions with:
              * Tx.contractCall(...)
             */
         ]);

--- a/components/clarinet-cli/src/lsp/mod.rs
+++ b/components/clarinet-cli/src/lsp/mod.rs
@@ -1,5 +1,6 @@
 mod native_bridge;
 
+use self::native_bridge::LspNativeBridge;
 use clarity_lsp::utils;
 use clarity_repl::clarity::vm::diagnostic::{
     Diagnostic as ClarityDiagnostic, Level as ClarityLevel,
@@ -11,8 +12,6 @@ use tower_lsp::lsp_types::{
     Diagnostic, DiagnosticSeverity, Documentation, MarkupContent, MarkupKind, Position, Range,
 };
 use tower_lsp::{LspService, Server};
-
-use self::native_bridge::LspNativeBridge;
 
 pub fn run_lsp() {
     match block_on(do_run_lsp()) {

--- a/components/clarinet-cli/src/lsp/mod.rs
+++ b/components/clarinet-cli/src/lsp/mod.rs
@@ -170,7 +170,7 @@ pub fn clarity_diagnostic_to_tower_lsp_type(
 #[test]
 fn test_opening_counter_contract_should_return_fresh_analysis() {
     use clarinet_files::FileLocation;
-    use clarity_lsp::backend::{LspNotification, LspResponse};
+    use clarity_lsp::backend::{LspNotification, LspNotificationResponse};
     use crossbeam_channel::unbounded;
     use std::sync::mpsc::channel;
 
@@ -205,13 +205,13 @@ fn test_opening_counter_contract_should_return_fresh_analysis() {
     // re-opening this contract should not trigger a full analysis
     let _ = notification_tx.send(LspNotification::ContractOpened(contract_location));
     let response = response_rx.recv().expect("Unable to get response");
-    assert_eq!(response, LspResponse::default());
+    assert_eq!(response, LspNotificationResponse::default());
 }
 
 #[test]
 fn test_opening_counter_manifest_should_return_fresh_analysis() {
     use clarinet_files::FileLocation;
-    use clarity_lsp::backend::{LspNotification, LspResponse};
+    use clarity_lsp::backend::{LspNotification, LspNotificationResponse};
     use crossbeam_channel::unbounded;
     use std::sync::mpsc::channel;
 
@@ -245,7 +245,7 @@ fn test_opening_counter_manifest_should_return_fresh_analysis() {
     // re-opening this manifest should not trigger a full analysis
     let _ = notification_tx.send(LspNotification::ManifestOpened(manifest_location));
     let response = response_rx.recv().expect("Unable to get response");
-    assert_eq!(response, LspResponse::default());
+    assert_eq!(response, LspNotificationResponse::default());
 }
 
 #[test]

--- a/components/clarinet-deployments/src/lib.rs
+++ b/components/clarinet-deployments/src/lib.rs
@@ -490,11 +490,11 @@ pub async fn generate_default_deployment(
     let sources: HashMap<String, String> = match file_accessor {
         None => {
             let mut sources = HashMap::new();
-            for (contract_location, contract_config) in manifest.contracts_settings.iter() {
+            for (contract_location, _) in manifest.contracts_settings.iter() {
                 let source = contract_location.read_content_as_utf8().map_err(|_| {
                     format!(
-                        "unable to find contract at path {}",
-                        contract_config.expect_contract_path_as_str()
+                        "unable to find contract at {}",
+                        contract_location.to_string()
                     )
                 })?;
                 sources.insert(contract_location.to_string(), source);

--- a/components/clarinet-deployments/src/lib.rs
+++ b/components/clarinet-deployments/src/lib.rs
@@ -487,22 +487,10 @@ pub async fn generate_default_deployment(
     let mut contracts = HashMap::new();
     let mut contracts_sources = HashMap::new();
 
-    let base_location = manifest.location.clone().get_parent_location()?;
-
     let sources: HashMap<String, String> = match file_accessor {
         None => {
             let mut sources = HashMap::new();
-            for (_, contract_config) in manifest.contracts.iter() {
-                let mut contract_location = base_location.clone();
-                contract_location
-                    .append_path(&contract_config.expect_contract_path_as_str())
-                    .map_err(|_| {
-                        format!(
-                            "unable to build path for contract {}",
-                            contract_config.expect_contract_path_as_str()
-                        )
-                    })?;
-
+            for (contract_location, contract_config) in manifest.contracts_settings.iter() {
                 let source = contract_location.read_content_as_utf8().map_err(|_| {
                     format!(
                         "unable to find contract at path {}",
@@ -515,15 +503,9 @@ pub async fn generate_default_deployment(
         }
         Some(file_accessor) => {
             let contracts_location = manifest
-                .contracts
+                .contracts_settings
                 .iter()
-                .map(|(_, contract_config)| {
-                    let mut contract_location = base_location.clone();
-                    contract_location
-                        .append_path(&contract_config.expect_contract_path_as_str())
-                        .unwrap();
-                    contract_location.to_string()
-                })
+                .map(|(contract_location, _)| contract_location.to_string())
                 .collect();
             file_accessor
                 .read_contracts_content(contracts_location)
@@ -531,10 +513,15 @@ pub async fn generate_default_deployment(
         }
     };
 
-    for (name, contract_config) in manifest.contracts.iter() {
-        let contract_name = match ContractName::try_from(name.to_string()) {
+    for (contract_location, contract_config) in manifest.contracts_settings.iter() {
+        let contract_name = match ContractName::try_from(contract_config.name.to_string()) {
             Ok(res) => res,
-            Err(_) => return Err(format!("unable to use {} as a valid contract name", name)),
+            Err(_) => {
+                return Err(format!(
+                    "unable to use {} as a valid contract name",
+                    contract_config.name
+                ))
+            }
         };
 
         let deployer = match &contract_config.deployer {
@@ -561,13 +548,11 @@ pub async fn generate_default_deployment(
             }
         };
 
-        let mut contract_location = base_location.clone();
-        contract_location.append_path(&contract_config.expect_contract_path_as_str())?;
         let source = sources
             .get(&contract_location.to_string())
             .ok_or(format!(
                 "Invalid Clarinet.toml, source file not found for: {}",
-                name
+                &contract_config.name
             ))?
             .clone();
 
@@ -590,7 +575,7 @@ pub async fn generate_default_deployment(
                     contract_name,
                     emulated_sender: sender,
                     source,
-                    location: contract_location,
+                    location: contract_location.clone(),
                     clarity_version: contract_config.clarity_version,
                 },
             )
@@ -598,7 +583,7 @@ pub async fn generate_default_deployment(
             TransactionSpecification::ContractPublish(ContractPublishSpecification {
                 contract_name,
                 expected_sender: sender,
-                location: contract_location,
+                location: contract_location.clone(),
                 cost: deployment_fee_rate
                     .saturating_mul(source.as_bytes().len().try_into().unwrap()),
                 source,

--- a/components/clarinet-files/src/project_manifest.rs
+++ b/components/clarinet-files/src/project_manifest.rs
@@ -135,13 +135,14 @@ impl ProjectManifest {
         }
 
         let project_name = project_manifest_file.project.name;
-        let mut project_root_location = manifest_location.get_parent_location()?;
+        let project_root_location = manifest_location.get_parent_location()?;
         let cache_location = match project_manifest_file.project.cache_dir {
             Some(ref path) => FileLocation::try_parse(path, Some(&project_root_location))
                 .ok_or(format!("unable to parse path {}", path))?,
             None => {
-                project_root_location.append_path(".cache")?;
-                project_root_location.clone()
+                let mut cache_location = project_root_location.clone();
+                cache_location.append_path(".cache")?;
+                cache_location
             }
         };
 
@@ -257,6 +258,7 @@ impl ProjectManifest {
                             };
                             config_contracts
                                 .insert(contract_name.clone(), clarity_contract.clone());
+
                             let mut contract_location = project_root_location.clone();
                             contract_location.append_path(contract_path)?;
                             contracts_settings.insert(contract_location, clarity_contract);

--- a/components/clarinet-files/src/project_manifest.rs
+++ b/components/clarinet-files/src/project_manifest.rs
@@ -14,6 +14,14 @@ use std::path::PathBuf;
 use std::str::FromStr;
 use toml::value::Value;
 
+#[derive(Deserialize, Debug, Clone)]
+pub struct ClarityContractMetadata {
+    pub name: String,
+    pub deployer: ContractDeployer,
+    pub clarity_version: ClarityVersion,
+    pub epoch: StacksEpochId,
+}
+
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ProjectManifestFile {
     project: ProjectConfigFile,
@@ -46,7 +54,7 @@ pub struct ProjectManifest {
     #[serde(skip_serializing)]
     pub location: FileLocation,
     #[serde(skip_serializing)]
-    pub contracts_settings: HashMap<FileLocation, ClarityContract>,
+    pub contracts_settings: HashMap<FileLocation, ClarityContractMetadata>,
 }
 
 #[derive(Debug, Clone)]
@@ -249,19 +257,29 @@ impl ProjectManifest {
                                 }
                                 _ => DEFAULT_EPOCH,
                             };
-                            let clarity_contract = ClarityContract {
-                                name: contract_name.clone(),
-                                code_source,
-                                deployer,
-                                clarity_version,
-                                epoch,
-                            };
-                            config_contracts
-                                .insert(contract_name.clone(), clarity_contract.clone());
+
+                            config_contracts.insert(
+                                contract_name.to_string(),
+                                ClarityContract {
+                                    name: contract_name.to_string(),
+                                    deployer: deployer.clone(),
+                                    code_source,
+                                    clarity_version,
+                                    epoch,
+                                },
+                            );
 
                             let mut contract_location = project_root_location.clone();
                             contract_location.append_path(contract_path)?;
-                            contracts_settings.insert(contract_location, clarity_contract);
+                            contracts_settings.insert(
+                                contract_location,
+                                ClarityContractMetadata {
+                                    name: contract_name.to_string(),
+                                    deployer,
+                                    clarity_version,
+                                    epoch,
+                                },
+                            );
                         }
                         _ => {}
                     }

--- a/components/clarity-lsp/src/common/backend.rs
+++ b/components/clarity-lsp/src/common/backend.rs
@@ -1,45 +1,84 @@
+use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
+
 use crate::lsp_types::MessageType;
 use crate::state::{build_state, EditorState, ProtocolState};
 use crate::types::{CompletionItem, CompletionItemKind};
 use clarinet_files::{FileAccessor, FileLocation};
 use clarity_repl::clarity::diagnostic::Diagnostic;
+use clarity_repl::repl::DEFAULT_CLARITY_VERSION;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize)]
-pub enum LspNotification {
-    ManifestOpened(FileLocation),
-    ManifestChanged(FileLocation),
-    ContractOpened(FileLocation),
-    ContractChanged(FileLocation),
+#[derive(Debug, Clone)]
+pub struct EditorStateInput {
+    editor_state: Option<EditorState>,
+    editor_state_lock: Option<Arc<RwLock<EditorState>>>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-pub enum LspRequest {
-    GetIntellisense(FileLocation),
-}
+impl EditorStateInput {
+    pub fn new(
+        editor_state: Option<EditorState>,
+        editor_state_lock: Option<Arc<RwLock<EditorState>>>,
+    ) -> Self {
+        EditorStateInput {
+            editor_state,
+            editor_state_lock,
+        }
+    }
 
-#[derive(Debug, PartialEq, Deserialize, Serialize)]
-pub struct LspResponse {
-    pub aggregated_diagnostics: Vec<(FileLocation, Vec<Diagnostic>)>,
-    pub notification: Option<(MessageType, String)>,
-    pub completion_items: Vec<CompletionItem>,
-}
+    pub fn try_read(&self) -> Result<RwLockReadGuard<EditorState>, String> {
+        match (self.editor_state.as_ref(), self.editor_state_lock.as_ref()) {
+            (Some(_editor_state), None) => unimplemented!(),
+            (None, Some(editor_state_lock)) => match editor_state_lock.try_read() {
+                Ok(editor_state) => Ok(editor_state),
+                Err(_) => Err("failed to read editor_state".to_string()),
+            },
+            _ => {
+                unreachable!();
+            }
+        }
+    }
 
-impl LspResponse {
-    pub fn default() -> LspResponse {
-        LspResponse {
-            aggregated_diagnostics: vec![],
-            notification: None,
-            completion_items: vec![],
+    pub fn try_write(&self) -> Result<RwLockWriteGuard<EditorState>, String> {
+        match (self.editor_state.as_ref(), self.editor_state_lock.as_ref()) {
+            (Some(_editor_state), None) => unimplemented!(),
+            (None, Some(editor_state_lock)) => match editor_state_lock.try_write() {
+                Ok(editor_state) => Ok(editor_state),
+                Err(_) => Err("failed to write editor_state".to_string()),
+            },
+            _ => {
+                unreachable!();
+            }
         }
     }
 }
 
-impl LspResponse {
-    pub fn error(message: &str) -> LspResponse {
-        LspResponse {
+#[derive(Debug, Serialize, Deserialize)]
+pub enum LspNotification {
+    ManifestOpened(FileLocation),
+    ManifestSaved(FileLocation),
+    ContractOpened(FileLocation),
+    ContractSaved(FileLocation),
+    ContractChanged(FileLocation, String),
+    ContractClosed(FileLocation),
+}
+
+#[derive(Debug, PartialEq, Deserialize, Serialize)]
+pub struct LspNotificationResponse {
+    pub aggregated_diagnostics: Vec<(FileLocation, Vec<Diagnostic>)>,
+    pub notification: Option<(MessageType, String)>,
+}
+
+impl LspNotificationResponse {
+    pub fn default() -> LspNotificationResponse {
+        LspNotificationResponse {
             aggregated_diagnostics: vec![],
-            completion_items: vec![],
+            notification: None,
+        }
+    }
+
+    pub fn error(message: &str) -> LspNotificationResponse {
+        LspNotificationResponse {
+            aggregated_diagnostics: vec![],
             notification: Some((MessageType::ERROR, format!("Internal error: {}", message))),
         }
     }
@@ -47,40 +86,86 @@ impl LspResponse {
 
 pub async fn process_notification(
     command: LspNotification,
-    editor_state: &mut EditorState,
+    editor_state: &EditorStateInput,
     file_accessor: Option<&Box<dyn FileAccessor>>,
-) -> Result<LspResponse, String> {
+) -> Result<LspNotificationResponse, String> {
     match command {
         LspNotification::ManifestOpened(manifest_location) => {
-            // The only reason why we're waiting for this kind of events, is building our initial state
-            // if the system is initialized, move on.
-            if editor_state.protocols.contains_key(&manifest_location) {
-                return Ok(LspResponse::default());
+            {
+                // Only build the initial state if it does not exist
+                if editor_state
+                    .try_read()?
+                    .protocols
+                    .contains_key(&manifest_location)
+                {
+                    return Ok(LspNotificationResponse::default());
+                }
             }
 
             // With this manifest_location, let's initialize our state.
             let mut protocol_state = ProtocolState::new();
             match build_state(&manifest_location, &mut protocol_state, file_accessor).await {
                 Ok(_) => {
-                    editor_state.index_protocol(manifest_location, protocol_state);
+                    editor_state
+                        .try_write()?
+                        .index_protocol(manifest_location, protocol_state);
                     let (aggregated_diagnostics, notification) =
-                        editor_state.get_aggregated_diagnostics();
-                    return Ok(LspResponse {
+                        editor_state.try_read()?.get_aggregated_diagnostics();
+                    return Ok(LspNotificationResponse {
                         aggregated_diagnostics,
                         notification,
-                        completion_items: vec![],
                     });
                 }
-                Err(e) => return Ok(LspResponse::error(&e)),
+                Err(e) => return Ok(LspNotificationResponse::error(&e)),
             };
         }
+
+        LspNotification::ManifestSaved(manifest_location) => {
+            // We will rebuild the entire state, without to try any optimizations for now
+            let mut protocol_state = ProtocolState::new();
+            match build_state(&manifest_location, &mut protocol_state, file_accessor).await {
+                Ok(_) => {
+                    editor_state
+                        .try_write()?
+                        .index_protocol(manifest_location, protocol_state);
+                    let (aggregated_diagnostics, notification) =
+                        editor_state.try_read()?.get_aggregated_diagnostics();
+                    return Ok(LspNotificationResponse {
+                        aggregated_diagnostics,
+                        notification,
+                    });
+                }
+                Err(e) => return Ok(LspNotificationResponse::error(&e)),
+            };
+        }
+
         LspNotification::ContractOpened(contract_location) => {
-            // This event can be ignored if the contract is already in the state
+            if !editor_state
+                .try_read()?
+                .active_contracts
+                .contains_key(&contract_location)
+            {
+                let contract_source = match file_accessor {
+                    None => contract_location.read_content_as_utf8(),
+                    Some(file_accessor) => {
+                        file_accessor.read_file(contract_location.to_string()).await
+                    }
+                }?;
+
+                let clarity_version = DEFAULT_CLARITY_VERSION;
+                editor_state.try_write()?.insert_active_contract(
+                    contract_location.clone(),
+                    clarity_version,
+                    contract_source.as_str(),
+                );
+            }
+
             if editor_state
+                .try_read()?
                 .contracts_lookup
                 .contains_key(&contract_location)
             {
-                return Ok(LspResponse::default());
+                return Ok(LspNotificationResponse::default());
             }
 
             let manifest_location = contract_location
@@ -90,47 +175,32 @@ pub async fn process_notification(
             let mut protocol_state = ProtocolState::new();
             match build_state(&manifest_location, &mut protocol_state, file_accessor).await {
                 Ok(_) => {
-                    editor_state.index_protocol(manifest_location, protocol_state);
+                    editor_state
+                        .try_write()?
+                        .index_protocol(manifest_location, protocol_state);
                     let (aggregated_diagnostics, notification) =
-                        editor_state.get_aggregated_diagnostics();
-                    return Ok(LspResponse {
+                        editor_state.try_read()?.get_aggregated_diagnostics();
+                    return Ok(LspNotificationResponse {
                         aggregated_diagnostics,
                         notification,
-                        completion_items: vec![],
                     });
                 }
-                Err(e) => return Ok(LspResponse::error(&e)),
+                Err(e) => return Ok(LspNotificationResponse::error(&e)),
             };
         }
-        LspNotification::ManifestChanged(manifest_location) => {
-            editor_state.clear_protocol(&manifest_location);
 
-            // We will rebuild the entire state, without to try any optimizations for now
-            let mut protocol_state = ProtocolState::new();
-            match build_state(&manifest_location, &mut protocol_state, file_accessor).await {
-                Ok(_) => {
-                    editor_state.index_protocol(manifest_location, protocol_state);
-                    let (aggregated_diagnostics, notification) =
-                        editor_state.get_aggregated_diagnostics();
-                    return Ok(LspResponse {
-                        aggregated_diagnostics,
-                        notification,
-                        completion_items: vec![],
-                    });
+        LspNotification::ContractSaved(contract_location) => {
+            let manifest_location = match editor_state
+                .try_write()?
+                .clear_protocol_associated_with_contract(&contract_location)
+            {
+                Some(manifest_location) => manifest_location,
+                None => {
+                    contract_location
+                        .get_project_manifest_location(file_accessor)
+                        .await?
                 }
-                Err(e) => return Ok(LspResponse::error(&e)),
             };
-        }
-        LspNotification::ContractChanged(contract_location) => {
-            let manifest_location =
-                match editor_state.clear_protocol_associated_with_contract(&contract_location) {
-                    Some(manifest_location) => manifest_location,
-                    None => {
-                        contract_location
-                            .get_project_manifest_location(file_accessor)
-                            .await?
-                    }
-                };
 
             // TODO(lgalabru): introduce partial analysis
             // https://github.com/hirosystems/clarity-lsp/issues/98
@@ -138,26 +208,66 @@ pub async fn process_notification(
             let mut protocol_state = ProtocolState::new();
             match build_state(&manifest_location, &mut protocol_state, file_accessor).await {
                 Ok(_contracts_updates) => {
-                    editor_state.index_protocol(manifest_location, protocol_state);
+                    editor_state
+                        .try_write()?
+                        .index_protocol(manifest_location, protocol_state);
                     let (aggregated_diagnostics, notification) =
-                        editor_state.get_aggregated_diagnostics();
-                    return Ok(LspResponse {
+                        editor_state.try_read()?.get_aggregated_diagnostics();
+                    return Ok(LspNotificationResponse {
                         aggregated_diagnostics,
                         notification,
-                        completion_items: vec![],
                     });
                 }
-                Err(e) => return Ok(LspResponse::error(&e)),
+                Err(e) => return Ok(LspNotificationResponse::error(&e)),
             };
+        }
+
+        LspNotification::ContractChanged(contract_location, contract_source) => {
+            match editor_state
+                .try_write()?
+                .update_contract(&contract_location, &contract_source)
+            {
+                Ok(result) => {
+                    let aggregated_diagnostics = match result.diagnostic {
+                        Some(diagnostic) => vec![(contract_location, vec![diagnostic])],
+                        None => vec![],
+                    };
+                    return Ok(LspNotificationResponse {
+                        aggregated_diagnostics,
+                        notification: None,
+                    });
+                }
+                Err(err) => Ok(LspNotificationResponse::error(&err)),
+            }
+        }
+
+        LspNotification::ContractClosed(contract_location) => {
+            editor_state
+                .try_write()?
+                .active_contracts
+                .remove(&contract_location);
+            Ok(LspNotificationResponse::default())
         }
     }
 }
 
-pub fn process_request(command: LspRequest, editor_state: &EditorState) -> LspResponse {
+#[derive(Debug, Serialize, Deserialize)]
+pub enum LspRequest {
+    GetIntellisense(FileLocation),
+}
+
+#[derive(Debug, PartialEq, Deserialize, Serialize)]
+pub struct LspRequestResponse {
+    pub completion_items: Vec<CompletionItem>,
+}
+
+pub fn process_request(command: LspRequest, editor_state: &EditorStateInput) -> LspRequestResponse {
     match command {
         LspRequest::GetIntellisense(contract_location) => {
-            let mut completion_items_src =
-                editor_state.get_completion_items_for_contract(&contract_location);
+            let mut completion_items_src = editor_state
+                .try_read()
+                .unwrap()
+                .get_completion_items_for_contract(&contract_location);
             let mut completion_items = vec![];
             // Little big detail: should we wrap the inserted_text with braces?
             let should_wrap = {
@@ -187,11 +297,7 @@ pub fn process_request(command: LspRequest, editor_state: &EditorState) -> LspRe
                 }
             }
 
-            LspResponse {
-                aggregated_diagnostics: vec![],
-                notification: None,
-                completion_items,
-            }
+            LspRequestResponse { completion_items }
         }
     }
 }

--- a/components/clarity-lsp/src/common/backend.rs
+++ b/components/clarity-lsp/src/common/backend.rs
@@ -188,8 +188,7 @@ pub async fn process_notification(
                 }
             };
 
-            // TODO(lgalabru): introduce partial analysis
-            // https://github.com/hirosystems/clarity-lsp/issues/98
+            // TODO(lgalabru): introduce partial analysis #604
             // We will rebuild the entire state, without trying any optimizations for now
             let mut protocol_state = ProtocolState::new();
             match build_state(&manifest_location, &mut protocol_state, file_accessor).await {
@@ -212,15 +211,12 @@ pub async fn process_notification(
             match editor_state
                 .try_write(|es| es.update_contract(&contract_location, &contract_source))?
             {
-                Ok(result) => {
-                    let aggregated_diagnostics = match result.diagnostic {
-                        Some(diagnostic) => vec![(contract_location, vec![diagnostic])],
-                        None => vec![],
-                    };
-                    return Ok(LspNotificationResponse {
-                        aggregated_diagnostics,
-                        notification: None,
-                    });
+                Ok(_result) => {
+                    // In case the source can not be parsed, the diagnostic could be sent but it would
+                    // remove the other diagnostic errors (types, check-checker, etc).
+                    // Let's address it as part of #604
+                    // let aggregated_diagnostics = vec![(contract_location, vec![diagnostic.unwrap()])],
+                    return Ok(LspNotificationResponse::default());
                 }
                 Err(err) => Ok(LspNotificationResponse::error(&err)),
             }

--- a/components/clarity-lsp/src/common/state.rs
+++ b/components/clarity-lsp/src/common/state.rs
@@ -21,13 +21,13 @@ use std::borrow::BorrowMut;
 use std::collections::{HashMap, HashSet};
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct ActiveContractState {
+pub struct ActiveContractData {
     pub clarity_version: ClarityVersion,
     pub expressions: Option<Vec<SymbolicExpression>>,
     pub diagnostic: Option<ClarityDiagnostic>,
 }
 
-impl ActiveContractState {
+impl ActiveContractData {
     pub fn new(clarity_version: ClarityVersion, source: &str) -> Self {
         match build_ast(
             &QualifiedContractIdentifier::transient(),
@@ -36,12 +36,12 @@ impl ActiveContractState {
             clarity_version,
             StacksEpochId::Epoch21,
         ) {
-            Ok(ast) => ActiveContractState {
+            Ok(ast) => ActiveContractData {
                 clarity_version,
                 expressions: Some(ast.expressions),
                 diagnostic: None,
             },
-            Err(err) => ActiveContractState {
+            Err(err) => ActiveContractData {
                 clarity_version,
                 expressions: None,
                 diagnostic: Some(err.diagnostic),
@@ -135,7 +135,7 @@ pub struct ContractMetadata {
 pub struct EditorState {
     pub protocols: HashMap<FileLocation, ProtocolState>,
     pub contracts_lookup: HashMap<FileLocation, ContractMetadata>,
-    pub active_contracts: HashMap<FileLocation, ActiveContractState>,
+    pub active_contracts: HashMap<FileLocation, ActiveContractData>,
     pub native_functions: Vec<CompletionItem>,
 }
 
@@ -300,7 +300,7 @@ impl EditorState {
         clarity_version: ClarityVersion,
         source: &str,
     ) {
-        let contract = ActiveContractState::new(clarity_version, source);
+        let contract = ActiveContractData::new(clarity_version, source);
         self.active_contracts.insert(contract_location, contract);
     }
 
@@ -308,7 +308,7 @@ impl EditorState {
         &mut self,
         contract_location: &FileLocation,
         source: &str,
-    ) -> Result<ActiveContractState, String> {
+    ) -> Result<ActiveContractData, String> {
         let contract_state = self
             .active_contracts
             .get_mut(contract_location)

--- a/components/clarity-lsp/src/common/state.rs
+++ b/components/clarity-lsp/src/common/state.rs
@@ -23,26 +23,29 @@ use std::collections::{HashMap, HashSet};
 #[derive(Debug, Clone, PartialEq)]
 pub struct ActiveContractData {
     pub clarity_version: ClarityVersion,
+    pub epoch: StacksEpochId,
     pub expressions: Option<Vec<SymbolicExpression>>,
     pub diagnostic: Option<ClarityDiagnostic>,
 }
 
 impl ActiveContractData {
-    pub fn new(clarity_version: ClarityVersion, source: &str) -> Self {
+    pub fn new(clarity_version: ClarityVersion, epoch: StacksEpochId, source: &str) -> Self {
         match build_ast(
             &QualifiedContractIdentifier::transient(),
             source,
             &mut (),
             clarity_version,
-            StacksEpochId::Epoch21,
+            epoch,
         ) {
             Ok(ast) => ActiveContractData {
                 clarity_version,
+                epoch,
                 expressions: Some(ast.expressions),
                 diagnostic: None,
             },
             Err(err) => ActiveContractData {
                 clarity_version,
+                epoch,
                 expressions: None,
                 diagnostic: Some(err.diagnostic),
             },
@@ -55,7 +58,7 @@ impl ActiveContractData {
             source,
             &mut (),
             self.clarity_version,
-            StacksEpochId::Epoch21,
+            self.epoch,
         ) {
             Ok(ast) => {
                 self.expressions = Some(ast.expressions);
@@ -298,9 +301,10 @@ impl EditorState {
         &mut self,
         contract_location: FileLocation,
         clarity_version: ClarityVersion,
+        epoch: StacksEpochId,
         source: &str,
     ) {
-        let contract = ActiveContractData::new(clarity_version, source);
+        let contract = ActiveContractData::new(clarity_version, epoch, source);
         self.active_contracts.insert(contract_location, contract);
     }
 

--- a/components/clarity-lsp/src/vscode_bridge.rs
+++ b/components/clarity-lsp/src/vscode_bridge.rs
@@ -80,12 +80,13 @@ impl LspVscodeBridge {
                     return Promise::reject(&JsValue::from_str("Unsupported file opened"));
                 };
 
-                let editor_state = self.editor_state.clone();
+                let mut editor_state = self.editor_state.clone();
                 let send_diagnostic = self.client_diagnostic_tx.clone();
 
                 return future_to_promise(async move {
                     let mut result =
-                        process_notification(command, &editor_state, Some(&file_accessor)).await;
+                        process_notification(command, &mut editor_state, Some(&file_accessor))
+                            .await;
 
                     let mut aggregated_diagnostics = vec![];
 
@@ -125,12 +126,13 @@ impl LspVscodeBridge {
                     return Promise::reject(&JsValue::from_str("Unsupported file opened"));
                 };
 
-                let editor_state = self.editor_state.clone();
+                let mut editor_state = self.editor_state.clone();
                 let send_diagnostic = self.client_diagnostic_tx.clone();
 
                 return future_to_promise(async move {
                     let mut result =
-                        process_notification(command, &editor_state, Some(&file_accessor)).await;
+                        process_notification(command, &mut editor_state, Some(&file_accessor))
+                            .await;
 
                     let mut aggregated_diagnostics = vec![];
 
@@ -173,12 +175,13 @@ impl LspVscodeBridge {
                     return Promise::resolve(&JsValue::NULL);
                 };
 
-                let editor_state = self.editor_state.clone();
+                let mut editor_state = self.editor_state.clone();
                 let send_diagnostic = self.client_diagnostic_tx.clone();
 
                 return future_to_promise(async move {
                     let result =
-                        process_notification(command, &editor_state, Some(&file_accessor)).await?;
+                        process_notification(command, &mut editor_state, Some(&file_accessor))
+                            .await?;
 
                     if let Some((location, diagnostic)) = result.aggregated_diagnostics.get(0) {
                         if let Ok(uri) = Url::parse(&location.to_string()) {
@@ -212,10 +215,10 @@ impl LspVscodeBridge {
                     return Promise::resolve(&JsValue::NULL);
                 };
 
-                let editor_state = self.editor_state.clone();
+                let mut editor_state = self.editor_state.clone();
 
                 return future_to_promise(async move {
-                    process_notification(command, &editor_state, Some(&file_accessor)).await?;
+                    process_notification(command, &mut editor_state, Some(&file_accessor)).await?;
                     Ok(JsValue::TRUE)
                 });
             }

--- a/components/clarity-lsp/src/vscode_bridge.rs
+++ b/components/clarity-lsp/src/vscode_bridge.rs
@@ -1,5 +1,7 @@
 extern crate console_error_panic_hook;
-use crate::backend::{process_notification, process_request, LspNotification, LspRequest};
+use crate::backend::{
+    process_notification, process_request, EditorStateInput, LspNotification, LspRequest,
+};
 use crate::state::EditorState;
 use crate::utils::{
     clarity_diagnostics_to_lsp_type, get_contract_location, get_manifest_location, log,
@@ -7,25 +9,27 @@ use crate::utils::{
 use clarinet_files::{FileAccessor, WASMFileSystemAccessor};
 use js_sys::{Function as JsFunction, Promise};
 use lsp_types::notification::{
-    DidOpenTextDocument, DidSaveTextDocument, Initialized, Notification,
+    DidChangeTextDocument, DidCloseTextDocument, DidOpenTextDocument, DidSaveTextDocument,
+    Initialized, Notification,
 };
 use lsp_types::{
     request::{Completion, Request},
-    CompletionParams, DidOpenTextDocumentParams, DidSaveTextDocumentParams,
-    PublishDiagnosticsParams, Url,
+    CompletionParams, DidChangeTextDocumentParams, DidCloseTextDocumentParams,
+    DidOpenTextDocumentParams, DidSaveTextDocumentParams, PublishDiagnosticsParams, Url,
 };
 use serde_wasm_bindgen::{from_value as decode_from_js, to_value as encode_to_js};
 use std::panic;
 use std::sync::{Arc, RwLock};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::future_to_promise;
+use web_sys::console;
 
 #[wasm_bindgen]
 pub struct LspVscodeBridge {
-    editor_state_lock: Arc<RwLock<EditorState>>,
     client_diagnostic_tx: JsFunction,
     _client_notification_tx: JsFunction,
     backend_to_client_tx: JsFunction,
+    editor_state: EditorStateInput,
 }
 
 #[wasm_bindgen]
@@ -38,12 +42,14 @@ impl LspVscodeBridge {
     ) -> LspVscodeBridge {
         panic::set_hook(Box::new(console_error_panic_hook::hook));
 
-        let editor_state_lock = Arc::new(RwLock::new(EditorState::new()));
         LspVscodeBridge {
-            editor_state_lock,
             client_diagnostic_tx,
             _client_notification_tx,
             backend_to_client_tx,
+            editor_state: EditorStateInput::new(
+                None,
+                Some(Arc::new(RwLock::new(EditorState::new()))),
+            ),
         }
     }
 
@@ -64,26 +70,22 @@ impl LspVscodeBridge {
                     Err(err) => return Promise::reject(&JsValue::from(format!("error: {}", err))),
                 };
                 let uri = params.text_document.uri;
+                log!("> opened uri: {:}", &uri.path());
 
                 let command = if let Some(contract_location) = get_contract_location(&uri) {
-                    LspNotification::ContractOpened(contract_location)
+                    LspNotification::ContractOpened(contract_location.clone())
                 } else if let Some(manifest_location) = get_manifest_location(&uri) {
                     LspNotification::ManifestOpened(manifest_location)
                 } else {
                     return Promise::reject(&JsValue::from_str("Unsupported file opened"));
                 };
 
-                let editor_state_lock = self.editor_state_lock.clone();
+                let editor_state = self.editor_state.clone();
                 let send_diagnostic = self.client_diagnostic_tx.clone();
 
                 return future_to_promise(async move {
-                    let mut result = match editor_state_lock.try_write() {
-                        Ok(mut editor_state) => {
-                            process_notification(command, &mut editor_state, Some(&file_accessor))
-                                .await
-                        }
-                        Err(_) => return Err(JsValue::from("unable to lock editor_state")),
-                    };
+                    let mut result =
+                        process_notification(command, &editor_state, Some(&file_accessor)).await;
 
                     let mut aggregated_diagnostics = vec![];
 
@@ -113,26 +115,22 @@ impl LspVscodeBridge {
                     Err(err) => return Promise::reject(&JsValue::from(format!("error: {}", err))),
                 };
                 let uri = &params.text_document.uri;
+                log!("> saved uri: {:}", &uri.path());
 
                 let command = if let Some(contract_location) = get_contract_location(uri) {
-                    LspNotification::ContractChanged(contract_location)
+                    LspNotification::ContractSaved(contract_location)
                 } else if let Some(manifest_location) = get_manifest_location(uri) {
-                    LspNotification::ManifestChanged(manifest_location)
+                    LspNotification::ManifestSaved(manifest_location)
                 } else {
                     return Promise::reject(&JsValue::from_str("Unsupported file opened"));
                 };
 
-                let editor_state_lock = self.editor_state_lock.clone();
+                let editor_state = self.editor_state.clone();
                 let send_diagnostic = self.client_diagnostic_tx.clone();
 
                 return future_to_promise(async move {
-                    let mut result = match editor_state_lock.try_write() {
-                        Ok(mut editor_state) => {
-                            process_notification(command, &mut editor_state, Some(&file_accessor))
-                                .await
-                        }
-                        Err(_) => return Err(JsValue::from("unable to lock editor_state")),
-                    };
+                    let mut result =
+                        process_notification(command, &editor_state, Some(&file_accessor)).await;
 
                     let mut aggregated_diagnostics = vec![];
 
@@ -142,19 +140,86 @@ impl LspVscodeBridge {
 
                     for (location, mut diags) in aggregated_diagnostics.into_iter() {
                         if let Ok(uri) = Url::parse(&location.to_string()) {
-                            let value = PublishDiagnosticsParams {
-                                uri,
-                                diagnostics: clarity_diagnostics_to_lsp_type(&mut diags),
-                                version: None,
-                            };
-
-                            send_diagnostic.call1(&JsValue::NULL, &encode_to_js(&value)?)?;
+                            send_diagnostic.call1(
+                                &JsValue::NULL,
+                                &encode_to_js(&PublishDiagnosticsParams {
+                                    uri,
+                                    diagnostics: clarity_diagnostics_to_lsp_type(&mut diags),
+                                    version: None,
+                                })?,
+                            )?;
                         }
                     }
 
                     Ok(JsValue::TRUE)
                 });
             }
+
+            DidChangeTextDocument::METHOD => {
+                console::time_with_label("handle_did_change");
+                let params: DidChangeTextDocumentParams = match decode_from_js(js_params) {
+                    Ok(params) => params,
+                    Err(err) => return Promise::reject(&JsValue::from(format!("error: {}", err))),
+                };
+                let uri = &params.text_document.uri;
+                log!("> changed uri: {:}", &uri.path());
+
+                let command = if let Some(contract_location) = get_contract_location(uri) {
+                    LspNotification::ContractChanged(
+                        contract_location,
+                        params.content_changes[0].text.to_string(),
+                    )
+                } else {
+                    return Promise::resolve(&JsValue::NULL);
+                };
+
+                let editor_state = self.editor_state.clone();
+                let send_diagnostic = self.client_diagnostic_tx.clone();
+
+                return future_to_promise(async move {
+                    let result =
+                        process_notification(command, &editor_state, Some(&file_accessor)).await?;
+
+                    if let Some((location, diagnostic)) = result.aggregated_diagnostics.get(0) {
+                        if let Ok(uri) = Url::parse(&location.to_string()) {
+                            send_diagnostic.call1(
+                                &JsValue::NULL,
+                                &encode_to_js(&PublishDiagnosticsParams {
+                                    uri,
+                                    diagnostics: clarity_diagnostics_to_lsp_type(diagnostic),
+                                    version: None,
+                                })?,
+                            )?;
+                        }
+                    }
+
+                    console::time_end_with_label("handle_did_change");
+                    Ok(JsValue::TRUE)
+                });
+            }
+
+            DidCloseTextDocument::METHOD => {
+                let params: DidCloseTextDocumentParams = match decode_from_js(js_params) {
+                    Ok(params) => params,
+                    Err(err) => return Promise::reject(&JsValue::from(format!("error: {}", err))),
+                };
+                let uri = &params.text_document.uri;
+                log!("> closed uri: {:}", &uri.path());
+
+                let command = if let Some(contract_location) = get_contract_location(uri) {
+                    LspNotification::ContractClosed(contract_location)
+                } else {
+                    return Promise::resolve(&JsValue::NULL);
+                };
+
+                let editor_state = self.editor_state.clone();
+
+                return future_to_promise(async move {
+                    process_notification(command, &editor_state, Some(&file_accessor)).await?;
+                    Ok(JsValue::TRUE)
+                });
+            }
+
             _ => {
                 #[cfg(debug_assertions)]
                 log!("unexpected notification ({})", method);
@@ -172,14 +237,11 @@ impl LspVscodeBridge {
                 let file_url = params.text_document_position.text_document.uri;
                 let location = get_contract_location(&file_url).ok_or(JsValue::NULL)?;
                 let command = LspRequest::GetIntellisense(location);
-                let editor_state = self
-                    .editor_state_lock
-                    .try_read()
-                    .map_err(|_| JsValue::NULL)?;
-                let lsp_response = process_request(command, &editor_state);
+                let lsp_response = process_request(command, &self.editor_state);
 
                 return encode_to_js(&lsp_response.completion_items).map_err(|_| JsValue::NULL);
             }
+
             _ => {
                 #[cfg(debug_assertions)]
                 log!("unexpected request ({})", method);

--- a/components/clarity-vscode/client/src/common.ts
+++ b/components/clarity-vscode/client/src/common.ts
@@ -21,10 +21,22 @@ export const clientOpts: LanguageClientOptions = {
   ),
 };
 
+declare const __DEV_MODE__: boolean | undefined;
+
 export async function initClient(
   context: ExtensionContext,
   client: LanguageClient,
 ) {
+  if (__DEV_MODE__) {
+    // update vscode default config in dev
+    if (workspace.getConfiguration("files").autoSave !== "off") {
+      vscode.commands.executeCommand("workbench.action.toggleAutoSave");
+    }
+    if (window.activeColorTheme.kind !== 2) {
+      vscode.commands.executeCommand("workbench.action.toggleLightDarkThemes");
+    }
+  }
+
   let config = workspace.getConfiguration("clarity-lsp");
 
   /* clarity insight webview */

--- a/components/clarity-vscode/package.json
+++ b/components/clarity-vscode/package.json
@@ -24,7 +24,7 @@
     "test": "node client/dist/tests/runTests.js",
     "lint": "eslint ./client/src ./server/src --ext .ts,.tsx",
     "dev:watch": "webpack -c ./webpack.config.dev.js -w",
-    "dev:browser": "vscode-test-web --extensionDevelopmentPath=. ./test-data --open-devtools --browser=chromium",
+    "dev:browser": "vscode-test-web --extensionDevelopmentPath=. ./test-data --open-devtools",
     "dev": "webpack -c ./webpack.config.dev.js; concurrently \"npm:dev:*\"",
     "vscode:prepublish": "npm run clean; NODE_ENV=production webpack",
     "vsce:package": "vsce package",

--- a/components/clarity-vscode/server/src/common.ts
+++ b/components/clarity-vscode/server/src/common.ts
@@ -11,7 +11,7 @@ import {
 import type { ServerCapabilities, Connection } from "vscode-languageserver";
 
 // this type is the same for the browser and node but node isn't alwasy built in dev
-import type { LspVscodeBridge } from "./clarity-lsp-browser";
+import type { LspVscodeBridge } from "./clarity-lsp-browser/lsp-browser";
 
 const VALID_PROTOCOLS = ["file", "vscode-vfs", "vscode-test-web"];
 

--- a/components/clarity-vscode/server/src/common.ts
+++ b/components/clarity-vscode/server/src/common.ts
@@ -22,7 +22,7 @@ export function initConnection(
   connection.onInitialize(() => {
     const capabilities: ServerCapabilities = {
       textDocumentSync: {
-        change: TextDocumentSyncKind.None,
+        change: TextDocumentSyncKind.Full,
         willSave: false,
         openClose: true,
         save: { includeText: false },

--- a/components/clarity-vscode/server/src/common.ts
+++ b/components/clarity-vscode/server/src/common.ts
@@ -1,14 +1,11 @@
 import {
-  TextDocumentSyncKind,
   CompletionRequest,
-  MarkupKind,
-  InsertTextFormat,
   DidOpenTextDocumentParams,
   DidCloseTextDocumentNotification,
   DidOpenTextDocumentNotification,
-  CompletionItemKind,
+  InitializeRequest,
 } from "vscode-languageserver";
-import type { ServerCapabilities, Connection } from "vscode-languageserver";
+import type { Connection } from "vscode-languageserver";
 
 // this type is the same for the browser and node but node isn't alwasy built in dev
 import type { LspVscodeBridge } from "./clarity-lsp-browser/lsp-browser";
@@ -19,18 +16,9 @@ export function initConnection(
   connection: Connection,
   bridge: LspVscodeBridge,
 ) {
-  connection.onInitialize(() => {
-    const capabilities: ServerCapabilities = {
-      textDocumentSync: {
-        change: TextDocumentSyncKind.Full,
-        willSave: false,
-        openClose: true,
-        save: { includeText: false },
-      },
-      completionProvider: {},
-    };
-    return { capabilities };
-  });
+  connection.onInitialize(async (params) =>
+    bridge.onRequest(InitializeRequest.method, params),
+  );
 
   const notifications: [string, unknown][] = [];
   async function consumeNotification() {
@@ -49,16 +37,14 @@ export function initConnection(
     // vscode.dev sends didOpen notification twice
     // including a notification with a read only github:// url
     // instead of vscode-vfs://
-    if (method === DidOpenTextDocumentNotification.method) {
+    if (
+      method === DidOpenTextDocumentNotification.method ||
+      method === DidCloseTextDocumentNotification.method
+    ) {
       const [protocol] = (
         params as DidOpenTextDocumentParams
       ).textDocument.uri.split("://");
-
       if (!VALID_PROTOCOLS.includes(protocol)) return;
-    } else if (method === DidCloseTextDocumentNotification.method) {
-      // ignore didClose notifications
-      // it fires twice as well for nothing
-      return;
     }
 
     notifications.push([method, params]);
@@ -74,24 +60,7 @@ export function initConnection(
     // in the (occasional) event of a completion request happening while the server has
     // notifications to handle, let's ignore the completion request
     if (notifications.length > 0) return null;
-    const res = await bridge.onRequest(CompletionRequest.method, params);
-    if (!res) return null;
-    return res.map((item: Record<string, any>) => {
-      return {
-        ...item,
-        insertText: item.insert_text,
-        insertTextFormat:
-          item.insert_text_format === "PlainText"
-            ? InsertTextFormat.PlainText
-            : InsertTextFormat.Snippet,
-        // @ts-ignore
-        kind: CompletionItemKind[item.kind],
-        documentation: {
-          kind: MarkupKind.Markdown,
-          value: item.markdown_documentation,
-        },
-      };
-    });
+    return bridge.onRequest(CompletionRequest.method, params);
   });
 
   connection.listen();

--- a/components/clarity-vscode/web-extension.code-workspace
+++ b/components/clarity-vscode/web-extension.code-workspace
@@ -8,9 +8,15 @@
     }
   ],
   "settings": {
-    "typescript.tsc.autoDetect": "off",
-    "rust-analyzer.cargo.features": ["clarity-lsp/wasm", "clarity/wasm"],
     "rust-analyzer.cargo.noDefaultFeatures": true,
-    "rust-analyzer.debug.openDebugPane": true
+    "rust-analyzer.cargo.features": ["clarity-lsp/wasm"],
+    "rust-analyzer.checkOnSave.overrideCommand": [
+      "cargo",
+      "check",
+      "--no-default-features",
+      "--package=clarity-lsp",
+      "--features=wasm",
+      "--message-format=json"
+    ]
   }
 }

--- a/components/clarity-vscode/webpack.config.dev.js
+++ b/components/clarity-vscode/webpack.config.dev.js
@@ -13,6 +13,12 @@ const [clientBrowserConfig, serverBrowserConfig] = configs;
 
 const extensionURL = "http://localhost:3000/static/devextensions/";
 
+clientBrowserConfig.plugins = [
+  new webpack.DefinePlugin({
+    __DEV_MODE__: JSON.stringify(true),
+  }),
+];
+
 serverBrowserConfig.plugins = [
   new webpack.DefinePlugin({
     __EXTENSION_URL__: JSON.stringify(extensionURL),

--- a/components/clarity-vscode/webpack.config.js
+++ b/components/clarity-vscode/webpack.config.js
@@ -51,6 +51,11 @@ const clientBrowserConfig = {
   },
   output: browserOutput,
   resolve: browserResolve,
+  plugins: [
+    new webpack.DefinePlugin({
+      __DEV_MODE__: JSON.stringify(false),
+    }),
+  ],
   module: { rules: [swcLoader] },
   externals: { vscode: "commonjs vscode" },
 };
@@ -64,6 +69,11 @@ const clientNodeConfig = {
   entry: { clientNode: "./src/clientNode.ts" },
   output: browserOutput,
   resolve: browserResolve,
+  plugins: [
+    new webpack.DefinePlugin({
+      __DEV_MODE__: JSON.stringify(false),
+    }),
+  ],
   module: { rules: [swcLoader] },
   externals: { vscode: "commonjs vscode" },
 };


### PR DESCRIPTION
Resolves: #630

This PR does not introduce reals changes for Clarity developers, instead it prepares the LSP for #610 and #626 by keeping track of the state of the files being modified (but not saved).

It'll bring nice addition better performances and more reliability by having the editor_state being locked for smaller period of times and less often (thanks @lgalabru for the help on that) with the introduction of
```rust
pub struct EditorStateInput {
    editor_state: Option<EditorState>,
    editor_state_lock: Option<Arc<RwLock<EditorState>>>,
}
```

~Since the AST is now computed every time a contract is changed, I was able to display diagnostic errors for invalid AST in real time~ I removed it because it overrides other diagnostics (warning and type errors). Will spend more time on that

