### PR TITLE
feat: Add `epoch` field to batch in deployment plans

### DIFF
--- a/components/clarinet-deployments/src/lib.rs
+++ b/components/clarinet-deployments/src/lib.rs
@@ -686,6 +686,7 @@ pub async fn generate_default_deployment(
         batches.push(TransactionsBatchSpecification {
             id: id,
             transactions: transactions.to_vec(),
+            epoch: None,
         })
     }
 

--- a/components/clarinet-deployments/src/onchain/mod.rs
+++ b/components/clarinet-deployments/src/onchain/mod.rs
@@ -33,7 +33,7 @@ use libsecp256k1::{PublicKey, SecretKey};
 
 mod bitcoin_deployment;
 
-use crate::types::{DeploymentSpecification, TransactionSpecification};
+use crate::types::{DeploymentSpecification, EpochSpec, TransactionSpecification};
 
 fn get_btc_keypair(
     account: &AccountConfig,
@@ -343,14 +343,16 @@ pub fn apply_on_chain_deployment(
     let mut accounts_cached_nonces: BTreeMap<String, u64> = BTreeMap::new();
     let mut stx_accounts_lookup: BTreeMap<String, &AccountConfig> = BTreeMap::new();
     let mut btc_accounts_lookup: BTreeMap<String, &AccountConfig> = BTreeMap::new();
-    let mut clarity_version_available = false;
+    let mut default_epoch = EpochSpec::Epoch2_05;
     if !fetch_initial_nonces {
         if network == StacksNetwork::Devnet {
             for (_, account) in network_manifest.accounts.iter() {
                 accounts_cached_nonces.insert(account.stx_address.clone(), 0);
             }
             if let Some(ref devnet) = network_manifest.devnet {
-                clarity_version_available = devnet.enable_next_features;
+                if devnet.enable_next_features {
+                    default_epoch = EpochSpec::Epoch2_1;
+                }
             };
         }
     }
@@ -376,6 +378,7 @@ pub fn apply_on_chain_deployment(
     let mut index = 0;
     let mut contracts_ids_to_remap: HashSet<(String, String)> = HashSet::new();
     for batch_spec in deployment.plan.batches.iter() {
+        let epoch = batch_spec.epoch.unwrap_or(default_epoch);
         let mut batch = Vec::new();
         for transaction in batch_spec.transactions.iter() {
             let tracker = match transaction {
@@ -548,7 +551,7 @@ pub fn apply_on_chain_deployment(
                         false => TransactionAnchorMode::Any,
                     };
 
-                    let clarity_version = if clarity_version_available {
+                    let clarity_version = if epoch >= EpochSpec::Epoch2_1 {
                         Some(tx.clarity_version.clone())
                     } else {
                         None
@@ -672,7 +675,7 @@ pub fn apply_on_chain_deployment(
             index += 1;
         }
 
-        batches.push_back(batch);
+        batches.push_back((epoch, batch));
     }
 
     let _cmd = match deployment_command_rx.recv() {
@@ -688,7 +691,31 @@ pub fn apply_on_chain_deployment(
     // Phase 2: we submit all the transactions previously encoded,
     // and wait for their inclusion in a block before moving to the next batch.
     let mut current_block_height = 0;
-    for batch in batches.into_iter() {
+    for (epoch, batch) in batches.into_iter() {
+        // Ensure we've reached the appropriate epoch for this batch
+        let after_block = match epoch {
+            EpochSpec::Epoch2_05 => network_manifest.devnet.as_ref().unwrap().epoch_2_05,
+            EpochSpec::Epoch2_1 => network_manifest.devnet.as_ref().unwrap().epoch_2_1,
+        };
+        while current_block_height < after_block {
+            let new_block_height = match stacks_rpc.get_info() {
+                Ok(info) => info.burn_block_height,
+                _ => {
+                    std::thread::sleep(std::time::Duration::from_secs(delay_between_checks.into()));
+                    continue;
+                }
+            };
+
+            // If no block has been mined since `delay_between_checks`,
+            // avoid flooding the stacks-node with status update requests.
+            if new_block_height <= current_block_height {
+                std::thread::sleep(std::time::Duration::from_secs(delay_between_checks.into()));
+                continue;
+            }
+
+            current_block_height = new_block_height;
+        }
+
         let mut ongoing_batch = BTreeMap::new();
         for mut tracker in batch.into_iter() {
             let (transaction, check) = match tracker.status {

--- a/components/clarinet-deployments/src/onchain/mod.rs
+++ b/components/clarinet-deployments/src/onchain/mod.rs
@@ -708,7 +708,16 @@ pub fn apply_on_chain_deployment(
         };
         while !fetch_initial_nonces && current_block_height < after_block {
             let new_block_height = match stacks_rpc.get_info() {
-                Ok(info) => info.burn_block_height,
+                Ok(info) => {
+                    if info.stacks_tip_height == 0 {
+                        // Always loop if we have not yet seen the genesis block.
+                        std::thread::sleep(std::time::Duration::from_secs(
+                            delay_between_checks.into(),
+                        ));
+                        continue;
+                    }
+                    info.burn_block_height
+                }
                 _ => {
                     std::thread::sleep(std::time::Duration::from_secs(delay_between_checks.into()));
                     continue;

--- a/components/clarinet-deployments/src/types.rs
+++ b/components/clarinet-deployments/src/types.rs
@@ -1,4 +1,5 @@
 use clarinet_files::FileLocation;
+use clarity_repl::clarity::stacks_common::types::StacksEpochId;
 use clarity_repl::clarity::util::hash::{hex_bytes, to_hex};
 use clarity_repl::clarity::vm::analysis::ContractAnalysis;
 use clarity_repl::clarity::vm::ast::ContractAST;
@@ -20,15 +21,22 @@ use std::collections::HashMap;
 
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Copy, Eq, PartialOrd, Ord)]
 pub enum EpochSpec {
+    #[serde(rename = "2.0")]
+    Epoch2_0,
     #[serde(rename = "2.05")]
     Epoch2_05,
     #[serde(rename = "2.1")]
     Epoch2_1,
 }
 
-impl Default for EpochSpec {
-    fn default() -> Self {
-        Self::Epoch2_1
+impl From<StacksEpochId> for EpochSpec {
+    fn from(epoch: StacksEpochId) -> Self {
+        match epoch {
+            StacksEpochId::Epoch20 => EpochSpec::Epoch2_0,
+            StacksEpochId::Epoch2_05 => EpochSpec::Epoch2_05,
+            StacksEpochId::Epoch21 => EpochSpec::Epoch2_1,
+            StacksEpochId::Epoch10 => unreachable!("epoch 1.0 is not supported"),
+        }
     }
 }
 

--- a/components/clarinet-deployments/src/types.rs
+++ b/components/clarinet-deployments/src/types.rs
@@ -18,6 +18,20 @@ use clarity_repl::analysis::ast_dependency_detector::DependencySet;
 use clarity_repl::repl::{Session, DEFAULT_CLARITY_VERSION};
 use std::collections::HashMap;
 
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Copy, Eq, PartialOrd, Ord)]
+pub enum EpochSpec {
+    #[serde(rename = "2.05")]
+    Epoch2_05,
+    #[serde(rename = "2.1")]
+    Epoch2_1,
+}
+
+impl Default for EpochSpec {
+    fn default() -> Self {
+        Self::Epoch2_1
+    }
+}
+
 pub struct DeploymentGenerationArtifacts {
     pub asts: HashMap<QualifiedContractIdentifier, ContractAST>,
     pub deps: HashMap<QualifiedContractIdentifier, DependencySet>,
@@ -43,6 +57,8 @@ pub struct TransactionPlanSpecificationFile {
 pub struct TransactionsBatchSpecificationFile {
     pub id: usize,
     pub transactions: Vec<TransactionSpecificationFile>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub epoch: Option<EpochSpec>,
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
@@ -154,6 +170,7 @@ pub struct EmulatedContractPublishSpecificationFile {
 pub struct TransactionsBatchSpecification {
     pub id: usize,
     pub transactions: Vec<TransactionSpecification>,
+    pub epoch: Option<EpochSpec>,
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -692,6 +709,7 @@ impl DeploymentSpecification {
                         batches.push(TransactionsBatchSpecification {
                             id: batch.id,
                             transactions,
+                            epoch: batch.epoch,
                         });
                     }
                 }
@@ -741,6 +759,7 @@ impl DeploymentSpecification {
                         batches.push(TransactionsBatchSpecification {
                             id: batch.id,
                             transactions,
+                            epoch: batch.epoch,
                         });
                     }
                 }
@@ -1009,6 +1028,7 @@ impl TransactionPlanSpecification {
             batches.push(TransactionsBatchSpecificationFile {
                 id: batch.id,
                 transactions,
+                epoch: batch.epoch,
             });
         }
 

--- a/components/clarity-repl/src/repl/mod.rs
+++ b/components/clarity-repl/src/repl/mod.rs
@@ -60,6 +60,20 @@ impl Serialize for ClarityContract {
                 map.serialize_entry("clarity_version", &2)?;
             }
         }
+        match self.epoch {
+            StacksEpochId::Epoch10 => {
+                map.serialize_entry("epoch", &1.0)?;
+            }
+            StacksEpochId::Epoch20 => {
+                map.serialize_entry("epoch", &2.0)?;
+            }
+            StacksEpochId::Epoch2_05 => {
+                map.serialize_entry("epoch", &2.05)?;
+            }
+            StacksEpochId::Epoch21 => {
+                map.serialize_entry("epoch", &2.1)?;
+            }
+        }
         map.end()
     }
 }

--- a/components/clarity-repl/src/repl/session.rs
+++ b/components/clarity-repl/src/repl/session.rs
@@ -1332,8 +1332,7 @@ mod tests {
 }
 
 async fn fetch_message() -> Result<String, reqwest::Error> {
-    const gist: &str =
-        "https://storage.googleapis.com/hiro-public/assets/clarinet-egg.txt";
+    const gist: &str = "https://storage.googleapis.com/hiro-public/assets/clarinet-egg.txt";
     let response = reqwest::get(gist).await?;
     let message = response.text().await?;
     Ok(message)

--- a/components/stacks-network/src/chains_coordinator.rs
+++ b/components/stacks-network/src/chains_coordinator.rs
@@ -174,8 +174,7 @@ pub async fn start_chains_coordinator(
 
     // Loop over events being received from Bitcoin and Stacks,
     // and orchestrate the 2 chains + protocol.
-    let protocol_deployment_enabled = config.devnet_config.enable_next_features == false;
-    let mut should_deploy_protocol = protocol_deployment_enabled;
+    let mut should_deploy_protocol = true;
     let boot_completed = Arc::new(AtomicBool::new(false));
 
     let mut deployment_events_rx = Some(deployment_events_rx);
@@ -247,7 +246,7 @@ pub async fn start_chains_coordinator(
                 let _ = devnet_event_tx.send(DevnetEvent::BitcoinChainEvent(chain_update.clone()));
             }
             ObserverEvent::StacksChainEvent(chain_event) => {
-                if protocol_deployment_enabled && should_deploy_protocol {
+                if should_deploy_protocol {
                     should_deploy_protocol = false;
 
                     let automining_disabled =
@@ -282,7 +281,7 @@ pub async fn start_chains_coordinator(
                             }
                         },
                     );
-                } else if !protocol_deployment_enabled && !boot_completed.load(Ordering::SeqCst) {
+                } else if !boot_completed.load(Ordering::SeqCst) {
                     boot_completed.store(true, Ordering::SeqCst);
                     let _ =
                         devnet_event_tx.send(DevnetEvent::BootCompleted(mining_command_tx.clone()));


### PR DESCRIPTION
If an `epoch` is specified for a batch of transactions in the deployment
plan, then this batch will not be deployed until that epoch is live.
Note that the batches are still processed in order, so if a batch that
specifies `2.1` is followed by a batch that specifies `2.05`, that
second batch will run in 2.1.

Example:

```yaml
---
id: 0
name: Devnet deployment
network: devnet
stacks-node: "http://localhost:20443"
bitcoin-node: "http://devnet:devnet@localhost:18443"
plan:
  batches:
    - id: 0
      epoch: 2.05
      transactions:
        - contract-publish:
            contract-name: early
            expected-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
            cost: 830
            path: contracts/early.clar
            anchor-block-only: true
    - id: 1
      epoch: 2.1
      transactions:
        - contract-publish:
            contract-name: test
            expected-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
            cost: 1180
            path: contracts/test.clar
            anchor-block-only: true
            clarity-version: 2
```