### PR TITLE
fix: resolve panic when generating completions

### DIFF
--- a/components/clarinet-cli/src/frontend/cli.rs
+++ b/components/clarinet-cli/src/frontend/cli.rs
@@ -68,7 +68,7 @@ use super::telemetry::{telemetry_report_event, DeveloperUsageDigest, DeveloperUs
 /// For Clarinet documentation, refer to https://docs.hiro.so/clarinet/introduction.
 /// Report any issues here https://github.com/hirosystems/clarinet/issues/new.
 #[derive(Parser, PartialEq, Clone, Debug)]
-#[clap(version = option_env!("CARGO_PKG_VERSION").expect("Unable to detect version"), name = "clarinet")]
+#[clap(version = option_env!("CARGO_PKG_VERSION").expect("Unable to detect version"), name = "clarinet", bin_name = "clarinet")]
 struct Opts {
     #[clap(subcommand)]
     command: Command,


### PR DESCRIPTION
```
$ clarinet completions bash
thread 'main' panicked at 'crate::generate should have set the bin_name', /Users/brice/.cargo/registry/src/github.com-1ecc6299db9ec823/clap_complete-3.2.5/src/shells/bash.rs:17:24
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```