### PR TITLE
fix: avoid expression ID conflict

### DIFF
--- a/components/clarity-repl/src/repl/tracer.rs
+++ b/components/clarity-repl/src/repl/tracer.rs
@@ -24,7 +24,7 @@ impl Tracer {
         println!("{}  {}", snippet, black!("<console>"));
         Tracer {
             snippet,
-            stack: vec![0],
+            stack: vec![u64::MAX],
             pending_call_string: Vec::new(),
             pending_args: Vec::new(),
             emitted_events: 0,


### PR DESCRIPTION
There is a placeholder expression ID inserted for the top-level
instruction which was previously set at 0. It seems that an expression
can have ID 0 during normal evaluation, so instead, use `u64::MAX`.