### PR TITLE
fix: handle clarity-version in the dependency detector

### DIFF
--- a/components/clarity-repl/src/repl/interpreter.rs
+++ b/components/clarity-repl/src/repl/interpreter.rs
@@ -240,7 +240,7 @@ impl ClarityInterpreter {
         }
 
         let mut contract_map = BTreeMap::new();
-        contract_map.insert(contract_id.clone(), ast);
+        contract_map.insert(contract_id.clone(), (contract.clarity_version, ast));
         let mut all_dependencies =
             match ASTDependencyDetector::detect_dependencies(&contract_map, &BTreeMap::new()) {
                 Ok(dependencies) => dependencies,


### PR DESCRIPTION
In Clarity 1 it was possible to have duplicated functions in trait declarations. It now illegal in Clarity 2.

But when requiring a trait from mainnet that does exploit this bug, clarinet has to handle it.
In the dependency detector, we thought it would be safe to default to Clarity2 for requirements. In this case (requiring a trait with duplicated function), it isn't.

Ideally, we'll want to do the same the EPOCH (avoid default epoch in dependency detector) (to be done in this PR or a future one)

This PR also revers the changes from #985