### PR TITLE
fix: docker socket handling

### DIFF
--- a/components/clarinet-files/src/network_manifest.rs
+++ b/components/clarinet-files/src/network_manifest.rs
@@ -121,6 +121,7 @@ pub struct DevnetConfigFile {
     pub epoch_2_05: Option<u64>,
     pub epoch_2_1: Option<u64>,
     pub pox_2_activation: Option<u64>,
+    pub use_docker_gateway_routing: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -237,6 +238,7 @@ pub struct DevnetConfig {
     pub epoch_2_05: u64,
     pub epoch_2_1: u64,
     pub pox_2_activation: u64,
+    pub use_docker_gateway_routing: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -610,6 +612,10 @@ impl NetworkManifest {
                 if let Some(val) = devnet_override.network_id {
                     devnet_config.network_id = Some(val);
                 }
+
+                if let Some(val) = devnet_override.use_docker_gateway_routing {
+                    devnet_config.use_docker_gateway_routing = Some(val);
+                }
             };
 
             let now = clarity_repl::clarity::util::get_epoch_time_secs();
@@ -856,6 +862,9 @@ impl NetworkManifest {
                     .take()
                     .unwrap_or(vec![]),
                 enable_next_features,
+                use_docker_gateway_routing: devnet_config
+                    .use_docker_gateway_routing
+                    .unwrap_or(false),
             };
             if !config.disable_stacks_api && config.disable_stacks_api {
                 config.disable_stacks_api = false;

--- a/components/stacks-devnet-js/lib/index.ts
+++ b/components/stacks-devnet-js/lib/index.ts
@@ -186,13 +186,19 @@ export interface DevnetConfig {
   stacks_explorer_port?: number;
   /**
    * Bind bitcoind and stacks-node data volumes (false by default)
-   * @type {number}
+   * @type {boolean}
    * @memberof DevnetConfig
    */
   bind_containers_volumes?: boolean;
   /**
+   * Have the containers communicating through the gateway (false by default, required for certain docker setup)
+   * @type {boolean}
+   * @memberof DevnetConfig
+   */
+  use_docker_gateway_routing?: boolean;
+  /**
    * Disable Bitcoin automining
-   * @type {number}
+   * @type {boolean}
    * @memberof DevnetConfig
    */
   bitcoin_controller_automining_disabled?: boolean;

--- a/components/stacks-devnet-js/src/lib.rs
+++ b/components/stacks-devnet-js/src/lib.rs
@@ -590,6 +590,13 @@ impl StacksDevnet {
         }
 
         if let Ok(res) = devnet_settings
+            .get(&mut cx, "use_docker_gateway_routing")?
+            .downcast::<JsBoolean, _>(&mut cx)
+        {
+            overrides.use_docker_gateway_routing = Some(res.value(&mut cx));
+        }
+
+        if let Ok(res) = devnet_settings
             .get(&mut cx, "epoch_2_0")?
             .downcast::<JsNumber, _>(&mut cx)
         {

--- a/components/stacks-network/src/orchestrator.rs
+++ b/components/stacks-network/src/orchestrator.rs
@@ -109,39 +109,22 @@ impl DevnetOrchestrator {
         }
 
         let docker_client = match network_config.devnet {
-            Some(ref _devnet) => {
-                #[cfg(target_os = "unix")]
-                let res = if _devnet.docker_host.starts_with("unix://") {
-                    Docker::connect_with_unix(
-                        &_devnet.docker_host,
-                        120,
-                        bollard::API_DEFAULT_VERSION,
-                    )
-                } else {
-                    // By default, when docker is being setup, the installer creates the following symlink
-                    // sudo ln -s /Users/<username>/.docker/run/docker.sock /var/run/docker.sock
-                    // However it looks like users can opt out from this. As such, we try to fallback on
-                    // the home location.
-                    let res = match Docker::connect_with_socket_defaults() {
-                        Ok(client) => Ok(client),
-                        Err(_) => {
-                            let mut user_space_docker_socket =
-                                dirs::home_dir().expect("unable to retrieve homedir");
-                            user_space_docker_socket.push(".docker");
-                            user_space_docker_socket.push("run");
-                            user_space_docker_socket.push("docker.sock");
-                            Docker::connect_with_unix(
-                                &user_space_docker_socket.to_str().unwrap(),
-                                120,
-                                bollard::API_DEFAULT_VERSION,
-                            )
-                        }
-                    };
-                };
-                #[cfg(not(target_os = "unix"))]
-                let res = Docker::connect_with_socket_defaults();
-
-                res.map_err(|e| format!("unable to connect to docker: {:?}", e))?
+            Some(ref devnet) => {
+                Docker::connect_with_socket(&devnet.docker_host, 120, bollard::API_DEFAULT_VERSION)
+                    .or_else(|_| Docker::connect_with_socket_defaults())
+                    .or_else(|_| {
+                        let mut user_space_docker_socket =
+                            dirs::home_dir().expect("unable to retrieve homedir");
+                        user_space_docker_socket.push(".docker");
+                        user_space_docker_socket.push("run");
+                        user_space_docker_socket.push("docker.sock");
+                        Docker::connect_with_socket(
+                            &user_space_docker_socket.to_str().unwrap(),
+                            120,
+                            bollard::API_DEFAULT_VERSION,
+                        )
+                    })
+                    .map_err(|e| format!("unable to connect to docker: {:?}", e))?
             }
             None => unreachable!(),
         };

--- a/components/stacks-network/src/orchestrator.rs
+++ b/components/stacks-network/src/orchestrator.rs
@@ -207,9 +207,7 @@ impl DevnetOrchestrator {
             .and_then(|map| map.get("Gateway"))
             .ok_or("unable to retrieve gateway")?;
 
-        let use_virtual_port_map = false;
-
-        let services_map_hosts = if use_virtual_port_map {
+        let services_map_hosts = if devnet_config.use_docker_gateway_routing {
             ServicesMapHosts {
                 bitcoin_node_host: format!("{}:{}", gateway, devnet_config.bitcoin_node_rpc_port),
                 stacks_node_host: format!("{}:{}", gateway, devnet_config.stacks_node_rpc_port),

--- a/components/stacks-network/src/orchestrator.rs
+++ b/components/stacks-network/src/orchestrator.rs
@@ -8,7 +8,7 @@ use bollard::errors::Error as DockerError;
 use bollard::exec::CreateExecOptions;
 use bollard::image::CreateImageOptions;
 use bollard::models::{HostConfig, PortBinding};
-use bollard::network::{ConnectNetworkOptions, CreateNetworkOptions, PruneNetworksOptions};
+use bollard::network::{CreateNetworkOptions, PruneNetworksOptions};
 use bollard::service::Ipam;
 use bollard::Docker;
 use chainhook_event_observer::utils::Context;
@@ -169,8 +169,14 @@ impl DevnetOrchestrator {
         options.insert("enable_icc".into(), "true".into());
         options.insert("host_binding_ipv4".into(), "0.0.0.0".into());
         options.insert("com.docker.network.bridge.enable_icc".into(), "true".into());
-        options.insert("com.docker.network.bridge.enable_ip_masquerade".into(), "true".into());
-        options.insert("com.docker.network.bridge.host_binding_ipv4".into(), "0.0.0.0".into());
+        options.insert(
+            "com.docker.network.bridge.enable_ip_masquerade".into(),
+            "true".into(),
+        );
+        options.insert(
+            "com.docker.network.bridge.host_binding_ipv4".into(),
+            "0.0.0.0".into(),
+        );
 
         let network_id = docker
             .create_network::<&str>(CreateNetworkOptions {


### PR DESCRIPTION
Improving the best effort to use docker:
- use the socket path specified in the config or use a default path
- use docker defaults settings
- try to use the socket eventually living in `/Users/<name>/.docker/run/docker.sock`