### PR TITLE
Fix: go to definition iterators

### DIFF
--- a/components/clarity-lsp/src/common/backend.rs
+++ b/components/clarity-lsp/src/common/backend.rs
@@ -416,7 +416,6 @@ pub fn process_request(command: LspRequest, editor_state: &EditorStateInput) -> 
                 Some(contract_location) => contract_location,
                 None => return LspRequestResponse::DocumentSymbol(vec![]),
             };
-
             LspRequestResponse::DocumentSymbol(
                 match editor_state
                     .try_read(|es| es.get_document_symbols_for_contract(&contract_location))

--- a/components/clarity-lsp/src/common/requests/definitions.rs
+++ b/components/clarity-lsp/src/common/requests/definitions.rs
@@ -281,6 +281,37 @@ impl<'a> ASTVisitor<'a> for Definitions {
         true
     }
 
+    fn visit_map(
+        &mut self,
+        expr: &'a SymbolicExpression,
+        func: &'a ClarityName,
+        _sequences: &'a [SymbolicExpression],
+    ) -> bool {
+        self.set_definition_for_arg_at_index(expr, func, 1);
+        true
+    }
+
+    fn visit_filter(
+        &mut self,
+        expr: &'a SymbolicExpression,
+        func: &'a ClarityName,
+        _sequence: &'a SymbolicExpression,
+    ) -> bool {
+        self.set_definition_for_arg_at_index(expr, func, 1);
+        true
+    }
+
+    fn visit_fold(
+        &mut self,
+        expr: &'a SymbolicExpression,
+        func: &'a ClarityName,
+        _sequence: &'a SymbolicExpression,
+        _initial: &'a SymbolicExpression,
+    ) -> bool {
+        self.set_definition_for_arg_at_index(expr, func, 1);
+        true
+    }
+
     fn visit_static_contract_call(
         &mut self,
         expr: &'a SymbolicExpression,
@@ -704,6 +735,42 @@ mod definitions_visitor_tests {
         assert_eq!(
             tokens.get(&(1, 51)),
             Some(&DefinitionLocation::Internal(new_range(0, 25, 0, 35)))
+        );
+    }
+
+    #[test]
+    fn find_definition_in_map() {
+        let tokens =
+            get_tokens("(define-private (double (n int)) (* n 2)) (map double (list 1 2))");
+
+        assert_eq!(tokens.len(), 2);
+        assert_eq!(
+            tokens.get(&(1, 48)),
+            Some(&DefinitionLocation::Internal(new_range(0, 0, 0, 41)))
+        );
+    }
+
+    #[test]
+    fn find_definition_in_filter() {
+        let tokens =
+            get_tokens("(define-private (is-even (n int)) (is-eq (* (/ n 2) 2) n)) (filter is-even (list 0 1 2 3 4 5))");
+
+        assert_eq!(tokens.len(), 3);
+        assert_eq!(
+            tokens.get(&(1, 68)),
+            Some(&DefinitionLocation::Internal(new_range(0, 0, 0, 58)))
+        );
+    }
+
+    #[test]
+    fn find_definition_in_fold() {
+        let tokens =
+            get_tokens("(define-private (sum (a int) (b int)) (+ a b)) (fold sum (list 1 2) 0)");
+
+        assert_eq!(tokens.len(), 3);
+        assert_eq!(
+            tokens.get(&(1, 54)),
+            Some(&DefinitionLocation::Internal(new_range(0, 0, 0, 46)))
         );
     }
 }

--- a/components/clarity-lsp/src/common/state.rs
+++ b/components/clarity-lsp/src/common/state.rs
@@ -312,19 +312,7 @@ impl EditorState {
                 Some(expressions) => expressions,
                 None => return vec![],
             },
-            None => {
-                let analysis = self
-                    .contracts_lookup
-                    .get(contract_location)
-                    .and_then(|c| self.protocols.get(&c.manifest_location))
-                    .and_then(|p| p.contracts.get(contract_location))
-                    .and_then(|c| c.analysis.as_ref());
-
-                match analysis {
-                    Some(analysis) => &analysis.expressions,
-                    None => return vec![],
-                }
-            }
+            None => return vec![],
         };
 
         let ast_symbols = ASTSymbols::new();

