### PR TITLE
fix: remove warning in `expectPrintEvent`

### DIFF
--- a/components/clarinet-deno/index.ts
+++ b/components/clarinet-deno/index.ts
@@ -209,7 +209,7 @@ export class Chain {
       // @ts-ignore
       Deno.core.opSync("api/v1/switch_epoch", {
         sessionId: this.sessionId,
-        epoch: epoch
+        epoch: epoch,
       })
     );
     return result;
@@ -801,6 +801,7 @@ Array.prototype.expectPrintEvent = function (contractIdentifier, value) {
   for (const event of this) {
     try {
       const { contract_event } = event;
+      if (!contract_event) continue;
       if (!contract_event.topic.endsWith("print")) continue;
       if (!contract_event.value.endsWith(value)) continue;
 
@@ -812,8 +813,7 @@ Array.prototype.expectPrintEvent = function (contractIdentifier, value) {
         topic: contract_event.topic,
         value: contract_event.value,
       };
-    } catch (error) {
-      console.warn(error);
+    } catch (_error) {
       continue;
     }
   }


### PR DESCRIPTION
If you call `expectPrintEvent`, and there are other types of events before the print, then an error will be logged. This warning clutters the logs and made me think the test was failing.