### PR TITLE
fix: add clarity-repl component

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,17 +1,18 @@
 [workspace]
 members = [
+    "components/chainhook-event-observer",
+    "components/chainhook-node",
+    "components/chainhook-types-rs",
     "components/clarinet-cli",
     "components/clarinet-deployments",
     "components/clarinet-files",
     "components/clarinet-utils",
-    "components/clarity-lsp",
     "components/clarity-jupyter-kernel",
-    "components/stacks-rpc-client",
+    "components/clarity-lsp",
+    "components/clarity-repl",
+    "components/hiro-system-kit",
     "components/stacks-devnet-js",
     "components/stacks-network",
-    "components/chainhook-types-rs",
-    "components/chainhook-event-observer",
-    "components/chainhook-node",
-    "components/hiro-system-kit",
+    "components/stacks-rpc-client",
 ]
 default-members = ["components/clarinet-cli", "components/chainhook-event-observer"]


### PR DESCRIPTION
This PR adds a missing component `clarity-repl` to the main `Cargo.toml` file. The list of components is also re-organized in an alphabetically order.

This PR can be also used to check if the issue #462 is still relevant. If the CI runs automatically, that issue can be closed.