### PR TITLE
fix: better syntax highlighting for function arguments

### DIFF
--- a/components/clarity-vscode/syntaxes/clarity.tmLanguage.json
+++ b/components/clarity-vscode/syntaxes/clarity.tmLanguage.json
@@ -45,8 +45,6 @@
       },
       "name": "meta.define-function",
       "patterns": [
-        { "include": "#expression" },
-        { "include": "#user-func" },
         {
           "begin": "(?x) (\\() \\s* ([a-zA-Z][a-zA-Z0-9_\\-\\!\\?]*) \\s*",
           "end": "(\\))",
@@ -73,7 +71,9 @@
               "patterns": [{ "include": "#data-type" }]
             }
           ]
-        }
+        },
+        { "include": "#expression" },
+        { "include": "#user-func" }
       ]
     },
     "define-fungible-token": {


### PR DESCRIPTION
When defining a clarity function, the syntax highlighting of the function argument wasn't correct.
Here are some before / after screenshots

---
before
<img width="930" alt="Screenshot 2023-02-17 at 18 04 29" src="https://user-images.githubusercontent.com/911307/219719085-628ebb3e-1c31-4c0b-892b-d66102fc9ac3.png">

---
after
<img width="930" alt="Screenshot 2023-02-17 at 18 03 58" src="https://user-images.githubusercontent.com/911307/219719953-307293bf-3913-4758-b510-f0eec8938672.png">
