### PR TITLE
Add keywords command

### DIFF
--- a/components/clarity-repl/src/repl/session.rs
+++ b/components/clarity-repl/src/repl/session.rs
@@ -703,13 +703,13 @@ impl Session {
     pub fn lookup_functions_or_keywords_docs(&self, exp: &str) -> Option<&String> {
         if let Some(function_doc) = self.api_reference.get(exp) {
             return Some(function_doc);
-        } else {
-            if let Some(keyword_doc) = self.keywords_reference.get(exp) {
-                return Some(keyword_doc);
-            } else {
-                return None;
-            }
         }
+
+        if let Some(keyword_doc) = self.keywords_reference.get(exp) {
+            return Some(keyword_doc);
+        }
+
+        None
     }
 
     pub fn get_api_reference_index(&self) -> Vec<String> {


### PR DESCRIPTION
Fix #477

Added support, in the clarity-repl, for a new command called `keywords`. That command returns the keywords from the Clarity language.

Below some screenshots with the new command and it's usage.

<img width="1083" alt="image" src="https://user-images.githubusercontent.com/13015/208762865-19c4929e-2f9c-4a08-a59e-8f03e7c6caf0.png">

Thanks.