### PR TITLE
fix: support contract deploys in runner

### DIFF
--- a/components/clarinet-cli/src/runner/api_v1.rs
+++ b/components/clarinet-cli/src/runner/api_v1.rs
@@ -856,7 +856,10 @@ fn wrap_result_in_simulated_transaction(
 ) -> StacksTransactionData {
     let result = match execution.result {
         EvaluationResult::Snippet(ref result) => utils::value_to_string(&result.result),
-        _ => unreachable!("Contract result from snippet"),
+        EvaluationResult::Contract(ref contract) => match contract.result {
+            Some(ref result) => utils::value_to_string(result),
+            _ => (&"(ok true)").to_string(),
+        },
     };
     let (txid, _timestamp) = {
         let timestamp = DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(61, 0), Utc);


### PR DESCRIPTION
This allows contract deploys to work in Clarinet tests. Without this, a contract deploy tx would hit the `unreachable` branch.

Here's a simple Clarinet test that works if you use this branch:

```ts
// A simple test for fixing the `deployContract` tx type in Clarinet

import { Clarinet, Tx } from 'https://deno.land/x/clarinet@v1.0.3/index.ts';

Clarinet.test({
  name: 'deploy a contract',
  fn(chain) {
    const deployer = 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM';
    const contractName = 'contract';
    const src = '(define-read-only (test-fn) u123)';
    chain.mineBlock([
      Tx.deployContract(contractName, src, deployer),
    ]);

    const receipt = chain.callReadOnlyFn(contractName, 'test-fn', [], deployer);

    receipt.result.expectUint(123);
  },
});

```