### PR TITLE
fix: change asset title to uSTX

### DIFF
--- a/components/clarity-repl/src/repl/session.rs
+++ b/components/clarity-repl/src/repl/session.rs
@@ -963,8 +963,7 @@ impl Session {
         let accounts = self.interpreter.get_accounts();
         if accounts.len() > 0 {
             let tokens = self.interpreter.get_tokens();
-            let mut headers = vec!["Address".to_string()];
-            headers.append(&mut tokens.clone());
+            let headers = vec!["Address".to_string(), "uSTX".to_string()];
             let mut headers_cells = vec![];
             for header in headers.iter() {
                 headers_cells.push(Cell::new(&header));


### PR DESCRIPTION
Fix #531

Assets values are shown in uSTX unit.