### PR TITLE
fix: update epoch handling 

### DIFF
--- a/components/clarinet-cli/examples/billboard/Clarinet.toml
+++ b/components/clarinet-cli/examples/billboard/Clarinet.toml
@@ -4,5 +4,5 @@ requirements = []
 
 [contracts.billboard]
 path = "contracts/billboard.clar"
-clarity = 1
+clarity_version = 1
 epoch = "2.05"

--- a/components/clarinet-cli/examples/cbtc/Clarinet.toml
+++ b/components/clarinet-cli/examples/cbtc/Clarinet.toml
@@ -9,7 +9,7 @@ contract_id = "SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE.sip-010-trait-ft-standa
 
 [contracts.cbtc-token]
 path = "contracts/cbtc-token.clar"
-clarity = 1
+clarity_version = 1
 epoch = "2.05"
 
 [repl]

--- a/components/clarinet-cli/examples/counter/Clarinet.toml
+++ b/components/clarinet-cli/examples/counter/Clarinet.toml
@@ -9,6 +9,11 @@ path = "contracts/counter.clar"
 clarity_version = 1
 epoch = "2.05"
 
+[contracts.counter-2]
+path = "contracts/counter-v2.clar"
+clarity_version = 2
+epoch = "2.1"
+
 [repl.analysis]
 passes = ["check_checker"]
 check_checker = { trusted_sender = false, trusted_caller = false, callee_filter = false }

--- a/components/clarinet-cli/examples/counter/Clarinet.toml
+++ b/components/clarinet-cli/examples/counter/Clarinet.toml
@@ -6,7 +6,7 @@ telemetry = false
 
 [contracts.counter]
 path = "contracts/counter.clar"
-clarity = 1
+clarity_version = 1
 epoch = "2.05"
 
 [repl.analysis]

--- a/components/clarinet-cli/examples/counter/contracts/counter-v2.clar
+++ b/components/clarinet-cli/examples/counter/contracts/counter-v2.clar
@@ -1,0 +1,19 @@
+
+;; counter
+;; let's get started with smart contracts
+(define-data-var counter uint u1)
+
+(define-public (increment (step uint))
+    (let ((new-val (+ step (var-get counter)))) 
+        (var-set counter new-val)
+        (print { object: "counter", action: "incremented", value: new-val, chain: (slice? "blockstack" u5 u10) })
+        (ok new-val)))
+
+(define-public (decrement (step uint))
+    (let ((new-val (- step (var-get counter)))) 
+        (var-set counter new-val)
+        (print { object: "counter", action: "decremented", value: new-val, chain: (slice? "blockstack" u5 u10) })
+        (ok new-val)))
+
+(define-read-only (read-counter)
+    (ok (var-get counter)))

--- a/components/clarinet-cli/examples/counter/tests/counter_test.ts
+++ b/components/clarinet-cli/examples/counter/tests/counter_test.ts
@@ -12,7 +12,7 @@ Clarinet.test({
             Tx.contractCall("counter", "increment", [types.uint(4)], wallet_1.address),
             Tx.contractCall("counter", "increment", [types.uint(10)], wallet_1.address)
         ]);
-        assertEquals(block.height, 2);
+        assertEquals(block.height, 3);
         block.receipts[0].result
             .expectOk()
             .expectUint(2);
@@ -30,7 +30,7 @@ Clarinet.test({
             Tx.transferSTX(1, wallet_2.address, wallet_1.address),
         ]);
 
-        assertEquals(block.height, 3);
+        assertEquals(block.height, 4);
         block.receipts[0].result
             .expectOk()
             .expectUint(17);
@@ -68,7 +68,7 @@ Clarinet.test({
             Tx.contractCall("counter", "increment", [types.uint(4)], wallet_1.address),
             Tx.contractCall("counter", "increment", [types.uint(10)], wallet_1.address)
         ]);
-        assertEquals(block.height, 102);
+        assertEquals(block.height, 103);
         block.receipts[0].result
             .expectOk()
             .expectUint(2);

--- a/components/clarinet-cli/examples/simple-nft/Clarinet.toml
+++ b/components/clarinet-cli/examples/simple-nft/Clarinet.toml
@@ -5,13 +5,13 @@ cache_dir = "./.cache"
 
 [contracts.simple-nft]
 path = "contracts/simple-nft.clar"
-clarity = 1
+clarity_version = 1
 epoch = "2.05"
 
 # EXTERNAL CONTRACTS
 [contracts.sip-009-trait-ft-standard]
 path = "contracts/external/sip-009-nft-trait-standard.clar"
-clarity = 1
+clarity_version = 1
 epoch = "2.05"
 
 [repl.analysis]

--- a/components/clarinet-cli/src/lsp/mod.rs
+++ b/components/clarinet-cli/src/lsp/mod.rs
@@ -129,7 +129,7 @@ fn test_opening_counter_contract_should_return_fresh_analysis() {
     };
 
     // the counter project should emit 2 warnings and 2 notes coming from counter.clar
-    assert_eq!(response.aggregated_diagnostics.len(), 1);
+    assert_eq!(response.aggregated_diagnostics.len(), 2);
     let (_url, diags) = &response.aggregated_diagnostics[0];
     assert_eq!(diags.len(), 4);
 
@@ -181,7 +181,7 @@ fn test_opening_counter_manifest_should_return_fresh_analysis() {
     };
 
     // the counter project should emit 2 warnings and 2 notes coming from counter.clar
-    assert_eq!(response.aggregated_diagnostics.len(), 1);
+    assert_eq!(response.aggregated_diagnostics.len(), 2);
     let (_url, diags) = &response.aggregated_diagnostics[0];
     assert_eq!(diags.len(), 4);
 

--- a/components/clarinet-deployments/src/lib.rs
+++ b/components/clarinet-deployments/src/lib.rs
@@ -131,11 +131,9 @@ pub fn update_session_with_contracts_executions(
     let mut results = BTreeMap::new();
     for batch in deployment.plan.batches.iter() {
         let epoch: StacksEpochId = match (batch.epoch, forced_epoch) {
-            (Some(epoch), _) => {
-                epoch.into()
-            },
+            (Some(epoch), _) => epoch.into(),
             (None, Some(forced_epoch)) => forced_epoch,
-            _ =>  DEFAULT_EPOCH
+            _ => DEFAULT_EPOCH,
         };
         session.update_epoch(epoch.clone());
         for transaction in batch.transactions.iter() {


### PR DESCRIPTION
It looks like the latest clarity vm fixed an issue related to the epoch handling that requires some updates in clarinet.
Adding a clarity 2 contract in the counter example should help us catching eventual future regressions. 