### PR TITLE
fix: circular dependencies in deployments

### DIFF
--- a/components/clarinet-deployments/src/lib.rs
+++ b/components/clarinet-deployments/src/lib.rs
@@ -357,9 +357,10 @@ pub async fn generate_default_deployment(
             queue.push_front((contract_id, epoch, clarity_version));
         }
 
+        let mut already_added_contracts: Vec<QualifiedContractIdentifier> = vec![];
+
         while let Some((contract_id, epoch, clarity_version)) = queue.pop_front() {
-            // Extract principal from contract_id
-            if requirements_deps.contains_key(&contract_id) {
+            if already_added_contracts.contains(&contract_id) {
                 continue;
             }
 
@@ -452,6 +453,7 @@ pub async fn generate_default_deployment(
                                 clarity_version.clone(),
                             ));
                         }
+                        already_added_contracts.push(contract_id.clone());
                         requirements_deps.insert(contract_id.clone(), dependencies);
                         requirements_asts.insert(contract_id.clone(), ast);
                         break;
@@ -470,6 +472,7 @@ pub async fn generate_default_deployment(
                             ));
                         }
                     }
+                    already_added_contracts.push(contract_id.clone());
                     requirements_asts.insert(contract_id.clone(), ast);
                     queue.push_front((contract_id, epoch, clarity_version));
 

--- a/components/clarinet-deployments/src/lib.rs
+++ b/components/clarinet-deployments/src/lib.rs
@@ -31,7 +31,7 @@ use clarity_repl::clarity::vm::ExecutionResult;
 use clarity_repl::repl::session::BOOT_CONTRACTS_DATA;
 use clarity_repl::repl::Session;
 use clarity_repl::repl::SessionSettings;
-use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
 use types::DeploymentGenerationArtifacts;
 use types::RequirementPublishSpecification;
 use types::TransactionSpecification;
@@ -357,10 +357,10 @@ pub async fn generate_default_deployment(
             queue.push_front((contract_id, epoch, clarity_version));
         }
 
-        let mut already_added_contracts: Vec<QualifiedContractIdentifier> = vec![];
+        let mut already_added_contracts = HashSet::new();
 
         while let Some((contract_id, epoch, clarity_version)) = queue.pop_front() {
-            if already_added_contracts.contains(&contract_id) {
+            if already_added_contracts.contains(&contract_id.to_string()) {
                 continue;
             }
 
@@ -453,7 +453,7 @@ pub async fn generate_default_deployment(
                                 clarity_version.clone(),
                             ));
                         }
-                        already_added_contracts.push(contract_id.clone());
+                        already_added_contracts.insert(contract_id.to_string());
                         requirements_deps.insert(contract_id.clone(), dependencies);
                         requirements_asts.insert(contract_id.clone(), ast);
                         break;
@@ -472,7 +472,7 @@ pub async fn generate_default_deployment(
                             ));
                         }
                     }
-                    already_added_contracts.push(contract_id.clone());
+                    already_added_contracts.insert(contract_id.to_string());
                     requirements_asts.insert(contract_id.clone(), ast);
                     queue.push_front((contract_id, epoch, clarity_version));
 


### PR DESCRIPTION
Fix #980 

In case of circular dependency in unknown dependencies, like there is between [.alex-vault](https://explorer.hiro.so/txid/0x68e84359d36530fb71b47573796a4732651dcc5b766d2818e6f6b3e3d593e3e4?chain=mainnet) and [.fixed-weight-pool](https://explorer.hiro.so/txid/0x608734b7a5b09f90780ebd8a141f3254e5c06ea160c27c7f5157d50236a6cf90?chain=mainnet), we run into an infinite loop to handle requirements. 

The issue says that it used to work before, but I wasn't able to find at which point we broke it.

This is a naive implementation to patch it