### PR TITLE
feat: ability to set_epoch in repl

### DIFF
--- a/components/clarinet-deployments/src/lib.rs
+++ b/components/clarinet-deployments/src/lib.rs
@@ -130,6 +130,9 @@ pub fn update_session_with_contracts_executions(
 
     let mut results = BTreeMap::new();
     for batch in deployment.plan.batches.iter() {
+        if let Some(spec) = batch.epoch {
+            session.update_epoch(spec.into());
+        }
         for transaction in batch.transactions.iter() {
             match transaction {
                 TransactionSpecification::RequirementPublish(_)

--- a/components/clarinet-deployments/src/types.rs
+++ b/components/clarinet-deployments/src/types.rs
@@ -40,6 +40,16 @@ impl From<StacksEpochId> for EpochSpec {
     }
 }
 
+impl Into<StacksEpochId> for EpochSpec {
+    fn into(self) -> StacksEpochId {
+        match self {
+            EpochSpec::Epoch2_0 => StacksEpochId::Epoch20,
+            EpochSpec::Epoch2_05 => StacksEpochId::Epoch2_05,
+            EpochSpec::Epoch2_1 => StacksEpochId::Epoch21,
+        }
+    }
+}
+
 pub struct DeploymentGenerationArtifacts {
     pub asts: HashMap<QualifiedContractIdentifier, ContractAST>,
     pub deps: HashMap<QualifiedContractIdentifier, DependencySet>,


### PR DESCRIPTION
This PR is completing https://github.com/hirosystems/clarinet/pull/711 which was addressing https://github.com/hirosystems/clarinet/issues/709.
It essentially introduce a `session.currentEpoch` that developers (or deployment plan executor) can update for executing Clarity 2 snippets.
We're using 2.05 as a default epoch.