### PR TITLE
fix: use contracts name as index in deployements

### DIFF
--- a/components/clarinet-deployments/src/lib.rs
+++ b/components/clarinet-deployments/src/lib.rs
@@ -489,10 +489,22 @@ pub async fn generate_default_deployment(
     let mut contracts = HashMap::new();
     let mut contracts_sources = HashMap::new();
 
+    let base_location = manifest.location.clone().get_parent_location()?;
+
     let sources: HashMap<String, String> = match file_accessor {
         None => {
             let mut sources = HashMap::new();
-            for (contract_location, _) in manifest.contracts_settings.iter() {
+            for (_, contract_config) in manifest.contracts.iter() {
+                let mut contract_location = base_location.clone();
+                contract_location
+                    .append_path(&contract_config.expect_contract_path_as_str())
+                    .map_err(|_| {
+                        format!(
+                            "unable to build path for contract {}",
+                            contract_config.expect_contract_path_as_str()
+                        )
+                    })?;
+
                 let source = contract_location.read_content_as_utf8().map_err(|_| {
                     format!(
                         "unable to find contract at {}",
@@ -505,9 +517,15 @@ pub async fn generate_default_deployment(
         }
         Some(file_accessor) => {
             let contracts_location = manifest
-                .contracts_settings
+                .contracts
                 .iter()
-                .map(|(contract_location, _)| contract_location.to_string())
+                .map(|(_, contract_config)| {
+                    let mut contract_location = base_location.clone();
+                    contract_location
+                        .append_path(&contract_config.expect_contract_path_as_str())
+                        .unwrap();
+                    contract_location.to_string()
+                })
                 .collect();
             file_accessor
                 .read_contracts_content(contracts_location)
@@ -515,15 +533,10 @@ pub async fn generate_default_deployment(
         }
     };
 
-    for (contract_location, contract_config) in manifest.contracts_settings.iter() {
-        let contract_name = match ContractName::try_from(contract_config.name.to_string()) {
+    for (name, contract_config) in manifest.contracts.iter() {
+        let contract_name = match ContractName::try_from(name.to_string()) {
             Ok(res) => res,
-            Err(_) => {
-                return Err(format!(
-                    "unable to use {} as a valid contract name",
-                    contract_config.name
-                ))
-            }
+            Err(_) => return Err(format!("unable to use {} as a valid contract name", name)),
         };
 
         let deployer = match &contract_config.deployer {
@@ -550,11 +563,13 @@ pub async fn generate_default_deployment(
             }
         };
 
+        let mut contract_location = base_location.clone();
+        contract_location.append_path(&contract_config.expect_contract_path_as_str())?;
         let source = sources
             .get(&contract_location.to_string())
             .ok_or(format!(
                 "Invalid Clarinet.toml, source file not found for: {}",
-                &contract_config.name
+                &name
             ))?
             .clone();
 
@@ -577,7 +592,7 @@ pub async fn generate_default_deployment(
                     contract_name,
                     emulated_sender: sender,
                     source,
-                    location: contract_location.clone(),
+                    location: contract_location,
                     clarity_version: contract_config.clarity_version,
                 },
             )
@@ -585,7 +600,7 @@ pub async fn generate_default_deployment(
             TransactionSpecification::ContractPublish(ContractPublishSpecification {
                 contract_name,
                 expected_sender: sender,
-                location: contract_location.clone(),
+                location: contract_location,
                 cost: deployment_fee_rate
                     .saturating_mul(source.as_bytes().len().try_into().unwrap()),
                 source,

--- a/components/clarity-lsp/src/common/backend.rs
+++ b/components/clarity-lsp/src/common/backend.rs
@@ -384,7 +384,7 @@ pub fn process_request(command: LspRequest, editor_state: &EditorStateInput) -> 
             let file_url = params.text_document.uri;
             let contract_location = match get_contract_location(&file_url) {
                 Some(contract_location) => contract_location,
-                None => return LspRequestResponse::Hover(None),
+                None => return LspRequestResponse::DocumentSymbol(vec![]),
             };
 
             LspRequestResponse::DocumentSymbol(

--- a/components/clarity-vscode/package.json
+++ b/components/clarity-vscode/package.json
@@ -8,7 +8,7 @@
   "homepage": "https://github.com/hirosystems/clarinet",
   "bugs": "https://github.com/hirosystems/clarinet/issues",
   "license": "GPL-3.0-only",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "workspaces": [
     "client",
     "server",


### PR DESCRIPTION
Address regressions discovered here https://github.com/hirosystems/clarinet/issues/556#issuecomment-1325439110
Fix for Citycoins issue : https://github.com/citycoins/protocol/pull/19#issuecomment-1325431794

This PR reverts a change introduced in https://github.com/citycoins/protocol/pull/19#issuecomment-1325431794
The `manifest.contracts_settings` was introduced because the LSP needed the settings metadata indexed by file location.
But it was necessary to use it in deployments, it even broken it because multiple contracts name can refer to the same file.


Note: I also included a small fix on the LSP e3051c42c375151d907df908f481c307831783a0 (it triggered an error message when clarinet.toml files were opened)