### PR TITLE
Fix/lsp initial configuration

### DIFF
--- a/components/clarity-lsp/src/common/backend.rs
+++ b/components/clarity-lsp/src/common/backend.rs
@@ -380,10 +380,10 @@ pub fn process_mutating_request(
 ) -> Result<LspRequestResponse, String> {
     match command {
         LspRequest::Initialize(params) => {
-            let initialization_options: InitializationOptions = params
+            let initialization_options = params
                 .initialization_options
                 .and_then(|o| serde_json::from_str(o.as_str()?).ok())
-                .expect("failed to parse initialization options");
+                .unwrap_or(InitializationOptions::default());
 
             match editor_state.try_write(|es| es.settings = initialization_options.clone()) {
                 Ok(_) => Ok(LspRequestResponse::Initialize(InitializeResult {

--- a/components/clarity-lsp/src/common/requests/capabilities.rs
+++ b/components/clarity-lsp/src/common/requests/capabilities.rs
@@ -17,6 +17,20 @@ pub struct InitializationOptions {
     signature_help: bool,
 }
 
+impl InitializationOptions {
+    pub fn default() -> Self {
+        InitializationOptions {
+            completion: true,
+            completion_smart_parenthesis_wrap: true,
+            completion_include_native_placeholders: true,
+            document_symbols: false,
+            go_to_definition: true,
+            hover: true,
+            signature_help: true,
+        }
+    }
+}
+
 pub fn get_capabilities(initialization_options: &InitializationOptions) -> ServerCapabilities {
     ServerCapabilities {
         text_document_sync: Some(TextDocumentSyncCapability::Options(


### PR DESCRIPTION
fix #986 

The LSP server expect well formed `InitializationOptions`. Which are sent by the VSCode extension.
But other LSP clients (in noevim or sublime for instance) might send no options or an empty object `{}` by default.
This PR addresses it