### PR TITLE
docs: homebrew release warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ Please review and watch the YouTube playlist on [Hiro's Youtube](https://www.you
 
 ### Install on macOS (Homebrew)
 
+**Note:** We are currently experiencing issues to release Clarinet on Homebrew. The latest version on Homebrew is stuck at clarinet v1.5.x, while clarinet v1.6.0 and above bring significant changes (Subnets, Epoch 2.4, POX-3, etc).
+We are working on fix to release new versions on Homebrew. In the meantime, you can install pre-built binaries by following these instructions: [Install from a pre-built binary](#install-from-a-pre-built-binary).
+
 To install Clarinet on macOS, run the following command:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ Please review and watch the YouTube playlist on [Hiro's Youtube](https://www.you
 ### Install on macOS (Homebrew)
 
 > **_NOTE:_**
+>
 > We are experiencing issues with releasing Clarinet on Homebrew. The latest version of Homebrew is at clarinet v1.5.x, while clarinet v1.6.0 and above bring significant changes (Subnets, Epoch 2.4, POX-3, etc.). We are working on a fix to release new versions on Homebrew. In the meantime, you can install pre-built binaries by following these instructions: [Install from a pre-built binary](#install-from-a-pre-built-binary).
-:::
+
 We are working on fix to release new versions on Homebrew. In the meantime, you can install pre-built binaries by following these instructions: [Install from a pre-built binary](#install-from-a-pre-built-binary).
 
 To install Clarinet on macOS, run the following command:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ Please review and watch the YouTube playlist on [Hiro's Youtube](https://www.you
 
 ### Install on macOS (Homebrew)
 
-**Note:** We are currently experiencing issues to release Clarinet on Homebrew. The latest version on Homebrew is stuck at clarinet v1.5.x, while clarinet v1.6.0 and above bring significant changes (Subnets, Epoch 2.4, POX-3, etc).
+> **_NOTE:_**
+> We are experiencing issues with releasing Clarinet on Homebrew. The latest version of Homebrew is at clarinet v1.5.x, while clarinet v1.6.0 and above bring significant changes (Subnets, Epoch 2.4, POX-3, etc.). We are working on a fix to release new versions on Homebrew. In the meantime, you can install pre-built binaries by following these instructions: [Install from a pre-built binary](#install-from-a-pre-built-binary).
+:::
 We are working on fix to release new versions on Homebrew. In the meantime, you can install pre-built binaries by following these instructions: [Install from a pre-built binary](#install-from-a-pre-built-binary).
 
 To install Clarinet on macOS, run the following command:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -60,7 +60,7 @@ winget install clarinet
 
 For more information on how to install Clarinet on Windows, please see the [Setting Up Your Clarity Environment (Windows)](https://www.youtube.com/watch?v=r5LY1J5oACs) video walkthrough.
 
-### Install from pre-built binary
+### Install from a pre-built binary
 
 If you would like to install Clarinet from pre-built binaries, you must first download the latest release from the 
 [Hiro releases page](https://github.com/hirosystems/clarinet/releases). When you have downloaded the latest release,

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -33,6 +33,7 @@ To install Clarinet, you may choose from the following:
 ### Install on macOS (Homebrew)
 
 > **_NOTE:_**
+> 
 > We are experiencing issues with releasing Clarinet on Homebrew. The latest version of Homebrew is at clarinet v1.5.x, while clarinet v1.6.0 and above bring significant changes (Subnets, Epoch 2.4, POX-3, etc.). We are working on a fix to release new versions on Homebrew. In the meantime, you can install pre-built binaries by following these instructions: [Install from a pre-built binary](#install-from-a-pre-built-binary).
 
 We are working on fix to release new versions on Homebrew. In the meantime, you can install pre-built binaries by following these instructions: [Install from a pre-built binary](#install-from-a-pre-built-binary).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -32,6 +32,9 @@ To install Clarinet, you may choose from the following:
 
 ### Install on macOS (Homebrew)
 
+**Note:** We are currently experiencing issues to release Clarinet on Homebrew. The latest version on Homebrew is stuck at clarinet v1.5.x, while clarinet v1.6.0 and above bring significant changes (Subnets, Epoch 2.4, POX-3, etc).
+We are working on fix to release new versions on Homebrew. In the meantime, you can install pre-built binaries by following these instructions: [Install from a pre-built binary](#install-from-a-pre-built-binary).
+
 To install Clarinet using macOs, you must first have Homebrew installed on your system. If you do not already have Homebrew already installed, 
 please refer to the [Homebrew](https://brew.sh/)documentation for detailed information on how to install Homebrew.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -32,7 +32,9 @@ To install Clarinet, you may choose from the following:
 
 ### Install on macOS (Homebrew)
 
-**Note:** We are currently experiencing issues to release Clarinet on Homebrew. The latest version on Homebrew is stuck at clarinet v1.5.x, while clarinet v1.6.0 and above bring significant changes (Subnets, Epoch 2.4, POX-3, etc).
+> **_NOTE:_**
+> We are experiencing issues with releasing Clarinet on Homebrew. The latest version of Homebrew is at clarinet v1.5.x, while clarinet v1.6.0 and above bring significant changes (Subnets, Epoch 2.4, POX-3, etc.). We are working on a fix to release new versions on Homebrew. In the meantime, you can install pre-built binaries by following these instructions: [Install from a pre-built binary](#install-from-a-pre-built-binary).
+
 We are working on fix to release new versions on Homebrew. In the meantime, you can install pre-built binaries by following these instructions: [Install from a pre-built binary](#install-from-a-pre-built-binary).
 
 To install Clarinet using macOs, you must first have Homebrew installed on your system. If you do not already have Homebrew already installed, 


### PR DESCRIPTION
@LakshmiLavanyaKasturi  I added the same note in the readme and in the docs.

The idea is simply to explain that we need some time and effort to be able to release the latest and futures versions of Clarinet on homebrew.
And link to the alternative solutions (which is to download the binary and install it).

Let me know what you think