### PR TITLE
ci: force brew bump formula

### DIFF
--- a/.github/workflows/pkg-version-bump.yaml
+++ b/.github/workflows/pkg-version-bump.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'The tag of the release.'
+        description: "The tag of the release."
         required: true
   repository_dispatch:
     types:
@@ -34,6 +34,7 @@ jobs:
           brew bump-formula-pr \
             --no-browse \
             --no-audit \
+            --force \
             --tag "${TAG}" \
             ${{ github.event.repository.name }}
 
@@ -54,7 +55,7 @@ jobs:
 
           # Get wingetcreate
           iwr https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
-  
+
           # Update manifest and submit PR
           ./wingetcreate.exe update `
             --urls https://github.com/${{ github.repository }}/releases/download/${env:TAG}/clarinet-windows-x64.msi `


### PR DESCRIPTION
As we are currently investigating CI issues on the homebrew side that we fail to reproduce anywhere else, I'd like to have this `force` flag. Afaik it only forces PRs even if we already have one opened on the homebrew-core repo (which can be detected as duplicated). 


Note: The 2 other lines are automatic formatting