### PR TITLE
chore: update clarity-vscode version

### DIFF
--- a/components/clarity-vscode/package.json
+++ b/components/clarity-vscode/package.json
@@ -8,7 +8,7 @@
   "homepage": "https://github.com/hirosystems/clarinet",
   "bugs": "https://github.com/hirosystems/clarinet/issues",
   "license": "GPL-3.0-only",
-  "version": "1.3.0",
+  "version": "1.2.0",
   "workspaces": [
     "client",
     "server",


### PR DESCRIPTION
My bad, "1.3.0" shouldn't have make it to develop, this version was never released.
Version "1.1.0" was the pre-release and "1.2.0" has been released to VSCE and OVSX