--- a/components/clarity-repl/src/analysis/ast_visitor.rs
+++ b/components/clarity-repl/src/analysis/ast_visitor.rs
@@ -144,14 +144,17 @@ pub trait ASTVisitor<'a> {
                             args.get(1).unwrap_or(&DEFAULT_EXPR),
                             args.get(2).unwrap_or(&DEFAULT_EXPR),
                         ),
-                        DefineFunctions::Trait => self.traverse_define_trait(
-                            expr,
-                            args.get(0)
-                                .unwrap_or(&DEFAULT_EXPR)
-                                .match_atom()
-                                .unwrap_or(&DEFAULT_NAME),
-                            &args[1..],
-                        ),
+                        DefineFunctions::Trait => {
+                            let params = if args.len() >= 1 { &args[1..] } else { &[] };
+                            self.traverse_define_trait(
+                                expr,
+                                args.get(0)
+                                    .unwrap_or(&DEFAULT_EXPR)
+                                    .match_atom()
+                                    .unwrap_or(&DEFAULT_NAME),
+                                params,
+                            )
+                        }
                         DefineFunctions::UseTrait => self.traverse_use_trait(
                             expr,
                             args.get(0)
@@ -209,7 +212,8 @@ pub trait ASTVisitor<'a> {
                         Let => {
                             let bindings = match_pairs(args.get(0).unwrap_or(&DEFAULT_EXPR))
                                 .unwrap_or_default();
-                            self.traverse_let(expr, &bindings, &args[1..])
+                            let params = if args.len() >= 1 { &args[1..] } else { &[] };
+                            self.traverse_let(expr, &bindings, params)
                         }
                         ElementAt | ElementAtAlias => self.traverse_element_at(
                             expr,
@@ -227,7 +231,8 @@ pub trait ASTVisitor<'a> {
                                 .unwrap_or(&DEFAULT_EXPR)
                                 .match_atom()
                                 .unwrap_or(&DEFAULT_NAME);
-                            self.traverse_map(expr, name, &args[1..])
+                            let params = if args.len() >= 1 { &args[1..] } else { &[] };
+                            self.traverse_map(expr, name, params)
                         }
                         Fold => {
                             let name = args
@@ -388,6 +393,7 @@ pub trait ASTVisitor<'a> {
                                 .unwrap_or(&DEFAULT_EXPR)
                                 .match_atom()
                                 .unwrap_or(&DEFAULT_NAME);
+                            let params = if args.len() >= 2 { &args[2..] } else { &[] };
                             if let SymbolicExpressionType::LiteralValue(Value::Principal(
                                 PrincipalData::Contract(ref contract_identifier),
                             )) = args.get(0).unwrap_or(&DEFAULT_EXPR).expr
@@ -396,14 +402,14 @@ pub trait ASTVisitor<'a> {
                                     expr,
                                     contract_identifier,
                                     function_name,
-                                    &args[2..],
+                                    params,
                                 )
                             } else {
                                 self.traverse_dynamic_contract_call(
                                     expr,
                                     args.get(0).unwrap_or(&DEFAULT_EXPR),
                                     function_name,
-                                    &args[2..],
+                                    params,
                                 )
                             }
                         }

--- a/components/clarity-vscode/package.json
+++ b/components/clarity-vscode/package.json
@@ -8,7 +8,7 @@
   "homepage": "https://github.com/hirosystems/clarinet",
   "bugs": "https://github.com/hirosystems/clarinet/issues",
   "license": "GPL-3.0-only",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "workspaces": [
     "client",
     "server",


### PR DESCRIPTION
Fix: #725 
The first commit (39867c26e130ddc70aaf8e074e0f865f86cfd965) add go to definition for map, filter and fold methods.

The second one (26c72d44ca62104ff79a9e966543597a69944804) makes safer access to params in ast visitor.