### PR TITLE
Make debug codec module public

### DIFF
--- a/components/clarity-repl/src/repl/debug/dap/mod.rs
+++ b/components/clarity-repl/src/repl/debug/dap/mod.rs
@@ -33,7 +33,7 @@ use self::codec::{DebugAdapterCodec, ParseError};
 
 use super::DebugState;
 
-mod codec;
+pub mod codec;
 
 /*
  * DAP Session:


### PR DESCRIPTION
Hello! Really cool project, thanks for this! This is seemingly the only DAP adaptor implementation written in Rust (at least according to sourcegraph)!

AFAICT clarinet has implemented the DAP adapter communication layer.  Unfortunately, the `DebugAdapterCodec` struct is private. Would yall be willing to make it `pub` so I can depend on it? I'm trying to write an [adapter](https://github.com/DieracDelta/nix-debug-adapter), and specifically that codec is quite useful 😅 

It would actually be really great if that codec file was its own (admittedly small) crate. That way much less dependencies would be brought in for other dap adaptors written in rust.