### PR TITLE
Update default Clarity template for new contracts

### DIFF
--- a/components/clarinet-cli/src/generate/contract.rs
+++ b/components/clarinet-cli/src/generate/contract.rs
@@ -41,20 +41,35 @@ impl GetChangesForNewContract {
         } else {
             format!(
                 r#"
-;; {}
-;; <add a description here>
+;; title: {}
+;; version:
+;; summary:
+;; description:
+
+;; traits
+;;
+
+;; token definitions
+;; 
 
 ;; constants
 ;;
 
-;; data maps and vars
+;; data vars
+;;
+
+;; data maps
+;;
+
+;; public functions
+;;
+
+;; read only functions
 ;;
 
 ;; private functions
 ;;
 
-;; public functions
-;;
 "#,
                 self.contract_name
             )


### PR DESCRIPTION
This updates the default template for contracts created with `clarinet contract new` based on the discussion in #730.

In the PR `synopsis` was changed to `summary`, but everything else is the same.

An example of the output after building locally is below:

```bash
> clarinet contract new fancy-contract
Created file contracts/fancy-contract.clar
Created file tests/fancy-contract_test.ts
Updated Clarinet.toml with contract fancy-contract
> cat contracts/fancy-contract.clar
```

```clarity
;; title: fancy-contract
;; version:
;; summary:
;; description:

;; traits
;;

;; token definitions
;; 

;; constants
;;

;; data vars
;;

;; data maps
;;

;; public functions
;;

;; read only functions
;;

;; private functions
;;

```

One thought was to add a suggestion to each item to explain it's usage, but I also like it as a clean slate. Open to feedback!