### PR TITLE
test: improvements to the generated unit tests

### DIFF
--- a/components/clarinet-cli/src/generate/contract.rs
+++ b/components/clarinet-cli/src/generate/contract.rs
@@ -100,23 +100,23 @@ import {{ assertEquals }} from 'https://deno.land/std@0.170.0/testing/asserts.ts
 Clarinet.test({{
     name: "Ensure that <...>",
     async fn(chain: Chain, accounts: Map<string, Account>) {{
+        // arrange: set up the chain, state, and other required elements
+        let wallet_1 = accounts.get("wallet_1").unwrap();
+
+        // act: perform actions related to the current test
         let block = chain.mineBlock([
             /*
              * Add transactions with:
              * Tx.contractCall(...)
             */
         ]);
+
+        // assert: review returned data, contract state, and other requirements
         assertEquals(block.receipts.length, 0);
         assertEquals(block.height, 2);
 
-        block = chain.mineBlock([
-            /*
-             * Add transactions with:
-             * Tx.contractCall(...)
-            */
-        ]);
-        assertEquals(block.receipts.length, 0);
-        assertEquals(block.height, 3);
+        // TODO
+        assertEquals("TODO", "a complete test");
     }},
 }});
 "#,


### PR DESCRIPTION
These ideas come from @whoabuddy and the CityCoins project. The TODO
assertion adds a nice visual reminder to add new tests if the user runs
`clarinet test` with the default tests. The "arrange, act, assert" is a
nice pattern for organizing these tests.