### PR TITLE
fix: default genesis time to 0 in wasm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -721,9 +721,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.23"
+version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
+checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -1090,6 +1090,7 @@ dependencies = [
  "ansi_term",
  "atty",
  "bytes",
+ "chrono",
  "clarity-vm",
  "debug_types",
  "futures",

--- a/components/clarity-repl/Cargo.toml
+++ b/components/clarity-repl/Cargo.toml
@@ -22,6 +22,7 @@ categories = [
 
 [dependencies]
 ansi_term = "0.12.1"
+chrono = "0.4.24"
 lazy_static = "1.4.0"
 regex = "1.7"
 serde = { version = "1.0", features = ["derive"] }

--- a/components/clarity-repl/src/repl/datastore.rs
+++ b/components/clarity-repl/src/repl/datastore.rs
@@ -21,7 +21,6 @@ use clarity::vm::EvalHook;
 use clarity::vm::StacksEpoch;
 use std::collections::HashMap;
 use std::hash::Hash;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 #[derive(Clone, Debug)]
 pub struct Datastore {
@@ -294,10 +293,7 @@ impl BurnDatastore {
         let bytes = height_to_hashed_bytes(0);
         let id = StacksBlockId(bytes.clone());
         let sortition_id = SortitionId(bytes);
-        let genesis_time = match SystemTime::now().duration_since(UNIX_EPOCH) {
-            Ok(now) => now.as_secs(),
-            Err(_) => 0,
-        };
+        let genesis_time = chrono::Utc::now().timestamp() as u64;
 
         let genesis_block = BlockInfo {
             block_header_hash: BlockHeaderHash([0x00; 32]),


### PR DESCRIPTION
`std::time` is not available in the browser.
It was introduced in https://github.com/hirosystems/clarinet/pull/963
`panicked at 'time not implemented on this platform'`
We missed the error because it happens at runtime (and not at compile time)
