### PR TITLE
feat: chainhook-node replay mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,6 +386,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf9ff0bbfd639f15c74af777d81383cf53efb7c93613f6cab67c6c11e05bbf8b"
 
 [[package]]
+name = "bech32"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
+
+[[package]]
 name = "better_scoped_tls"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -416,7 +422,7 @@ version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a41df6ad9642c5c15ae312dd3d074de38fd3eb7cc87ad4ce10f90292a83fe4d"
 dependencies = [
- "bech32",
+ "bech32 0.8.1",
  "bitcoin_hashes 0.10.0",
  "secp256k1 0.20.3",
  "serde",
@@ -428,9 +434,21 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05bba324e6baf655b882df672453dbbc527bc938cadd27750ae510aaccc3a66a"
 dependencies = [
- "bech32",
+ "bech32 0.8.1",
  "bitcoin_hashes 0.10.0",
  "secp256k1 0.22.1",
+]
+
+[[package]]
+name = "bitcoin"
+version = "0.29.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0694ea59225b0c5f3cb405ff3f670e4828358ed26aec49dc352f730f0cb1a8a3"
+dependencies = [
+ "bech32 0.9.1",
+ "bitcoin_hashes 0.11.0",
+ "secp256k1 0.24.1",
+ "serde",
 ]
 
 [[package]]
@@ -449,12 +467,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitcoin_hashes"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90064b8dee6815a6470d60bad07bbbaee885c0e12d04177138fa3291a01b7bc4"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitcoincore-rpc"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b8d99d58466295cb2bf72c6959b784d59f8f0d6977458d2ba3eb75c834f36c3"
 dependencies = [
- "bitcoincore-rpc-json",
+ "bitcoincore-rpc-json 0.14.0",
+ "jsonrpc",
+ "log",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "bitcoincore-rpc"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0261b2bb7617e0c91b452a837bbd1291fd34ad6990cb8e3ffc28239cc045b5ca"
+dependencies = [
+ "bitcoincore-rpc-json 0.16.0",
  "jsonrpc",
  "log",
  "serde",
@@ -468,6 +508,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dce91de73c61f5776cf938bfa88378c5b404a70e3369b761dacbe6024fea79dd"
 dependencies = [
  "bitcoin 0.27.1",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "bitcoincore-rpc-json"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c231bea28e314879c5aef240f6052e8a72a369e3c9f9b20d9bfbb33ad18029b2"
+dependencies = [
+ "bitcoin 0.29.2",
  "serde",
  "serde_json",
 ]
@@ -718,8 +769,8 @@ version = "1.0.0"
 dependencies = [
  "base58 0.2.0",
  "base64 0.13.0",
- "bitcoincore-rpc",
- "bitcoincore-rpc-json",
+ "bitcoincore-rpc 0.16.0",
+ "bitcoincore-rpc-json 0.16.0",
  "chainhook-types",
  "clap 3.2.23",
  "clap_generate",
@@ -748,6 +799,8 @@ version = "0.1.0"
 dependencies = [
  "ansi_term",
  "atty",
+ "bitcoincore-rpc 0.16.0",
+ "bitcoincore-rpc-json 0.16.0",
  "chainhook-event-observer",
  "chainhook-types",
  "clap 3.2.23",
@@ -764,6 +817,7 @@ dependencies = [
  "num_cpus",
  "redis",
  "reqwest",
+ "sentry",
  "serde",
  "serde-redis",
  "serde_derive",
@@ -805,6 +859,12 @@ dependencies = [
  "wasm-bindgen",
  "winapi",
 ]
+
+[[package]]
+name = "chunked_transfer"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fff857943da45f546682664a79488be82e69e43c1a7a2307679ab9afb3a66d2e"
 
 [[package]]
 name = "cipher"
@@ -1015,8 +1075,8 @@ version = "1.0.0"
 dependencies = [
  "base58 0.2.0",
  "bitcoin 0.28.1",
- "bitcoincore-rpc",
- "bitcoincore-rpc-json",
+ "bitcoincore-rpc 0.14.0",
+ "bitcoincore-rpc-json 0.14.0",
  "chainhook-types",
  "clarinet-files",
  "clarinet-utils",
@@ -1640,6 +1700,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a032eac705ca39214d169f83e3d3da290af06d8d1d344d1baad2fd002dca4b3"
 dependencies = [
  "unreachable",
+]
+
+[[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "serde",
+ "uuid 1.0.0",
 ]
 
 [[package]]
@@ -2293,6 +2363,15 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "erased-serde"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54558e0ba96fbe24280072642eceb9d7d442e32c7ec0ea9e7ecd7b4ea2cf4e11"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -4105,6 +4184,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_info"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4750134fb6a5d49afc80777394ad5d95b04bc12068c6abb92fae8f43817270f"
+dependencies = [
+ "log",
+ "serde",
+ "winapi",
+]
+
+[[package]]
 name = "os_pipe"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5480,6 +5570,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "secp256k1"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff55dc09d460954e9ef2fa8a7ced735a964be9981fd50e870b2b3b0705e14964"
+dependencies = [
+ "bitcoin_hashes 0.11.0",
+ "secp256k1-sys 0.6.1",
+ "serde",
+]
+
+[[package]]
 name = "secp256k1-sys"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5493,6 +5594,15 @@ name = "secp256k1-sys"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "152e20a0fd0519390fc43ab404663af8a0b794273d2a91d60ad4a39f13ffe110"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83080e2c2fc1006e625be82e5d1eb6a43b7fd9578b617fcc55814daf286bba4b"
 dependencies = [
  "cc",
 ]
@@ -5571,6 +5681,102 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
 dependencies = [
  "pest",
+]
+
+[[package]]
+name = "sentry"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a120fb5e8b7975736bf1fc57de380531e617a6a8f5a55d037bcea25a7f5e8371"
+dependencies = [
+ "httpdate",
+ "native-tls",
+ "reqwest",
+ "sentry-backtrace",
+ "sentry-contexts",
+ "sentry-core",
+ "sentry-panic",
+ "sentry-slog",
+ "tokio",
+ "ureq",
+]
+
+[[package]]
+name = "sentry-backtrace"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ac56ff9aae25b024a5aad4f0242808dfde29161c82d183adce778338c6822ef"
+dependencies = [
+ "backtrace",
+ "once_cell",
+ "regex",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-contexts"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "188506b08b5e64004c71b7a5edb34959083e6e1288fada3b8d18d0bc7449ce1e"
+dependencies = [
+ "hostname",
+ "libc",
+ "os_info",
+ "rustc_version 0.4.0",
+ "sentry-core",
+ "uname",
+]
+
+[[package]]
+name = "sentry-core"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff58433a7ad557b586a09c42c4298d5f3ddb0c777e1a79d950e510d7b93fce0e"
+dependencies = [
+ "once_cell",
+ "rand 0.8.5",
+ "sentry-types",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "sentry-panic"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4145005d9b5c117132765c34e2cb33e9d24d16e73d7f3a357122b77fe3a3b815"
+dependencies = [
+ "sentry-backtrace",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-slog"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ff3bd6de956e114bdbcc5df560c7351bd7fac497da8cf631468d9946d9587fa"
+dependencies = [
+ "sentry-core",
+ "serde_json",
+ "slog",
+]
+
+[[package]]
+name = "sentry-types"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb30d75498a041005a774ec1b6b7d9589c5906d17ebaca338cb685dc92170f9b"
+dependencies = [
+ "chrono",
+ "debugid",
+ "getrandom 0.2.7",
+ "hex 0.4.3",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "time 0.3.14",
+ "url",
+ "uuid 1.0.0",
 ]
 
 [[package]]
@@ -5944,6 +6150,9 @@ name = "slog"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8347046d4ebd943127157b94d63abb990fcf729dc4e9978927fdf4ac3c998d06"
+dependencies = [
+ "erased-serde",
+]
 
 [[package]]
 name = "slog-async"
@@ -6128,7 +6337,7 @@ version = "0.1.0"
 dependencies = [
  "base58 0.2.0",
  "bitcoin 0.28.1",
- "bitcoincore-rpc",
+ "bitcoincore-rpc 0.14.0",
  "bollard",
  "chainhook-event-observer",
  "chainhook-types",
@@ -7384,6 +7593,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
 
 [[package]]
+name = "uname"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b72f89f0ca32e4db1c04e2a72f5345d59796d4866a1ee0609084569f73683dc8"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "uncased"
 version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7518,6 +7736,20 @@ name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "ureq"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97acb4c28a254fd7a4aeec976c46a7fa404eac4d7c134b30c75144846d7cb8f"
+dependencies = [
+ "base64 0.13.0",
+ "chunked_transfer",
+ "log",
+ "native-tls",
+ "once_cell",
+ "url",
+]
 
 [[package]]
 name = "url"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -817,7 +817,6 @@ dependencies = [
  "num_cpus",
  "redis",
  "reqwest",
- "sentry",
  "serde",
  "serde-redis",
  "serde_derive",
@@ -859,12 +858,6 @@ dependencies = [
  "wasm-bindgen",
  "winapi",
 ]
-
-[[package]]
-name = "chunked_transfer"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fff857943da45f546682664a79488be82e69e43c1a7a2307679ab9afb3a66d2e"
 
 [[package]]
 name = "cipher"
@@ -1703,16 +1696,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "debugid"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
-dependencies = [
- "serde",
- "uuid 1.0.0",
-]
-
-[[package]]
 name = "deno_ast"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2363,15 +2346,6 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
-]
-
-[[package]]
-name = "erased-serde"
-version = "0.3.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54558e0ba96fbe24280072642eceb9d7d442e32c7ec0ea9e7ecd7b4ea2cf4e11"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -4184,17 +4158,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "os_info"
-version = "3.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4750134fb6a5d49afc80777394ad5d95b04bc12068c6abb92fae8f43817270f"
-dependencies = [
- "log",
- "serde",
- "winapi",
-]
-
-[[package]]
 name = "os_pipe"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5684,102 +5647,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sentry"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a120fb5e8b7975736bf1fc57de380531e617a6a8f5a55d037bcea25a7f5e8371"
-dependencies = [
- "httpdate",
- "native-tls",
- "reqwest",
- "sentry-backtrace",
- "sentry-contexts",
- "sentry-core",
- "sentry-panic",
- "sentry-slog",
- "tokio",
- "ureq",
-]
-
-[[package]]
-name = "sentry-backtrace"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ac56ff9aae25b024a5aad4f0242808dfde29161c82d183adce778338c6822ef"
-dependencies = [
- "backtrace",
- "once_cell",
- "regex",
- "sentry-core",
-]
-
-[[package]]
-name = "sentry-contexts"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "188506b08b5e64004c71b7a5edb34959083e6e1288fada3b8d18d0bc7449ce1e"
-dependencies = [
- "hostname",
- "libc",
- "os_info",
- "rustc_version 0.4.0",
- "sentry-core",
- "uname",
-]
-
-[[package]]
-name = "sentry-core"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff58433a7ad557b586a09c42c4298d5f3ddb0c777e1a79d950e510d7b93fce0e"
-dependencies = [
- "once_cell",
- "rand 0.8.5",
- "sentry-types",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "sentry-panic"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4145005d9b5c117132765c34e2cb33e9d24d16e73d7f3a357122b77fe3a3b815"
-dependencies = [
- "sentry-backtrace",
- "sentry-core",
-]
-
-[[package]]
-name = "sentry-slog"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ff3bd6de956e114bdbcc5df560c7351bd7fac497da8cf631468d9946d9587fa"
-dependencies = [
- "sentry-core",
- "serde_json",
- "slog",
-]
-
-[[package]]
-name = "sentry-types"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb30d75498a041005a774ec1b6b7d9589c5906d17ebaca338cb685dc92170f9b"
-dependencies = [
- "chrono",
- "debugid",
- "getrandom 0.2.7",
- "hex 0.4.3",
- "serde",
- "serde_json",
- "thiserror",
- "time 0.3.14",
- "url",
- "uuid 1.0.0",
-]
-
-[[package]]
 name = "serde"
 version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6150,9 +6017,6 @@ name = "slog"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8347046d4ebd943127157b94d63abb990fcf729dc4e9978927fdf4ac3c998d06"
-dependencies = [
- "erased-serde",
-]
 
 [[package]]
 name = "slog-async"
@@ -7593,15 +7457,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
 
 [[package]]
-name = "uname"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b72f89f0ca32e4db1c04e2a72f5345d59796d4866a1ee0609084569f73683dc8"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "uncased"
 version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7736,20 +7591,6 @@ name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
-
-[[package]]
-name = "ureq"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97acb4c28a254fd7a4aeec976c46a7fa404eac4d7c134b30c75144846d7cb8f"
-dependencies = [
- "base64 0.13.0",
- "chunked_transfer",
- "log",
- "native-tls",
- "once_cell",
- "url",
-]
 
 [[package]]
 name = "url"

--- a/components/chainhook-event-observer/Cargo.toml
+++ b/components/chainhook-event-observer/Cargo.toml
@@ -16,8 +16,8 @@ hiro_system_kit = { package = "hiro-system-kit", path = "../../components/hiro-s
 
 chainhook_types = { package = "chainhook-types", path = "../chainhook-types-rs" }
 rocket = { version = "=0.5.0-rc.2", features = ["json"] }
-bitcoincore-rpc = "0.14.0"
-bitcoincore-rpc-json = "0.14.0"
+bitcoincore-rpc = "0.16.0"
+bitcoincore-rpc-json = "0.16.0"
 base64 = "0.13.0"
 reqwest = { version = "0.11", default-features = false, features = [
     "blocking",

--- a/components/chainhook-event-observer/src/chainhooks/bitcoin/mod.rs
+++ b/components/chainhook-event-observer/src/chainhooks/bitcoin/mod.rs
@@ -153,7 +153,7 @@ pub fn serialize_bitcoin_payload_to_json<'a>(
                         "operations": transaction.operations,
                         "metadata": json!({
                             "inputs": transaction.metadata.inputs,
-                            "outputs": transaction.metadata.inputs,
+                            "outputs": transaction.metadata.outputs,
                             "stacks_operations": transaction.metadata.stacks_operations,
                             "proof": proofs.get(&transaction.transaction_identifier),
                         }),

--- a/components/chainhook-event-observer/src/indexer/bitcoin/mod.rs
+++ b/components/chainhook-event-observer/src/indexer/bitcoin/mod.rs
@@ -78,7 +78,12 @@ pub fn build_block(
                 },
                 script_sig: to_hex(input.script_sig.as_bytes()),
                 sequence: input.sequence.0,
-                witness: input.witness.to_vec(),
+                witness: input
+                    .witness
+                    .to_vec()
+                    .iter()
+                    .map(|w| format!("0x{}", to_hex(w)))
+                    .collect::<Vec<_>>(),
             })
         }
 

--- a/components/chainhook-event-observer/src/observer/mod.rs
+++ b/components/chainhook-event-observer/src/observer/mod.rs
@@ -875,7 +875,8 @@ pub fn handle_new_stacks_block(
             let chain_event = indexer.handle_stacks_marshalled_block(marshalled_block.into_inner());
             (pox_info, chain_event)
         }
-        _ => {
+        Err(e) => {
+            warn!("unable to acquire indexer_rw_lock: {}", e.to_string());
             return Json(json!({
                 "status": 500,
                 "result": "Unable to acquire lock",
@@ -889,7 +890,13 @@ pub fn handle_new_stacks_block(
             Ok(tx) => {
                 let _ = tx.send(ObserverCommand::PropagateStacksChainEvent(chain_event));
             }
-            _ => {}
+            Err(e) => {
+                warn!("unable to acquire background_job_tx: {}", e.to_string());
+                return Json(json!({
+                    "status": 500,
+                    "result": "Unable to acquire lock",
+                }))    
+            }
         };
     }
 

--- a/components/chainhook-event-observer/src/observer/mod.rs
+++ b/components/chainhook-event-observer/src/observer/mod.rs
@@ -484,7 +484,7 @@ pub async fn start_observer_commands_handler(
                                             ) {
                                                 Ok(proof) => {
                                                     proofs.insert(
-                                                        transaction.transaction_identifier,
+                                                        &transaction.transaction_identifier,
                                                         proof,
                                                     );
                                                 }

--- a/components/chainhook-event-observer/src/observer/mod.rs
+++ b/components/chainhook-event-observer/src/observer/mod.rs
@@ -880,7 +880,7 @@ pub fn handle_new_stacks_block(
             return Json(json!({
                 "status": 500,
                 "result": "Unable to acquire lock",
-            }))
+            }));
         }
     };
 
@@ -895,7 +895,7 @@ pub fn handle_new_stacks_block(
                 return Json(json!({
                     "status": 500,
                     "result": "Unable to acquire lock",
-                }))    
+                }));
             }
         };
     }

--- a/components/chainhook-node/Cargo.toml
+++ b/components/chainhook-node/Cargo.toml
@@ -34,6 +34,8 @@ tar = "0.4.38"
 flume = "0.10.14"
 ansi_term = "0.12.1"
 atty = "0.2.14"
+bitcoincore-rpc = "0.16.0"
+bitcoincore-rpc-json = "0.16.0"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/components/chainhook-node/Chainhook.toml
+++ b/components/chainhook-node/Chainhook.toml
@@ -1,0 +1,14 @@
+[storage]
+driver = "redis"
+redis_uri = "redis://localhost:6379/"
+
+[chainhooks]
+max_stacks_registrations = 500
+max_bitcoin_registrations = 500
+
+[network]
+mode = "devnet"
+bitcoin_node_rpc_url = "http://0.0.0.0:18443"
+bitcoin_node_rpc_username = "devnet"
+bitcoin_node_rpc_password = "devnet"
+stacks_node_rpc_url = "http://0.0.0.0:20443"

--- a/components/chainhook-node/src/block/digestion.rs
+++ b/components/chainhook-node/src/block/digestion.rs
@@ -2,7 +2,6 @@ use super::DigestingCommand;
 use crate::config::Config;
 use chainhook_event_observer::indexer;
 use chainhook_event_observer::indexer::Indexer;
-use redis;
 use redis::Commands;
 use std::cmp::Ordering;
 use std::{collections::BinaryHeap, process, sync::mpsc::Receiver};
@@ -23,7 +22,7 @@ pub fn start(command_rx: Receiver<DigestingCommand>, config: &Config) -> Result<
     let mut job_queue: BinaryHeap<Job> = BinaryHeap::new();
     let redis_config = config.expected_redis_config();
     let client = redis::Client::open(redis_config.uri.clone()).unwrap();
-    let mut indexer = Indexer::new(config.indexer.clone());
+    let mut indexer = Indexer::new(config.network.clone());
 
     let mut con = match client.get_connection() {
         Ok(con) => con,

--- a/components/chainhook-node/src/block/ingestion.rs
+++ b/components/chainhook-node/src/block/ingestion.rs
@@ -1,7 +1,6 @@
 use crate::config::Config;
 use chainhook_event_observer::indexer::{self, Indexer};
 use chainhook_types::BlockIdentifier;
-use redis;
 use redis::Commands;
 use serde::Deserialize;
 use std::sync::mpsc::Sender;
@@ -94,7 +93,7 @@ pub fn start(
                 return Err(format!("Redis: {}", message.to_string()));
             }
         };
-        let _indexer = Indexer::new(stacks_thread_config.indexer.clone());
+        let _indexer = Indexer::new(stacks_thread_config.network.clone());
 
         // Retrieve the former highest block height stored
         let former_tip_height: u64 = con.get(&format!("stx:tip")).unwrap_or(0);

--- a/components/chainhook-node/src/block/ingestion.rs
+++ b/components/chainhook-node/src/block/ingestion.rs
@@ -180,7 +180,7 @@ pub fn start(
             let _ = digestion_tx.send(DigestingCommand::DigestSeedBlock(cursor.clone()));
             cursor = parent_block_identifier.clone();
         }
-        info!("{} Stacks blocks queued for processing...", tip_height);
+        info!("{} Stacks blocks queued for processing", tip_height);
 
         let _ = digestion_tx.send(DigestingCommand::GarbageCollect);
         Ok(selected_tip)

--- a/components/chainhook-node/src/cli/mod.rs
+++ b/components/chainhook-node/src/cli/mod.rs
@@ -102,8 +102,8 @@ struct ReplayConfig {
     )]
     pub mainnet: bool,
     /// Apply chainhook action (false by default)
-    #[clap(long = "apply")]
-    pub apply: bool,
+    #[clap(long = "apply-trigger")]
+    pub apply_trigger: bool,
     /// Bitcoind node url
     #[clap(long = "bitcoind-rpc-url")]
     pub bitcoind_rpc_url: String,
@@ -167,7 +167,7 @@ pub fn main() {
                     }
                 }
             };
-            start_replay_flow(&network, bitcoind_rpc_url, cmd.apply);
+            start_replay_flow(&network, bitcoind_rpc_url, cmd.apply_trigger);
         }
     }
 }

--- a/components/chainhook-node/src/cli/mod.rs
+++ b/components/chainhook-node/src/cli/mod.rs
@@ -144,7 +144,6 @@ pub fn main() {
                     process::exit(1);
                 }
             };
-            println!("{:?}", config);
             start_node(config);
         }
         Command::Replay(cmd) => {

--- a/components/chainhook-node/src/cli/mod.rs
+++ b/components/chainhook-node/src/cli/mod.rs
@@ -3,6 +3,10 @@ use crate::archive;
 use crate::block::DigestingCommand;
 use crate::config::Config;
 
+use chainhook_event_observer::chainhooks::bitcoin::{
+    handle_bitcoin_hook_action, BitcoinChainhookOccurrence, BitcoinTriggerChainhook,
+};
+use chainhook_event_observer::indexer::bitcoin::build_block;
 use chainhook_event_observer::observer::{
     start_event_observer, EventObserverConfig, ObserverCommand, ObserverEvent,
 };
@@ -14,14 +18,16 @@ use chainhook_event_observer::{
     chainhooks::types::ChainhookSpecification,
 };
 
+use bitcoincore_rpc::{Auth, Client, RpcApi};
 use chainhook_types::{
-    BlockIdentifier, StacksBlockData, StacksBlockMetadata, StacksChainEvent, StacksNetwork,
-    StacksTransactionData,
+    BitcoinBlockData, BitcoinBlockMetadata, BitcoinTransactionData, BlockIdentifier,
+    StacksBlockData, StacksBlockMetadata, StacksChainEvent, StacksNetwork, StacksTransactionData,
 };
 use clap::{Parser, Subcommand};
 use ctrlc;
 use hiro_system_kit;
 use redis::{Commands, Connection};
+use reqwest::Url;
 use std::collections::HashSet;
 use std::{collections::HashMap, process, sync::mpsc::channel, thread};
 
@@ -40,6 +46,9 @@ enum Command {
     /// Start chainhook-node
     #[clap(name = "start", bin_name = "start")]
     Start(StartNode),
+    /// Start chainhook-node in replay mode
+    #[clap(name = "replay", bin_name = "replay")]
+    Replay(ReplayConfig),
 }
 
 #[derive(Parser, PartialEq, Clone, Debug)]
@@ -67,6 +76,36 @@ struct StartNode {
     pub mainnet: bool,
 }
 
+#[derive(Parser, PartialEq, Clone, Debug)]
+struct ReplayConfig {
+    /// Target Devnet network
+    #[clap(
+        long = "devnet",
+        conflicts_with = "testnet",
+        conflicts_with = "mainnet"
+    )]
+    pub devnet: bool,
+    /// Target Testnet network
+    #[clap(
+        long = "testnet",
+        conflicts_with = "devnet",
+        conflicts_with = "mainnet"
+    )]
+    pub testnet: bool,
+    /// Target Mainnet network
+    #[clap(
+        long = "mainnet",
+        conflicts_with = "testnet",
+        conflicts_with = "devnet"
+    )]
+    pub mainnet: bool,
+    /// Bitcoind node url
+    #[clap(long = "bitcoind-rpc-url")]
+    pub bitcoind_rpc_url: String,
+    /// Apply chainhook action (false by default)
+    pub apply: bool,
+}
+
 pub fn main() {
     let opts: Opts = match Opts::try_parse() {
         Ok(opts) => opts,
@@ -91,6 +130,483 @@ pub fn main() {
                 }
             };
             start_node(&network);
+        }
+        Command::Replay(cmd) => {
+            let network = match (cmd.devnet, cmd.testnet, cmd.mainnet) {
+                (true, false, false) => StacksNetwork::Devnet,
+                (false, true, false) => StacksNetwork::Testnet,
+                (false, false, true) => StacksNetwork::Mainnet,
+                _ => {
+                    println!(
+                        "{}",
+                        format_err!("network flag required (devnet, testnet, mainnet)")
+                    );
+                    process::exit(1);
+                }
+            };
+            let bitcoind_rpc_url = if cmd.bitcoind_rpc_url == "" {
+                Url::parse("http://devnet:devnet@localhost:18443").unwrap()
+            } else {
+                match Url::parse(&cmd.bitcoind_rpc_url) {
+                    Ok(url) => url,
+                    Err(e) => {
+                        println!(
+                            "{} ({})",
+                            format_err!("unable to parse bitcoin url"),
+                            e.to_string()
+                        );
+                        process::exit(1);
+                    }
+                }
+            };
+            start_replay_flow(&network, bitcoind_rpc_url, cmd.apply);
+        }
+    }
+}
+
+pub fn start_replay_flow(network: &StacksNetwork, bitcoind_rpc_url: Url, apply: bool) {
+    let (digestion_tx, digestion_rx) = channel();
+    let (observer_event_tx, observer_event_rx) = channel();
+    let (observer_command_tx, observer_command_rx) = channel();
+
+    let terminate_digestion_tx = digestion_tx.clone();
+    ctrlc::set_handler(move || {
+        warn!("Manual interruption signal received");
+        terminate_digestion_tx
+            .send(DigestingCommand::Kill)
+            .expect("Unable to terminate service");
+    })
+    .expect("Error setting Ctrl-C handler");
+
+    let mut config = match network {
+        StacksNetwork::Devnet => Config::devnet_default(),
+        StacksNetwork::Testnet => Config::testnet_default(),
+        StacksNetwork::Mainnet => Config::mainnet_default(),
+        _ => unreachable!(),
+    };
+    let bitcoin_host = bitcoind_rpc_url
+        .host()
+        .expect("unable to retrieve host from bitcoin_url")
+        .to_string();
+    let bitcoin_port = bitcoind_rpc_url
+        .port()
+        .expect("unable to retrieve port from bitcoin_url");
+    config.indexer.bitcoin_node_rpc_url = format!("http://{}:{}", bitcoin_host, bitcoin_port);
+    config.indexer.bitcoin_node_rpc_username = bitcoind_rpc_url.username().to_string();
+    config.indexer.bitcoin_node_rpc_password = bitcoind_rpc_url
+        .password()
+        .expect("unable to retrieve password from bitcoin_url")
+        .to_string();
+
+    if config.is_initial_ingestion_required() {
+        // Download default tsv.
+        if config.rely_on_remote_tsv() && config.should_download_remote_tsv() {
+            let url = config.expected_remote_tsv_url();
+            let mut destination_path = config.expected_cache_path();
+            destination_path.push("stacks-node-events.tsv");
+            // Download archive if not already present in cache
+            if !destination_path.exists() {
+                info!("Downloading {}...", url);
+                match hiro_system_kit::nestable_block_on(archive::download_tsv_file(&config)) {
+                    Ok(_) => {}
+                    Err(e) => {
+                        error!("{}", e);
+                        process::exit(1);
+                    }
+                }
+                let mut destination_path = config.expected_cache_path();
+                destination_path.push("stacks-node-events.tsv");
+            }
+            config.add_local_tsv_source(&destination_path);
+
+            let ingestion_config = config.clone();
+            let seed_digestion_tx = digestion_tx.clone();
+            thread::spawn(move || {
+                let res = block::ingestion::start(seed_digestion_tx.clone(), &ingestion_config);
+                let (_stacks_chain_tip, _bitcoin_chain_tip) = match res {
+                    Ok(chain_tips) => chain_tips,
+                    Err(e) => {
+                        error!("{}", e);
+                        process::exit(1);
+                    }
+                };
+            });
+        }
+    } else {
+        info!(
+            "Streaming blocks from stacks-node {}...",
+            config.expected_stacks_node_event_source()
+        );
+    }
+
+    let digestion_config = config.clone();
+    let terminate_observer_command_tx = observer_command_tx.clone();
+    thread::spawn(move || {
+        let res = block::digestion::start(digestion_rx, &digestion_config);
+        if let Err(e) = res {
+            error!("{}", e);
+        }
+        let _ = terminate_observer_command_tx.send(ObserverCommand::Terminate);
+    });
+
+    let event_observer_config = EventObserverConfig {
+        normalization_enabled: true,
+        grpc_server_enabled: false,
+        hooks_enabled: true,
+        bitcoin_rpc_proxy_enabled: true,
+        event_handlers: vec![],
+        initial_hook_formation: None,
+        ingestion_port: DEFAULT_INGESTION_PORT,
+        control_port: DEFAULT_CONTROL_PORT,
+        bitcoin_node_username: config.indexer.bitcoin_node_rpc_username.clone(),
+        bitcoin_node_password: config.indexer.bitcoin_node_rpc_password.clone(),
+        bitcoin_node_rpc_host: config.indexer.bitcoin_node_rpc_url.clone(),
+        bitcoin_node_rpc_port: bitcoin_port,
+        stacks_node_rpc_host: "http://localhost".into(),
+        stacks_node_rpc_port: 20443,
+        operators: HashSet::new(),
+        display_logs: false,
+    };
+    info!(
+        "Listening for new blockchain events on port {}",
+        DEFAULT_INGESTION_PORT
+    );
+    info!(
+        "Listening for chainhook predicate registrations on port {}",
+        DEFAULT_CONTROL_PORT
+    );
+    let _ = std::thread::spawn(move || {
+        let future = start_event_observer(
+            event_observer_config,
+            observer_command_tx,
+            observer_command_rx,
+            Some(observer_event_tx),
+        );
+        let _ = hiro_system_kit::nestable_block_on(future);
+    });
+
+    let redis_config = config.expected_redis_config();
+    let client = redis::Client::open(redis_config.uri.clone()).unwrap();
+    let mut redis_con = match client.get_connection() {
+        Ok(con) => con,
+        Err(message) => {
+            error!("Redis: {}", message.to_string());
+            panic!();
+        }
+    };
+
+    let auth = Auth::UserPass(
+        config.indexer.bitcoin_node_rpc_username.clone(),
+        config.indexer.bitcoin_node_rpc_password.clone(),
+    );
+    let bitcoin_rpc = Client::new(&config.indexer.bitcoin_node_rpc_url, auth).unwrap();
+
+    loop {
+        let event = match observer_event_rx.recv() {
+            Ok(cmd) => cmd,
+            Err(e) => {
+                error!("Error: broken channel {}", e.to_string());
+                break;
+            }
+        };
+        match event {
+            ObserverEvent::HookRegistered(chain_hook) => {
+                // If start block specified, use it.
+                // I no start block specified, depending on the nature the hook, we'd like to retrieve:
+                // - contract-id
+
+                match chain_hook {
+                    ChainhookSpecification::Stacks(stacks_hook) => {
+                        // Retrieve highest block height stored
+                        let tip_height: u64 = redis_con
+                            .get(&format!("stx:tip"))
+                            .expect("unable to retrieve tip height");
+
+                        let start_block = stacks_hook.start_block.unwrap_or(2); // TODO(lgalabru): handle STX hooks and genesis block :s
+                        let end_block = stacks_hook.end_block.unwrap_or(tip_height); // TODO(lgalabru): handle STX hooks and genesis block :s
+
+                        info!(
+                            "Processing Stacks chainhook {}, will scan blocks [{}; {}]...",
+                            stacks_hook.uuid, start_block, end_block
+                        );
+                        let mut total_hits = vec![];
+                        for cursor in start_block..=end_block {
+                            debug!(
+                                "Evaluating predicate #{} on block #{}",
+                                stacks_hook.uuid, cursor
+                            );
+                            let (
+                                block_identifier,
+                                parent_block_identifier,
+                                timestamp,
+                                transactions,
+                                metadata,
+                            ) = {
+                                let payload: Vec<String> = redis_con
+                                    .hget(
+                                        &format!("stx:{}", cursor),
+                                        &[
+                                            "block_identifier",
+                                            "parent_block_identifier",
+                                            "timestamp",
+                                            "transactions",
+                                            "metadata",
+                                        ],
+                                    )
+                                    .expect("unable to retrieve tip height");
+                                if payload.len() != 5 {
+                                    warn!("Chain still being processed, please retry in a few minutes");
+                                    continue;
+                                }
+                                (
+                                    serde_json::from_str::<BlockIdentifier>(&payload[0]).unwrap(),
+                                    serde_json::from_str::<BlockIdentifier>(&payload[1]).unwrap(),
+                                    serde_json::from_str::<i64>(&payload[2]).unwrap(),
+                                    serde_json::from_str::<Vec<StacksTransactionData>>(&payload[3])
+                                        .unwrap(),
+                                    serde_json::from_str::<StacksBlockMetadata>(&payload[4])
+                                        .unwrap(),
+                                )
+                            };
+                            let mut hits = vec![];
+                            for tx in transactions.iter() {
+                                if evaluate_stacks_transaction_predicate_on_transaction(
+                                    &tx,
+                                    &stacks_hook,
+                                ) {
+                                    debug!(
+                                        "Action #{} triggered by transaction {} (block #{})",
+                                        stacks_hook.uuid, tx.transaction_identifier.hash, cursor
+                                    );
+                                    hits.push(tx);
+                                    total_hits.push(tx.transaction_identifier.hash.to_string());
+                                }
+                            }
+
+                            if hits.len() > 0 {
+                                let block = StacksBlockData {
+                                    block_identifier,
+                                    parent_block_identifier,
+                                    timestamp,
+                                    transactions: vec![],
+                                    metadata,
+                                };
+                                let trigger = StacksTriggerChainhook {
+                                    chainhook: &stacks_hook,
+                                    apply: vec![(hits, &block)],
+                                    rollback: vec![],
+                                };
+
+                                let proofs = HashMap::new();
+                                if apply {
+                                    if let Some(result) =
+                                        handle_stacks_hook_action(trigger, &proofs)
+                                    {
+                                        if let StacksChainhookOccurrence::Http(request) = result {
+                                            hiro_system_kit::nestable_block_on(request.send())
+                                                .unwrap();
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        info!("Stacks chainhook {} scan completed and triggered by {} transactions {}", stacks_hook.uuid, total_hits.len(), total_hits.join(","))
+                    }
+                    ChainhookSpecification::Bitcoin(bitcoin_hook) => {
+                        let start_block = match bitcoin_hook.start_block {
+                            Some(start_block) => start_block,
+                            None => {
+                                error!("Bitcoin chainhook specification must include a field start_block in replay mode");
+                                continue;
+                            }
+                        };
+                        let tip_height = match bitcoin_rpc.get_blockchain_info() {
+                            Ok(result) => result.blocks,
+                            Err(e) => {
+                                error!("unable to retrieve Bitcoin chain tip ({})", e.to_string());
+                                continue;
+                            }
+                        };
+                        let end_block = bitcoin_hook.end_block.unwrap_or(tip_height);
+
+                        info!(
+                            "Processing Bitcoin chainhook {}, will scan blocks [{}; {}]...",
+                            bitcoin_hook.uuid, start_block, end_block
+                        );
+
+                        let mut total_hits = vec![];
+                        for cursor in start_block..=end_block {
+                            debug!(
+                                "Evaluating predicate #{} on block #{}",
+                                bitcoin_hook.uuid, cursor
+                            );
+
+                            // Try to retrieve block from cache
+
+                            let cached_block = {
+                                let payload: Vec<String> = redis_con
+                                    .hget(
+                                        &format!("btc:{}", cursor),
+                                        &[
+                                            "block_identifier",
+                                            "parent_block_identifier",
+                                            "timestamp",
+                                            "transactions",
+                                            "metadata",
+                                        ],
+                                    )
+                                    .expect("unable to retrieve tip height");
+                                if payload.len() != 5 {
+                                    None
+                                } else {
+                                    let block = BitcoinBlockData {
+                                        block_identifier: serde_json::from_str::<BlockIdentifier>(
+                                            &payload[0],
+                                        )
+                                        .unwrap(),
+                                        parent_block_identifier: serde_json::from_str::<
+                                            BlockIdentifier,
+                                        >(
+                                            &payload[1]
+                                        )
+                                        .unwrap(),
+                                        timestamp: serde_json::from_str::<u32>(&payload[2])
+                                            .unwrap(),
+                                        transactions: serde_json::from_str::<
+                                            Vec<BitcoinTransactionData>,
+                                        >(
+                                            &payload[3]
+                                        )
+                                        .unwrap(),
+                                        metadata: serde_json::from_str::<BitcoinBlockMetadata>(
+                                            &payload[4],
+                                        )
+                                        .unwrap(),
+                                    };
+                                    debug!(
+                                        "Bitcoin block #{} retrieved from cache",
+                                        block.block_identifier.index
+                                    );
+                                    Some(block)
+                                }
+                            };
+
+                            let block = match cached_block {
+                                Some(block) => block,
+                                None => {
+                                    let block_hash = match bitcoin_rpc.get_block_hash(cursor) {
+                                        Ok(block_hash) => block_hash,
+                                        Err(e) => {
+                                            error!("unable to retrieve block hash {}", cursor);
+                                            continue;
+                                        }
+                                    };
+
+                                    let block = match bitcoin_rpc.get_block(&block_hash) {
+                                        Ok(block) => build_block(block, cursor, &config.indexer),
+                                        Err(e) => {
+                                            error!("unable to retrieve block hash {}", cursor);
+                                            continue;
+                                        }
+                                    };
+
+                                    let key = format!("btc:{}", block.block_identifier.index);
+                                    match redis_con.hset_multiple(
+                                        &key,
+                                        &[
+                                            (
+                                                "block_identifier",
+                                                json!(block.block_identifier).to_string(),
+                                            ),
+                                            (
+                                                "parent_block_identifier",
+                                                json!(block.parent_block_identifier).to_string(),
+                                            ),
+                                            ("transactions", json!(block.transactions).to_string()),
+                                            ("metadata", json!(block.metadata).to_string()),
+                                            ("timestamp", json!(block.timestamp).to_string()),
+                                        ],
+                                    ) {
+                                        Ok(()) => {
+                                            debug!(
+                                                "Bitcoin block #{} saved to cache",
+                                                block.block_identifier.index
+                                            );
+                                        }
+                                        Err(e) => {
+                                            warn!(
+                                                "unable to keep block {key} in cache: {}",
+                                                e.to_string()
+                                            );
+                                        }
+                                    };
+
+                                    block
+                                }
+                            };
+
+                            let mut hits = vec![];
+                            for tx in block.transactions.iter() {
+                                if bitcoin_hook.evaluate_transaction_predicate(&tx) {
+                                    debug!(
+                                        "Action #{} triggered by transaction {} (block #{})",
+                                        bitcoin_hook.uuid, tx.transaction_identifier.hash, cursor
+                                    );
+                                    hits.push(tx);
+                                    total_hits.push(tx.transaction_identifier.hash.to_string());
+                                }
+                            }
+
+                            if hits.len() > 0 {
+                                let trigger = BitcoinTriggerChainhook {
+                                    chainhook: &bitcoin_hook,
+                                    apply: vec![(hits, &block)],
+                                    rollback: vec![],
+                                };
+
+                                let proofs = HashMap::new();
+                                if apply {
+                                    if let Some(result) =
+                                        handle_bitcoin_hook_action(trigger, &proofs)
+                                    {
+                                        if let BitcoinChainhookOccurrence::Http(request) = result {
+                                            hiro_system_kit::nestable_block_on(request.send())
+                                                .unwrap();
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        info!("Bitcoin chainhook {} scan completed and triggered by {} transactions {}", bitcoin_hook.uuid, total_hits.len(), total_hits.join(","))
+                    }
+                }
+            }
+            ObserverEvent::BitcoinChainEvent(_chain_update) => {
+                debug!("Bitcoin update not stored");
+            }
+            ObserverEvent::StacksChainEvent(chain_event) => {
+                match &chain_event {
+                    StacksChainEvent::ChainUpdatedWithBlocks(data) => {
+                        update_storage_with_confirmed_stacks_blocks(
+                            &mut redis_con,
+                            &data.confirmed_blocks,
+                        );
+                    }
+                    StacksChainEvent::ChainUpdatedWithReorg(data) => {
+                        update_storage_with_confirmed_stacks_blocks(
+                            &mut redis_con,
+                            &data.confirmed_blocks,
+                        );
+                    }
+                    StacksChainEvent::ChainUpdatedWithMicroblocks(_)
+                    | StacksChainEvent::ChainUpdatedWithMicroblocksReorg(_) => {}
+                };
+            }
+            ObserverEvent::Terminate => {
+                break;
+            }
+            _ => {}
         }
     }
 }

--- a/components/chainhook-node/src/cli/mod.rs
+++ b/components/chainhook-node/src/cli/mod.rs
@@ -206,7 +206,7 @@ pub fn start_replay_flow(network: &StacksNetwork, bitcoind_rpc_url: Url, apply: 
             destination_path.push("stacks-node-events.tsv");
             // Download archive if not already present in cache
             if !destination_path.exists() {
-                info!("Downloading {}...", url);
+                info!("Downloading {}", url);
                 match hiro_system_kit::nestable_block_on(archive::download_tsv_file(&config)) {
                     Ok(_) => {}
                     Err(e) => {
@@ -234,7 +234,7 @@ pub fn start_replay_flow(network: &StacksNetwork, bitcoind_rpc_url: Url, apply: 
         }
     } else {
         info!(
-            "Streaming blocks from stacks-node {}...",
+            "Streaming blocks from stacks-node {}",
             config.expected_stacks_node_event_source()
         );
     }
@@ -326,8 +326,8 @@ pub fn start_replay_flow(network: &StacksNetwork, bitcoind_rpc_url: Url, apply: 
                         let end_block = stacks_hook.end_block.unwrap_or(tip_height); // TODO(lgalabru): handle STX hooks and genesis block :s
 
                         info!(
-                            "Processing Stacks chainhook {}, will scan blocks [{}; {}]...",
-                            stacks_hook.uuid, start_block, end_block
+                            "Processing Stacks chainhook {}, will scan blocks [{}; {}]  (apply = {})",
+                            stacks_hook.uuid, start_block, end_block, apply
                         );
                         let mut total_hits = vec![];
                         for cursor in start_block..=end_block {
@@ -431,8 +431,8 @@ pub fn start_replay_flow(network: &StacksNetwork, bitcoind_rpc_url: Url, apply: 
                         let end_block = bitcoin_hook.end_block.unwrap_or(tip_height);
 
                         info!(
-                            "Processing Bitcoin chainhook {}, will scan blocks [{}; {}]...",
-                            bitcoin_hook.uuid, start_block, end_block
+                            "Processing Bitcoin chainhook {}, will scan blocks [{}; {}] (apply = {})",
+                            bitcoin_hook.uuid, start_block, end_block, apply
                         );
 
                         let mut total_hits = vec![];
@@ -640,7 +640,7 @@ pub fn start_node(network: &StacksNetwork) {
             destination_path.push("stacks-node-events.tsv");
             // Download archive if not already present in cache
             if !destination_path.exists() {
-                info!("Downloading {}...", url);
+                info!("Downloading {}", url);
                 match hiro_system_kit::nestable_block_on(archive::download_tsv_file(&config)) {
                     Ok(_) => {}
                     Err(e) => {
@@ -668,7 +668,7 @@ pub fn start_node(network: &StacksNetwork) {
         }
     } else {
         info!(
-            "Streaming blocks from stacks-node {}...",
+            "Streaming blocks from stacks-node {}",
             config.expected_stacks_node_event_source()
         );
     }
@@ -754,7 +754,7 @@ pub fn start_node(network: &StacksNetwork) {
                         let end_block = stacks_hook.end_block.unwrap_or(tip_height); // TODO(lgalabru): handle STX hooks and genesis block :s
 
                         info!(
-                            "Processing Stacks chainhook {}, will scan blocks [{}; {}]...",
+                            "Processing Stacks chainhook {}, will scan blocks [{}; {}]",
                             stacks_hook.uuid, start_block, end_block
                         );
                         let mut total_hits = 0;

--- a/components/chainhook-node/src/config/file.rs
+++ b/components/chainhook-node/src/config/file.rs
@@ -1,17 +1,18 @@
-#[derive(Clone, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 pub struct ConfigFile {
-    pub storage: Option<StorageConfigFile>,
-    pub event_source: Vec<EventSourceConfigFile>,
-    pub chainhooks: Option<ChainhooksConfigFile>,
+    pub storage: StorageConfigFile,
+    pub event_source: Option<Vec<EventSourceConfigFile>>,
+    pub chainhooks: ChainhooksConfigFile,
+    pub network: NetworkConfigFile,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 pub struct StorageConfigFile {
-    pub driver: Option<String>,
-    pub redis_uri: Option<String>,
+    pub driver: String,
+    pub redis_uri: String,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 pub struct EventSourceConfigFile {
     pub source_type: Option<String>,
     pub stacks_node_url: Option<String>,
@@ -21,8 +22,17 @@ pub struct EventSourceConfigFile {
     pub tsv_file_url: Option<String>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 pub struct ChainhooksConfigFile {
     pub max_stacks_registrations: Option<u16>,
     pub max_bitcoin_registrations: Option<u16>,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct NetworkConfigFile {
+    pub mode: String,
+    pub bitcoin_node_rpc_url: String,
+    pub bitcoin_node_rpc_username: String,
+    pub bitcoin_node_rpc_password: String,
+    pub stacks_node_rpc_url: String,
 }

--- a/components/chainhook-node/src/config/mod.rs
+++ b/components/chainhook-node/src/config/mod.rs
@@ -5,8 +5,8 @@ use chainhook_types::{BitcoinNetwork, StacksNetwork};
 pub use file::ConfigFile;
 use std::path::PathBuf;
 
-const DEFAULT_MAINNET_TSV_ARCHIVE: &str = "https://storage.googleapis.com/hirosystems-archive/mainnet/api/mainnet-blockchain-api-5.0.0-latest.tar.gz";
-const DEFAULT_TESTNET_TSV_ARCHIVE: &str = "https://storage.googleapis.com/hirosystems-archive/testnet/api/testnet-blockchain-api-5.0.0-latest.tar.gz";
+const DEFAULT_MAINNET_TSV_ARCHIVE: &str = "https://storage.googleapis.com/hirosystems-archive/mainnet/api/mainnet-blockchain-api-5.0.3-latest.tar.gz";
+const DEFAULT_TESTNET_TSV_ARCHIVE: &str = "https://storage.googleapis.com/hirosystems-archive/testnet/api/testnet-blockchain-api-5.0.3-latest.tar.gz";
 
 #[derive(Clone, Debug)]
 pub struct Config {

--- a/components/chainhook-node/src/config/mod.rs
+++ b/components/chainhook-node/src/config/mod.rs
@@ -3,17 +3,19 @@ pub mod file;
 pub use chainhook_event_observer::indexer::IndexerConfig;
 use chainhook_types::{BitcoinNetwork, StacksNetwork};
 pub use file::ConfigFile;
+use std::fs::File;
+use std::io::{BufReader, Read};
 use std::path::PathBuf;
 
-const DEFAULT_MAINNET_TSV_ARCHIVE: &str = "https://storage.googleapis.com/hirosystems-archive/mainnet/api/mainnet-blockchain-api-5.0.3-latest.tar.gz";
-const DEFAULT_TESTNET_TSV_ARCHIVE: &str = "https://storage.googleapis.com/hirosystems-archive/testnet/api/testnet-blockchain-api-5.0.3-latest.tar.gz";
+const DEFAULT_MAINNET_TSV_ARCHIVE: &str = "https://storage.googleapis.com/hirosystems-archive/mainnet/api/mainnet-blockchain-api-latest.tar.gz";
+const DEFAULT_TESTNET_TSV_ARCHIVE: &str = "https://storage.googleapis.com/hirosystems-archive/testnet/api/testnet-blockchain-api-latest.tar.gz";
 
 #[derive(Clone, Debug)]
 pub struct Config {
     pub storage: StorageConfig,
     pub event_sources: Vec<EventSourceConfig>,
     pub chainhooks: ChainhooksConfig,
-    pub indexer: IndexerConfig,
+    pub network: IndexerConfig,
 }
 
 #[derive(Clone, Debug)]
@@ -61,6 +63,70 @@ pub struct ChainhooksConfig {
 }
 
 impl Config {
+    pub fn from_file_path(file_path: &str) -> Result<Config, String> {
+        let file = File::open(file_path)
+            .map_err(|e| format!("unable to read file {}\n{:?}", file_path, e))?;
+        let mut file_reader = BufReader::new(file);
+        let mut file_buffer = vec![];
+        file_reader
+            .read_to_end(&mut file_buffer)
+            .map_err(|e| format!("unable to read file {}\n{:?}", file_path, e))?;
+
+        let config_file: ConfigFile = match toml::from_slice(&file_buffer) {
+            Ok(s) => s,
+            Err(e) => {
+                return Err(format!("Config file malformatted {}", e.to_string()));
+            }
+        };
+        Config::from_config_file(config_file)
+    }
+
+    pub fn from_config_file(config_file: ConfigFile) -> Result<Config, String> {
+        let (stacks_network, bitcoin_network) = match config_file.network.mode.as_str() {
+            "devnet" => (StacksNetwork::Devnet, BitcoinNetwork::Regtest),
+            "testnet" => (StacksNetwork::Testnet, BitcoinNetwork::Testnet),
+            "mainnet" => (StacksNetwork::Mainnet, BitcoinNetwork::Mainnet),
+            _ => return Err("network.mode not supported".to_string()),
+        };
+
+        let config = Config {
+            storage: StorageConfig {
+                driver: StorageDriver::Redis(RedisConfig {
+                    uri: config_file.storage.redis_uri.to_string(),
+                }),
+                cache_path: "cache".into(),
+            },
+            event_sources: vec![EventSourceConfig::StacksNode(StacksNodeConfig {
+                host: config_file.network.stacks_node_rpc_url.to_string(),
+            })],
+            chainhooks: ChainhooksConfig {
+                max_stacks_registrations: config_file
+                    .chainhooks
+                    .max_stacks_registrations
+                    .unwrap_or(100),
+                max_bitcoin_registrations: config_file
+                    .chainhooks
+                    .max_bitcoin_registrations
+                    .unwrap_or(100),
+            },
+            network: IndexerConfig {
+                stacks_node_rpc_url: config_file.network.stacks_node_rpc_url.to_string(),
+                bitcoin_node_rpc_url: config_file.network.bitcoin_node_rpc_url.to_string(),
+                bitcoin_node_rpc_username: config_file
+                    .network
+                    .bitcoin_node_rpc_username
+                    .to_string(),
+                bitcoin_node_rpc_password: config_file
+                    .network
+                    .bitcoin_node_rpc_password
+                    .to_string(),
+                stacks_network,
+                bitcoin_network,
+            },
+        };
+        Ok(config)
+    }
+
     pub fn is_initial_ingestion_required(&self) -> bool {
         for source in self.event_sources.iter() {
             match source {
@@ -155,7 +221,7 @@ impl Config {
                 max_stacks_registrations: 50,
                 max_bitcoin_registrations: 50,
             },
-            indexer: IndexerConfig {
+            network: IndexerConfig {
                 stacks_node_rpc_url: "http://0.0.0.0:20443".into(),
                 bitcoin_node_rpc_url: "http://0.0.0.0:18443".into(),
                 bitcoin_node_rpc_username: "devnet".into(),
@@ -181,7 +247,7 @@ impl Config {
                 max_stacks_registrations: 10,
                 max_bitcoin_registrations: 10,
             },
-            indexer: IndexerConfig {
+            network: IndexerConfig {
                 stacks_node_rpc_url: "http://0.0.0.0:20443".into(),
                 bitcoin_node_rpc_url: "http://0.0.0.0:18443".into(),
                 bitcoin_node_rpc_username: "devnet".into(),
@@ -207,7 +273,7 @@ impl Config {
                 max_stacks_registrations: 10,
                 max_bitcoin_registrations: 10,
             },
-            indexer: IndexerConfig {
+            network: IndexerConfig {
                 stacks_node_rpc_url: "http://0.0.0.0:20443".into(),
                 bitcoin_node_rpc_url: "http://0.0.0.0:18443".into(),
                 bitcoin_node_rpc_username: "devnet".into(),

--- a/components/chainhook-node/src/lib.rs
+++ b/components/chainhook-node/src/lib.rs
@@ -4,8 +4,10 @@ extern crate serde_json;
 #[macro_use]
 extern crate slog_scope;
 
-extern crate serde;
+#[macro_use]
 extern crate serde_derive;
+
+extern crate serde;
 
 pub mod block;
 pub mod config;

--- a/components/chainhook-node/src/main.rs
+++ b/components/chainhook-node/src/main.rs
@@ -7,8 +7,10 @@ extern crate slog_scope;
 #[macro_use]
 extern crate hiro_system_kit;
 
-extern crate serde;
+#[macro_use]
 extern crate serde_derive;
+
+extern crate serde;
 extern crate slog;
 
 use slog_async;

--- a/components/chainhook-types-rs/src/bitcoin.rs
+++ b/components/chainhook-types-rs/src/bitcoin.rs
@@ -16,7 +16,7 @@ pub struct TxIn {
     /// Encodable/Decodable, as it is (de)serialized at the end of the full
     /// Transaction. It *is* (de)serialized with the rest of the TxIn in other
     /// (de)serialization routines.
-    pub witness: Vec<Vec<u8>>,
+    pub witness: Vec<String>,
 }
 
 /// A transaction output, which defines new coins to be created from old ones.

--- a/components/clarinet-cli/src/deployments/ui/ui.rs
+++ b/components/clarinet-cli/src/deployments/ui/ui.rs
@@ -38,7 +38,7 @@ where
     });
 
     let t = Table::new(rows)
-        .block(Block::default().title(format!("Broadcasting transactions to {}...", app.node_url)))
+        .block(Block::default().title(format!("Broadcasting transactions to {}", app.node_url)))
         .style(Style::default().fg(Color::White))
         .widths(&[
             Constraint::Length(3),

--- a/components/stacks-network/src/chains_coordinator.rs
+++ b/components/stacks-network/src/chains_coordinator.rs
@@ -76,7 +76,7 @@ impl DevnetEventObserverConfig {
         deployment: DeploymentSpecification,
         chainhooks: HookFormation,
     ) -> Self {
-        info!("Checking contracts...");
+        info!("Checking contracts");
         let network_manifest = NetworkManifest::from_project_manifest_location(
             &manifest.location,
             &StacksNetwork::Devnet.get_networks(),

--- a/components/stacks-network/src/lib.rs
+++ b/components/stacks-network/src/lib.rs
@@ -131,7 +131,7 @@ pub async fn do_run_devnet(
         .expect("unable to retrieve join handle");
 
     if display_dashboard {
-        info!("Starting Devnet...");
+        info!("Starting Devnet");
         let moved_chains_coordinator_commands_tx = chains_coordinator_commands_tx.clone();
         let _ = ui::start_ui(
             devnet_events_tx,

--- a/components/stacks-network/src/orchestrator.rs
+++ b/components/stacks-network/src/orchestrator.rs
@@ -682,10 +682,10 @@ impl DevnetOrchestrator {
                         comment: "restarting".into(),
                     }));
 
-                    let _ = event_tx.send(DevnetEvent::debug("Killing containers...".into()));
+                    let _ = event_tx.send(DevnetEvent::debug("Killing containers".into()));
                     let _ = self.stop_containers().await;
 
-                    let _ = event_tx.send(DevnetEvent::debug("Restarting containers...".into()));
+                    let _ = event_tx.send(DevnetEvent::debug("Restarting containers".into()));
                     let (bitcoin_node_c_id, stacks_node_c_id) = self
                         .start_containers(boot_index)
                         .await
@@ -2296,7 +2296,7 @@ events_keys = ["*"]
             let _ = docker
                 .kill_container(bitcoin_explorer_container_id, options.clone())
                 .await;
-            println!("Terminating bitcoin-explorer...");
+            println!("Terminating bitcoin-explorer");
             let _ = docker.remove_container(bitcoin_explorer_container_id, None);
         }
 
@@ -2304,7 +2304,7 @@ events_keys = ["*"]
             let _ = docker
                 .kill_container(stacks_explorer_container_id, options.clone())
                 .await;
-            println!("Terminating stacks-explorer...");
+            println!("Terminating stacks-explorer");
             let _ = docker.remove_container(stacks_explorer_container_id, None);
         }
 
@@ -2312,7 +2312,7 @@ events_keys = ["*"]
             let _ = docker
                 .kill_container(bitcoin_node_container_id, options.clone())
                 .await;
-            println!("Terminating bitcoin-node...");
+            println!("Terminating bitcoin-node");
             let _ = docker.remove_container(bitcoin_node_container_id, None);
         }
 
@@ -2320,7 +2320,7 @@ events_keys = ["*"]
             let _ = docker
                 .kill_container(stacks_api_container_id, options.clone())
                 .await;
-            println!("Terminating stacks-api...");
+            println!("Terminating stacks-api");
             let _ = docker.remove_container(stacks_api_container_id, None);
         }
 
@@ -2328,7 +2328,7 @@ events_keys = ["*"]
             let _ = docker
                 .kill_container(postgres_container_id, options.clone())
                 .await;
-            println!("Terminating postgres...");
+            println!("Terminating postgres");
             let _ = docker.remove_container(postgres_container_id, None);
         }
 
@@ -2336,7 +2336,7 @@ events_keys = ["*"]
             let _ = docker
                 .kill_container(stacks_node_container_id, options.clone())
                 .await;
-            println!("Terminating stacks-node...");
+            println!("Terminating stacks-node");
             let _ = docker.remove_container(stacks_node_container_id, None);
         }
 
@@ -2344,7 +2344,7 @@ events_keys = ["*"]
             let _ = docker
                 .kill_container(subnet_node_container_id, options.clone())
                 .await;
-            println!("Terminating subnet-node...");
+            println!("Terminating subnet-node");
             let _ = docker.remove_container(subnet_node_container_id, None);
         }
 
@@ -2352,12 +2352,12 @@ events_keys = ["*"]
             let _ = docker
                 .kill_container(subnet_api_container_id, options)
                 .await;
-            println!("Terminating subnet-api...");
+            println!("Terminating subnet-api");
             let _ = docker.remove_container(subnet_api_container_id, None);
         }
 
         // Prune network
-        println!("Pruning network and containers...");
+        println!("Pruning network and containers");
         self.prune().await;
         if let Some(ref tx) = self.termination_success_tx {
             let _ = tx.send(true);

--- a/dockerfiles/components/chainhook-event-observer.dockerfile
+++ b/dockerfiles/components/chainhook-event-observer.dockerfile
@@ -1,0 +1,37 @@
+FROM rust:bullseye as build
+
+WORKDIR /src
+
+RUN apt update && apt install -y ca-certificates pkg-config libssl-dev
+
+RUN rustup update 1.59.0 && rustup default 1.59.0
+
+COPY ./components/chainhook-types-rs /src/components/chainhook-types-rs
+
+COPY ./components/chainhook-event-observer /src/components/chainhook-event-observer
+
+COPY ./components/stacks-rpc-client /src/components/stacks-rpc-client
+
+COPY ./components/clarity-repl /src/components/clarity-repl
+
+COPY ./components/clarinet-utils /src/components/clarinet-utils
+
+COPY ./components/hiro-system-kit /src/components/hiro-system-kit
+
+WORKDIR /src/components/chainhook-event-observer
+
+RUN mkdir /out
+
+RUN cargo build --release
+
+RUN cp target/release/chainhook-event-observer /out
+
+FROM debian:bullseye-slim
+
+RUN apt update && apt install -y libssl-dev
+
+COPY --from=build /out/ /bin/
+
+WORKDIR /workspace
+
+ENTRYPOINT ["chainhook-event-observer"]


### PR DESCRIPTION
In this PR, we are modifying the developer experience a bit by adding a new mode:
```bash
$ chainhook-node replay --testnet
```
letting developers replay devnet / testnet / mainnet dumps.
I will continue to refactor and tweak the CLI interface in a subsequent PR, but the current approach is already very useful.