### PR TITLE
Fix: lsp: better handling of clarity version

### DIFF
--- a/components/clarity-repl/Cargo.toml
+++ b/components/clarity-repl/Cargo.toml
@@ -38,7 +38,7 @@ rand_pcg = "0.3.1"
 rand_seeder = "0.2.2"
 atty = "0.2.14"
 clarity-vm = { version = "=2.0.1", default-features = false, optional = true }
-# clarity = { path = "../../../stacks-blockchain/clarity", default-features = false, optional = true }
+# clarity-vm = { path = "../../../stacks-blockchain/clarity", default-features = false, optional = true }
 
 # DAP Debugger
 tokio = { version = "1.24", features = ["full"], optional = true }

--- a/components/clarity-vscode/test-data/simple/Clarinet.toml
+++ b/components/clarity-vscode/test-data/simple/Clarinet.toml
@@ -13,6 +13,12 @@ clarity_version = 1
 [contracts.counter]
 path = "contracts/counter.clar"
 clarity_version = 2
+epoch = 2.1
+
+[contracts.empty]
+path = "contracts/empty.clar"
+clarity_version = 2
+epoch = 2.1
 
 [repl.analysis]
 passes = ["check_checker"]

--- a/components/clarity-vscode/test-data/simple/contracts/counter.clar
+++ b/components/clarity-vscode/test-data/simple/contracts/counter.clar
@@ -23,3 +23,5 @@
     (ok (var-get counter))
   )
 )
+
+(contract-call? .contract get-counter)

--- a/components/clarity-vscode/test-data/test-cases/Clarinet.toml
+++ b/components/clarity-vscode/test-data/test-cases/Clarinet.toml
@@ -13,17 +13,17 @@ contract_id = 'SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE.sip-010-trait-ft-standa
 [contracts.bns]
 path = 'contracts/bns.clar'
 clarity_version = 2
-epoch = 2.0
+epoch = 2.1
 
 [contracts.contract]
 path = 'contracts/contract.clar'
 clarity_version = 2
-epoch = 2.0
+epoch = 2.1
 
 [contracts.ft-project]
 path = 'contracts/ft-project.clar'
 clarity_version = 2
-epoch = 2.0
+epoch = 2.1
 
 [contracts.iterators]
 path = 'contracts/iterators.clar'
@@ -33,7 +33,8 @@ epoch = 2.0
 [contracts.nft-project]
 path = 'contracts/nft-project.clar'
 clarity_version = 2
-epoch = 2.0
+epoch = 2.1
+
 [repl.analysis]
 passes = ['check_checker']
 


### PR DESCRIPTION
The issue was that contracts with no analysis (so empty contracts or contracts with no functions defined) would default to `CLARITY_DEFAULT_VERSION`.
This default value would then be cascaded to the `active_contract_metadata` (for contracts currently opened in the editor) [here](https://github.com/hirosystems/clarinet/blob/develop/components/clarity-lsp/src/common/state.rs#L247-L249). Thus, ignoring the version specified in the manifest