### PR TITLE
Close BR tags to resolve docs compilation error

### DIFF
--- a/docs/feature-guides/clarinet-deploy.md
+++ b/docs/feature-guides/clarinet-deploy.md
@@ -16,7 +16,7 @@ You can commit, audit, and test contracts without including any secrets in the D
 
 | Transaction primitive | Typical usage |
 |---|---|
-| publish contracts | - deploy a contract to an in-memory simulated Stacks chain or an integrate Stacks-Bitcoin environment <br> - deploy to a public testnet or mainnet <br> - deploy an external contract to your local network for testing |
+| publish contracts | - deploy a contract to an in-memory simulated Stacks chain or an integrate Stacks-Bitcoin environment <br /> - deploy to a public testnet or mainnet <br /> - deploy an external contract to your local network for testing |
 | call contract functions | - call a contract deployed to any of your local devnets or public networks, chain transactions |
 | send BTC | - Perform a simple bitcoin transfer from a p2pkh address to a p2pkh address (devnet/testnet/mainnet)  |
 | wait for block | - Test or automate contract deployment across multiple Stacks or Bitcoin blocks  |


### PR DESCRIPTION
Without it, I run into the following errors when compiling docs. 

>SyntaxError: /Users/sabbyanandan/hiro/docs/docs/clarinet/feature-guides/clarinet-deploy.md: Expected corresponding JSX closing tag for <br>. (24:267)
  22 | <tr parentName="tbody">
  23 | <td parentName="tr" {...{"align":null}}>{`publish contracts`}</td>
> 24 | <td parentName="tr" {...{"align":null}}>{`- deploy a contract to an in-memory simulated Stacks chain or an integrate Stacks-Bitcoin environment `}<br>{` - deploy to a public testnet or mainnet `}<br>{` - deploy an external contract to your local network for testing`}</td>
     |                                                                                                                                                                                                                                                                            ^
  25 | </tr>
  26 | <tr parentName="tbody">
  27 | <td parentName="tr" {...{"align":null}}>{`call contract functions`}</td>
[ERROR] Client bundle compiled with errors therefore further build is impossible.