### PR TITLE
fix: safe access to define function params

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1077,6 +1077,7 @@ dependencies = [
  "lsp-types",
  "serde",
  "serde-wasm-bindgen",
+ "serde_json",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",

--- a/components/clarity-lsp/Cargo.toml
+++ b/components/clarity-lsp/Cargo.toml
@@ -7,6 +7,7 @@ version = "1.0.0"
 lazy_static = "1.4.0"
 lsp-types = "0.93.0"
 serde = { version = "1.0.136", features = ["derive"] }
+serde_json = "1.0"
 chainhook_types = { package = "chainhook-types", path = "../chainhook-types-rs" }
 clarinet_files = { package = "clarinet-files", path = "../clarinet-files", default-features = false }
 clarity_repl = { package = "clarity-repl", path = "../clarity-repl", default-features = false, optional = true }

--- a/components/clarity-repl/src/analysis/ast_visitor.rs
+++ b/components/clarity-repl/src/analysis/ast_visitor.rs
@@ -56,9 +56,12 @@ pub trait ASTVisitor<'a> {
                         DefineFunctions::PrivateFunction => {
                             match args.get(0).unwrap_or(&DEFAULT_EXPR).match_list() {
                                 Some(signature) => {
-                                    let name = signature[0].match_atom().unwrap_or(&DEFAULT_NAME);
+                                    let name = signature
+                                        .get(0)
+                                        .and_then(|n| n.match_atom())
+                                        .unwrap_or(&DEFAULT_NAME);
                                     let params = match signature.len() {
-                                        1 => None,
+                                        0 | 1 => None,
                                         _ => match_pairs_list(&signature[1..]),
                                     };
                                     self.traverse_define_private(
@@ -77,9 +80,12 @@ pub trait ASTVisitor<'a> {
                         DefineFunctions::ReadOnlyFunction => {
                             match args.get(0).unwrap_or(&DEFAULT_EXPR).match_list() {
                                 Some(signature) => {
-                                    let name = signature[0].match_atom().unwrap_or(&DEFAULT_NAME);
+                                    let name = signature
+                                        .get(0)
+                                        .and_then(|n| n.match_atom())
+                                        .unwrap_or(&DEFAULT_NAME);
                                     let params = match signature.len() {
-                                        1 => None,
+                                        0 | 1 => None,
                                         _ => match_pairs_list(&signature[1..]),
                                     };
                                     self.traverse_define_read_only(
@@ -95,9 +101,12 @@ pub trait ASTVisitor<'a> {
                         DefineFunctions::PublicFunction => {
                             match args.get(0).unwrap_or(&DEFAULT_EXPR).match_list() {
                                 Some(signature) => {
-                                    let name = signature[0].match_atom().unwrap_or(&DEFAULT_NAME);
+                                    let name = signature
+                                        .get(0)
+                                        .and_then(|n| n.match_atom())
+                                        .unwrap_or(&DEFAULT_NAME);
                                     let params = match signature.len() {
-                                        1 => None,
+                                        0 | 1 => None,
                                         _ => match_pairs_list(&signature[1..]),
                                     };
                                     self.traverse_define_public(

--- a/components/clarity-repl/src/analysis/ast_visitor.rs
+++ b/components/clarity-repl/src/analysis/ast_visitor.rs
@@ -53,7 +53,9 @@ pub trait ASTVisitor<'a> {
                                 .unwrap_or(&DEFAULT_NAME),
                             args.get(1).unwrap_or(&DEFAULT_EXPR),
                         ),
-                        DefineFunctions::PrivateFunction => {
+                        DefineFunctions::PrivateFunction
+                        | DefineFunctions::ReadOnlyFunction
+                        | DefineFunctions::PublicFunction => {
                             match args.get(0).unwrap_or(&DEFAULT_EXPR).match_list() {
                                 Some(signature) => {
                                     let name = signature
@@ -64,57 +66,20 @@ pub trait ASTVisitor<'a> {
                                         0 | 1 => None,
                                         _ => match_pairs_list(&signature[1..]),
                                     };
-                                    self.traverse_define_private(
-                                        expr,
-                                        name,
-                                        params,
-                                        args.get(1).unwrap_or(&DEFAULT_EXPR),
-                                    );
-                                }
-                                _ => {
-                                    false;
-                                }
-                            }
-                            true
-                        }
-                        DefineFunctions::ReadOnlyFunction => {
-                            match args.get(0).unwrap_or(&DEFAULT_EXPR).match_list() {
-                                Some(signature) => {
-                                    let name = signature
-                                        .get(0)
-                                        .and_then(|n| n.match_atom())
-                                        .unwrap_or(&DEFAULT_NAME);
-                                    let params = match signature.len() {
-                                        0 | 1 => None,
-                                        _ => match_pairs_list(&signature[1..]),
-                                    };
-                                    self.traverse_define_read_only(
-                                        expr,
-                                        name,
-                                        params,
-                                        args.get(1).unwrap_or(&DEFAULT_EXPR),
-                                    )
-                                }
-                                _ => false,
-                            }
-                        }
-                        DefineFunctions::PublicFunction => {
-                            match args.get(0).unwrap_or(&DEFAULT_EXPR).match_list() {
-                                Some(signature) => {
-                                    let name = signature
-                                        .get(0)
-                                        .and_then(|n| n.match_atom())
-                                        .unwrap_or(&DEFAULT_NAME);
-                                    let params = match signature.len() {
-                                        0 | 1 => None,
-                                        _ => match_pairs_list(&signature[1..]),
-                                    };
-                                    self.traverse_define_public(
-                                        expr,
-                                        name,
-                                        params,
-                                        args.get(1).unwrap_or(&DEFAULT_EXPR),
-                                    )
+                                    let body = args.get(1).unwrap_or(&DEFAULT_EXPR);
+
+                                    match define_function {
+                                        DefineFunctions::PrivateFunction => {
+                                            self.traverse_define_private(expr, name, params, body)
+                                        }
+                                        DefineFunctions::ReadOnlyFunction => {
+                                            self.traverse_define_read_only(expr, name, params, body)
+                                        }
+                                        DefineFunctions::PublicFunction => {
+                                            self.traverse_define_public(expr, name, params, body)
+                                        }
+                                        _ => unreachable!(),
+                                    }
                                 }
                                 _ => false,
                             }

--- a/components/clarity-vscode/package.json
+++ b/components/clarity-vscode/package.json
@@ -8,7 +8,7 @@
   "homepage": "https://github.com/hirosystems/clarinet",
   "bugs": "https://github.com/hirosystems/clarinet/issues",
   "license": "GPL-3.0-only",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "workspaces": [
     "client",
     "server",
@@ -77,6 +77,26 @@
             ],
             "default": "verbose",
             "description": "Traces the communication between VS Code and the web-extension language server."
+          },
+          "clarity-lsp.completion": {
+            "type": "boolean",
+            "default": true,
+            "description": "Allow auto completion for native and user-defined functions"
+          },
+          "clarity-lsp.hover": {
+            "type": "boolean",
+            "default": true,
+            "description": "Show documentation for native function and keywords on hover"
+          },
+          "clarity-lsp.documentSymbols": {
+            "type": "boolean",
+            "default": false,
+            "description": "Show contract symbols in breadcrumb (beta)"
+          },
+          "clarity-lsp.goToDefinition": {
+            "type": "boolean",
+            "default": true,
+            "description": "Enable go to definition"
           }
         }
       }

--- a/components/clarity-vscode/server/src/common.ts
+++ b/components/clarity-vscode/server/src/common.ts
@@ -16,7 +16,7 @@ export function initConnection(
   connection: Connection,
   bridge: LspVscodeBridge,
 ) {
-  connection.onInitialize(async (params) =>
+  connection.onInitialize((params) =>
     bridge.onRequest(InitializeRequest.method, params),
   );
 


### PR DESCRIPTION
Follow up for #728.
Fix more unsafe access to Slice in AST Visitor.
Plus: allow to disable/enable some LSP features

<img width="571" alt="Screenshot 2022-12-19 at 16 17 44" src="https://user-images.githubusercontent.com/911307/208458803-cea2747e-ef11-49d1-8ca3-e01611c8c472.png">
