### PR TITLE
Fix/syntax hightlighting

### DIFF
--- a/components/clarity-vscode/syntaxes/clarity.tmLanguage.json
+++ b/components/clarity-vscode/syntaxes/clarity.tmLanguage.json
@@ -48,7 +48,7 @@
         { "include": "#expression" },
         { "include": "#user-func" },
         {
-          "begin": "(?x) (\\() \\s* ([a-zA-Z][a-zA-Z0-9_\\-\\!\\?]*) \\s*",
+          "begin": "(?x) (\\() \\s* ([a-zA-Z][\\w\\?\\!\\-]*) \\s*",
           "end": "(\\))",
           "beginCaptures": {
             "1": { "name": "punctuation.function-signature.start.clarity" },
@@ -60,7 +60,7 @@
           "name": "meta.define-function-signature",
           "patterns": [
             {
-              "begin": "(?x) (\\() \\s* ([a-zA-Z][a-zA-Z0-9_\\-\\!\\?]*) \\s+",
+              "begin": "(?x) (\\() \\s* ([a-zA-Z][\\w\\?\\!\\-]*) \\s+",
               "end": "(\\))",
               "beginCaptures": {
                 "1": { "name": "punctuation.function-argument.start.clarity" },
@@ -77,7 +77,7 @@
       ]
     },
     "define-fungible-token": {
-      "match": "(?x) (\\() \\s* (define-fungible-token) \\s+ ([a-zA-Z][a-zA-Z0-9_\\-\\!\\?]*) (?:\\s+(u\\d+))?",
+      "match": "(?x) (\\() \\s* (define-fungible-token) \\s+ ([a-zA-Z][\\w\\?\\!\\-]*) (?:\\s+(u\\d+))?",
       "captures": {
         "1": { "name": "punctuation.define-fungible-token.start.clarity" },
         "2": { "name": "keyword.declaration.define-fungible-token.clarity" },
@@ -89,7 +89,7 @@
       }
     },
     "define-non-fungible-token": {
-      "begin": "(?x) (\\() \\s* (define-non-fungible-token) \\s+ ([a-zA-Z][a-zA-Z0-9_\\-\\!\\?]*) \\s+",
+      "begin": "(?x) (\\() \\s* (define-non-fungible-token) \\s+ ([a-zA-Z][\\w\\?\\!\\-]*) \\s+",
       "end": "(\\))",
       "beginCaptures": {
         "1": { "name": "punctuation.define-non-fungible-token.start.clarity" },
@@ -107,7 +107,7 @@
       "patterns": [{ "include": "#data-type" }]
     },
     "define-trait": {
-      "begin": "(?x) (\\() \\s* (define-trait) \\s+ ([a-zA-Z][a-zA-Z0-9_\\-\\!\\?]*) \\s+",
+      "begin": "(?x) (\\() \\s* (define-trait) \\s+ ([a-zA-Z][\\w\\?\\!\\-]*) \\s+",
       "end": "(\\))",
       "beginCaptures": {
         "1": { "name": "punctuation.define-trait.start.clarity" },
@@ -132,12 +132,12 @@
           "patterns": [
             { "include": "#expression" },
             {
-              "begin": "(?x) (\\() \\s* ([a-zA-Z][a-zA-Z0-9_\\-\\!\\?]+\\??) \\s+",
+              "begin": "(?x) (\\() \\s* ([a-zA-Z][\\w\\!\\?\\-]*) \\s+",
               "end": "(\\))",
               "beginCaptures": {
                 "1": { "name": "punctuation.trait-function.start.clarity" },
                 "2": {
-                  "name": "entity.name.trait-function-name.clarity variable.other.clarity"
+                  "name": "entity.name.function.clarity"
                 }
               },
               "endCaptures": {
@@ -169,7 +169,7 @@
       ]
     },
     "use-trait": {
-      "begin": "(?x) (\\() \\s* (use-trait) \\s+ ([a-zA-Z][a-zA-Z0-9_\\-\\!\\?]*) \\s+",
+      "begin": "(?x) (\\() \\s* (use-trait) \\s+ ([a-zA-Z][\\w\\?\\!\\-]*) \\s+",
       "end": "(\\))",
       "beginCaptures": {
         "1": { "name": "punctuation.use-trait.start.clarity" },
@@ -185,7 +185,7 @@
       "patterns": [{ "include": "#literal" }]
     },
     "define-constant": {
-      "begin": "(?x) (\\() \\s* (define-constant) \\s+ ([a-zA-Z][a-zA-Z0-9_\\-\\!\\?]*) \\s+",
+      "begin": "(?x) (\\() \\s* (define-constant) \\s+ ([a-zA-Z][\\w\\?\\!\\-]*) \\s+",
       "end": "(\\))",
       "beginCaptures": {
         "1": { "name": "punctuation.define-constant.start.clarity" },
@@ -201,7 +201,7 @@
       "patterns": [{ "include": "#expression" }]
     },
     "define-data-var": {
-      "begin": "(?x) (\\() \\s* (define-data-var) \\s+ ([a-zA-Z][a-zA-Z0-9_\\-\\!\\?]*) \\s+",
+      "begin": "(?x) (\\() \\s* (define-data-var) \\s+ ([a-zA-Z][\\w\\?\\!\\-]*) \\s+",
       "end": "(\\))",
       "beginCaptures": {
         "1": { "name": "punctuation.define-data-var.start.clarity" },
@@ -217,7 +217,7 @@
       "patterns": [{ "include": "#data-type" }, { "include": "#expression" }]
     },
     "define-map": {
-      "begin": "(?x) (\\() \\s* (define-map) \\s+ ([a-zA-Z][a-zA-Z0-9_\\-\\!\\?]*) \\s+",
+      "begin": "(?x) (\\() \\s* (define-map) \\s+ ([a-zA-Z][\\w\\?\\!\\-]*) \\s+",
       "end": "(\\))",
       "beginCaptures": {
         "1": { "name": "punctuation.define-map.start.clarity" },
@@ -300,7 +300,7 @@
           "patterns": [
             {
               "name": "entity.name.tag.tuple-key.clarity",
-              "match": "([a-zA-Z][a-zA-Z0-9_\\-\\!\\?]*)(?=:)"
+              "match": "([a-zA-Z][\\w\\?\\!\\-]*)(?=:)"
             },
             { "include": "#expression" },
             { "include": "#user-func" }
@@ -386,10 +386,10 @@
         {
           "match": "(?x) (\\() \\s* (?:(string-ascii|string-utf8)\\s+(\\d+)) \\s* (\\))",
           "captures": {
-            "1": { "name": "punctuation.string-def.start.clarity" },
-            "2": { "name": "entity.name.type.string.clarity" },
-            "3": { "name": "constant.numeric.string-len.clarity" },
-            "4": { "name": "punctuation.string-def.end.clarity" }
+            "1": { "name": "punctuation.string_type-def.start.clarity" },
+            "2": { "name": "entity.name.type.string_type.clarity" },
+            "3": { "name": "constant.numeric.string_type-len.clarity" },
+            "4": { "name": "punctuation.string_type-def.end.clarity" }
           }
         },
         {
@@ -457,7 +457,7 @@
           "patterns": [
             {
               "name": "entity.name.tag.tuple-data-type-key.clarity",
-              "match": "([a-zA-Z][a-zA-Z0-9_\\-\\!\\?]*)(?=:)"
+              "match": "([a-zA-Z][\\w\\?\\!\\-]*)(?=:)"
             },
             { "include": "#data-type" }
           ]
@@ -479,7 +479,7 @@
     },
     "get-set-func": {
       "name": "meta.get-set-func",
-      "begin": "(?x) (\\() \\s* (var-get|var-set|map-get\\?|map-set|map-insert|map-delete|get) \\s+ ([a-zA-Z][a-zA-Z0-9_\\-\\!\\?]*) \\s*",
+      "begin": "(?x) (\\() \\s* (var-get|var-set|map-get\\?|map-set|map-insert|map-delete|get) \\s+ ([a-zA-Z][\\w\\?\\!\\-]*) \\s*",
       "end": "(\\))",
       "beginCaptures": {
         "1": { "name": "punctuation.get-set-func.start.clarity" },
@@ -517,7 +517,7 @@
           "name": "meta.let-var",
           "patterns": [
             {
-              "begin": "(?x) (\\() ([a-zA-Z][a-zA-Z0-9_\\-\\!\\?]*) \\s+",
+              "begin": "(?x) (\\() ([a-zA-Z][\\w\\?\\!\\-]*) \\s+",
               "end": "(\\))",
               "beginCaptures": {
                 "1": { "name": "punctuation.let-local-var.start.clarity" },
@@ -540,7 +540,7 @@
       ]
     },
     "user-func": {
-      "begin": "(?x) (\\() \\s* (([a-zA-Z][a-zA-Z0-9_\\-\\!\\?]*)) \\s*",
+      "begin": "(?x) (\\() \\s* (([a-zA-Z][\\w\\?\\!\\-]*)) \\s*",
       "end": "(\\))",
       "beginCaptures": {
         "1": { "name": "punctuation.user-function.start.clarity" },

--- a/components/clarity-vscode/syntaxes/clarity.tmLanguage.json
+++ b/components/clarity-vscode/syntaxes/clarity.tmLanguage.json
@@ -31,7 +31,7 @@
     },
     "keyword": {
       "name": "constant.language.clarity",
-      "match": "\\b(?:block-height|burn-block-height|chain-id|contract-caller|is-in-regtest|stx-liquid-supply|tx-sender|tx-sponsor?)\\b"
+      "match": "(?<!\\S)(?!-)\\b(?:block-height|burn-block-height|chain-id|contract-caller|is-in-regtest|stx-liquid-supply|tx-sender|tx-sponsor?)\\b(?!\\s*-)"
     },
     "define-function": {
       "begin": "(?x) (\\() \\s* (define-(?:public|private|read-only)) \\s+",
@@ -247,23 +247,23 @@
             {
               "comment": "unsigned integers",
               "name": "constant.numeric.uint.clarity",
-              "match": "\\bu\\d+\\b"
+              "match": "(?<!\\S)(?!-)\\bu\\d+\\b(?!\\s*-)"
             },
             {
               "comment": "signed integers",
               "name": "constant.numeric.int.clarity",
-              "match": "\\b\\d+\\b"
+              "match": "(?<!\\S)(?!-)\\b\\d+\\b(?!\\s*-)"
             },
             {
               "comment": "hexadecimals",
               "name": "constant.numeric.hex.clarity",
-              "match": "\\b0x[0-9a-f]*\\b"
+              "match": "(?<!\\S)(?!-)\\b0x[0-9a-f]*\\b(?!\\s*-)"
             }
           ]
         },
         "bool-literal": {
           "name": "constant.language.bool.clarity",
-          "match": "\\b(true|false)\\b"
+          "match": "(?<!\\S)(?!-)\\b(true|false)\\b(?!\\s*-)"
         },
         "string-literal": {
           "patterns": [
@@ -329,7 +329,7 @@
         "optional-literal": {
           "patterns": [
             {
-              "match": "\\b(none)\\b",
+              "match": "(?<!\\S)(?!-)\\b(none)\\b(?!\\s*-)",
               "name": "constant.language.none.clarity"
             },
             {

--- a/components/clarity-vscode/syntaxes/clarity.tmLanguage.json
+++ b/components/clarity-vscode/syntaxes/clarity.tmLanguage.json
@@ -46,7 +46,6 @@
       "name": "meta.define-function",
       "patterns": [
         { "include": "#expression" },
-        { "include": "#user-func" },
         {
           "begin": "(?x) (\\() \\s* ([a-zA-Z][\\w\\?\\!\\-]*) \\s*",
           "end": "(\\))",
@@ -73,7 +72,8 @@
               "patterns": [{ "include": "#data-type" }]
             }
           ]
-        }
+        },
+        { "include": "#user-func" }
       ]
     },
     "define-fungible-token": {

--- a/components/clarity-vscode/test-data/test-cases/Clarinet.toml
+++ b/components/clarity-vscode/test-data/test-cases/Clarinet.toml
@@ -35,6 +35,11 @@ path = 'contracts/nft-project.clar'
 clarity_version = 2
 epoch = 2.1
 
+[contracts.syntax-highlighting-test]
+path = 'contracts/syntax-highlighting-test.clar'
+clarity_version = 2
+epoch = 2.1
+
 [repl.analysis]
 passes = ['check_checker']
 

--- a/components/clarity-vscode/test-data/test-cases/contracts/syntax-highlighting-test.clar
+++ b/components/clarity-vscode/test-data/test-cases/contracts/syntax-highlighting-test.clar
@@ -46,4 +46,29 @@
 (define-read-only (test-err) (ok (err u1)))
 (test-err)
 
+(define-read-only (test-func?) (ok true))
 
+(define-read-only (test-func!) (ok true))
+
+(define-fungible-token my-token!)
+(define-fungible-token my-token?)
+(define-fungible-token my-token)
+
+(define-data-var accounts! uint u0)
+(var-set accounts! u1)
+(var-get accounts!)
+(define-data-var accounts? uint u0)
+(var-set accounts? u1)
+(var-get accounts?)
+
+
+(define-trait ccd006-citycoin-mining-trait
+  (
+    (mine ((string-ascii 10) (list 200 uint))
+      (response bool uint)
+    )
+    (claim-mining-reward ((string-ascii 10) uint)
+      (response bool uint)
+    )
+  )
+)

--- a/components/clarity-vscode/test-data/test-cases/contracts/syntax-highlighting-test.clar
+++ b/components/clarity-vscode/test-data/test-cases/contracts/syntax-highlighting-test.clar
@@ -1,0 +1,49 @@
+(define-private (tst
+  (test-block-height uint)
+  (test-false uint)
+  (false-test uint)
+  (test-none uint)
+  (none-false uint)
+  (test-none uint)
+  (block-height-test uint)
+  (test-tx-sender uint)
+  (test-3 uint)
+  (test-u3 uint)
+  (test-0x4567 uint)
+)
+  (begin
+    (print test-block-height)
+    (print test-false)
+    (print false-test)
+    (print test-none)
+    (print none-false)
+    (print test-none)
+    (print block-height-test)
+    (print test-tx-sender)
+    (print test-u3)
+    (print test-3)
+    (print test-0x4567)
+
+    (print true)
+    (print false)
+    (print none)
+    (print u3)
+    (print 3)
+    (print 0x4567)
+  )
+)
+
+
+(define-read-only (test-true) (ok true))
+(test-true)
+
+(define-read-only (true-test) (ok true))
+(true-test)
+
+(define-read-only (err-test) (ok (err u1)))
+(err-test)
+
+(define-read-only (test-err) (ok (err u1)))
+(test-err)
+
+


### PR DESCRIPTION
Fix #966 


- false mach on native keywords
- function parameters

_before_
<img width="363" alt="Screenshot 2023-05-10 at 16 13 22" src="https://github.com/hirosystems/clarinet/assets/911307/068dadee-08d0-4887-b29a-2ec975e27881">
_after_
<img width="376" alt="Screenshot 2023-05-10 at 16 13 41" src="https://github.com/hirosystems/clarinet/assets/911307/e9f1af45-3cfe-4090-92e3-c0ae31ea67b7">

---

- improve define-trait function color
- parenthesis pair colorization for string-* types

_before_
<img width="551" alt="Screenshot 2023-05-10 at 16 15 48" src="https://github.com/hirosystems/clarinet/assets/911307/6ed418ca-6d27-4237-8908-4c74f5dc903a">
_after_
<img width="578" alt="Screenshot 2023-05-10 at 16 15 09" src="https://github.com/hirosystems/clarinet/assets/911307/83f9d2f8-722a-46e7-9644-9066b46535fa">

