### PR TITLE
refactor: better stacks-rpc crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -672,7 +672,7 @@ dependencies = [
  "serde_cbor",
  "serde_derive",
  "serde_json",
- "stacks-rpc-client 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stacks-rpc-client 1.0.6",
  "threadpool",
  "tokio",
 ]
@@ -909,7 +909,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_yaml",
- "stacks-rpc-client 1.0.6",
+ "stacks-rpc-client 1.0.7",
  "tiny-hderive",
 ]
 
@@ -5714,27 +5714,11 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "stacks-rpc-client 1.0.6",
+ "stacks-rpc-client 1.0.7",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
  "tui",
-]
-
-[[package]]
-name = "stacks-rpc-client"
-version = "1.0.6"
-dependencies = [
- "clarity-repl 1.6.4",
- "hmac 0.12.1",
- "libsecp256k1 0.7.1",
- "pbkdf2",
- "reqwest",
- "serde",
- "serde_derive",
- "serde_json",
- "sha2 0.10.6",
- "tiny-hderive",
 ]
 
 [[package]]
@@ -5748,6 +5732,22 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+]
+
+[[package]]
+name = "stacks-rpc-client"
+version = "1.0.7"
+dependencies = [
+ "clarity-repl 1.6.4",
+ "hmac 0.12.1",
+ "libsecp256k1 0.7.1",
+ "pbkdf2",
+ "reqwest",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sha2 0.10.6",
+ "tiny-hderive",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5726,10 +5726,15 @@ name = "stacks-rpc-client"
 version = "1.0.6"
 dependencies = [
  "clarity-repl 1.6.4",
+ "hmac 0.12.1",
+ "libsecp256k1 0.7.1",
+ "pbkdf2",
  "reqwest",
  "serde",
  "serde_derive",
  "serde_json",
+ "sha2 0.10.6",
+ "tiny-hderive",
 ]
 
 [[package]]

--- a/components/clarinet-cli/src/chainhooks/mod.rs
+++ b/components/clarinet-cli/src/chainhooks/mod.rs
@@ -40,10 +40,16 @@ pub fn load_chainhooks(
         match parse_chainhook_full_specification(&path) {
             Ok(hook) => {
                 match hook {
-                    ChainhookFullSpecification::Bitcoin(hook) => bitcoin_chainhooks
-                        .push(hook.into_selected_network_specification(&networks.0)?),
-                    ChainhookFullSpecification::Stacks(hook) => stacks_chainhooks
-                        .push(hook.into_selected_network_specification(&networks.1)?),
+                    ChainhookFullSpecification::Bitcoin(predicate) => {
+                        let mut spec = predicate.into_selected_network_specification(&networks.0)?;
+                        spec.enabled = true;
+                        bitcoin_chainhooks.push(spec)
+                    }
+                    ChainhookFullSpecification::Stacks(predicate) => {
+                        let mut spec = predicate.into_selected_network_specification(&networks.1)?;
+                        spec.enabled = true;
+                        stacks_chainhooks.push(spec)
+                    }
                 }
             }
             Err(msg) => return Err(format!("{} syntax incorrect: {}", relative_path, msg)),

--- a/components/clarinet-cli/src/chainhooks/mod.rs
+++ b/components/clarinet-cli/src/chainhooks/mod.rs
@@ -38,20 +38,18 @@ pub fn load_chainhooks(
     let mut bitcoin_chainhooks = vec![];
     for (path, relative_path) in hook_files.into_iter() {
         match parse_chainhook_full_specification(&path) {
-            Ok(hook) => {
-                match hook {
-                    ChainhookFullSpecification::Bitcoin(predicate) => {
-                        let mut spec = predicate.into_selected_network_specification(&networks.0)?;
-                        spec.enabled = true;
-                        bitcoin_chainhooks.push(spec)
-                    }
-                    ChainhookFullSpecification::Stacks(predicate) => {
-                        let mut spec = predicate.into_selected_network_specification(&networks.1)?;
-                        spec.enabled = true;
-                        stacks_chainhooks.push(spec)
-                    }
+            Ok(hook) => match hook {
+                ChainhookFullSpecification::Bitcoin(predicate) => {
+                    let mut spec = predicate.into_selected_network_specification(&networks.0)?;
+                    spec.enabled = true;
+                    bitcoin_chainhooks.push(spec)
                 }
-            }
+                ChainhookFullSpecification::Stacks(predicate) => {
+                    let mut spec = predicate.into_selected_network_specification(&networks.1)?;
+                    spec.enabled = true;
+                    stacks_chainhooks.push(spec)
+                }
+            },
             Err(msg) => return Err(format!("{} syntax incorrect: {}", relative_path, msg)),
         };
     }

--- a/components/stacks-rpc-client/Cargo.toml
+++ b/components/stacks-rpc-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stacks-rpc-client"
-version = "1.0.6"
+version = "1.0.7"
 description = "HTTP Client for the Stacks blockchain"
 license = "GPL-3.0"
 edition = "2021"
@@ -15,3 +15,8 @@ reqwest = { version = "0.11", default-features = false, features = [
     "json",
     "rustls-tls",
 ] }
+hmac = "0.12.0"
+pbkdf2 = { version = "0.11.0", features = ["simple"], default-features = false }
+sha2 = "0.10.0"
+tiny-hderive = { version = "0.3.0" }
+libsecp256k1 = { version = "0.7.0" }

--- a/components/stacks-rpc-client/src/crypto.rs
+++ b/components/stacks-rpc-client/src/crypto.rs
@@ -1,0 +1,192 @@
+use crate::clarity::codec::*;
+use crate::clarity::stacks_common::codec::StacksMessageCodec;
+use crate::clarity::stacks_common::types::chainstate::StacksAddress;
+use crate::clarity::vm::types::{PrincipalData, QualifiedContractIdentifier, Value};
+use crate::clarity::vm::{ClarityName, ClarityVersion, ContractName};
+use clarity_repl::clarity::address::{
+    AddressHashMode, C32_ADDRESS_VERSION_MAINNET_SINGLESIG, C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
+};
+use clarity_repl::clarity::util::secp256k1::{
+    MessageSignature, Secp256k1PrivateKey, Secp256k1PublicKey,
+};
+use hmac::Hmac;
+use libsecp256k1::{PublicKey, SecretKey};
+use pbkdf2::pbkdf2;
+use sha2::Sha512;
+use tiny_hderive::bip32::ExtendedPrivKey;
+
+#[derive(Clone, Debug)]
+pub struct Wallet {
+    pub mnemonic: String,
+    pub derivation: String,
+    pub mainnet: bool,
+}
+
+impl Wallet {
+    pub fn compute_stacks_address(&self) -> StacksAddress {
+        let keypair = compute_keypair(&self);
+        compute_stacks_address(&keypair.public_key, self.mainnet)
+    }
+}
+
+pub struct Keypair {
+    pub secret_key: Secp256k1PrivateKey,
+    pub public_key: PublicKey
+}
+
+pub fn compute_stacks_address(
+    public_key: &PublicKey,
+    mainnet: bool,
+) -> StacksAddress {
+    let wrapped_public_key =
+        Secp256k1PublicKey::from_slice(&public_key.serialize_compressed()).unwrap();
+
+    let signer_addr = StacksAddress::from_public_keys(
+        match mainnet {
+            true => C32_ADDRESS_VERSION_MAINNET_SINGLESIG,
+            false => C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
+        },
+        &AddressHashMode::SerializeP2PKH,
+        1,
+        &vec![wrapped_public_key],
+    )
+    .unwrap();
+
+    signer_addr
+}
+
+pub fn compute_keypair(wallet: &Wallet) -> Keypair {
+    let bip39_seed = match get_bip39_seed_from_mnemonic(&wallet.mnemonic, "") {
+        Ok(bip39_seed) => bip39_seed,
+        Err(_) => panic!(),
+    };
+    let ext = ExtendedPrivKey::derive(&bip39_seed[..], wallet.derivation.as_str()).unwrap();
+    let wrapped_secret_key = Secp256k1PrivateKey::from_slice(&ext.secret()).unwrap();
+    let secret_key = SecretKey::parse_slice(&ext.secret()).unwrap();
+    let public_key = PublicKey::from_secret_key(&secret_key);
+    Keypair {
+        secret_key: wrapped_secret_key,
+        public_key
+    }
+}
+
+pub fn sign_transaction_payload(
+    wallet: &Wallet,
+    payload: TransactionPayload,
+    nonce: u64,
+    tx_fee: u64,
+    anchor_mode: TransactionAnchorMode,
+) -> Result<StacksTransaction, String> {
+    let keypair = compute_keypair(wallet);
+    let signer_addr = compute_stacks_address(&keypair.public_key, wallet.mainnet);
+
+    let spending_condition = TransactionSpendingCondition::Singlesig(SinglesigSpendingCondition {
+        signer: signer_addr.bytes.clone(),
+        nonce: nonce,
+        tx_fee: tx_fee,
+        hash_mode: SinglesigHashMode::P2PKH,
+        key_encoding: TransactionPublicKeyEncoding::Compressed,
+        signature: MessageSignature::empty(),
+    });
+
+    let auth = TransactionAuth::Standard(spending_condition);
+    let unsigned_tx = StacksTransaction {
+        version: match wallet.mainnet {
+            true => TransactionVersion::Mainnet,
+            false => TransactionVersion::Testnet,
+        },
+        chain_id: match wallet.mainnet {
+            true => 0x00000001,
+            false => 0x80000000,
+        },
+        auth: auth,
+        anchor_mode: anchor_mode,
+        post_condition_mode: TransactionPostConditionMode::Allow,
+        post_conditions: vec![],
+        payload: payload,
+    };
+
+    let mut unsigned_tx_bytes = vec![];
+    unsigned_tx
+        .consensus_serialize(&mut unsigned_tx_bytes)
+        .expect("FATAL: invalid transaction");
+
+    let mut tx_signer = StacksTransactionSigner::new(&unsigned_tx);
+    tx_signer.sign_origin(&keypair.secret_key).unwrap();
+    let signed_tx = tx_signer.get_tx().unwrap();
+    Ok(signed_tx)
+}
+
+pub fn encode_contract_call(
+    contract_id: &QualifiedContractIdentifier,
+    function_name: ClarityName,
+    function_args: Vec<Value>,
+    wallet: &Wallet,
+    nonce: u64,
+    tx_fee: u64,
+    anchor_mode: TransactionAnchorMode,
+) -> Result<StacksTransaction, String> {
+    let payload = TransactionContractCall {
+        contract_name: contract_id.name.clone(),
+        address: StacksAddress::from(contract_id.issuer.clone()),
+        function_name: function_name.clone(),
+        function_args: function_args.clone(),
+    };
+    sign_transaction_payload(
+        wallet,
+        TransactionPayload::ContractCall(payload),
+        nonce,
+        tx_fee,
+        anchor_mode,
+    )
+}
+
+pub fn encode_stx_transfer(
+    recipient: PrincipalData,
+    amount: u64,
+    memo: [u8; 34],
+    wallet: &Wallet,
+    nonce: u64,
+    tx_fee: u64,
+    anchor_mode: TransactionAnchorMode,
+) -> Result<StacksTransaction, String> {
+    let payload = TransactionPayload::TokenTransfer(recipient, amount, TokenTransferMemo(memo));
+    sign_transaction_payload(wallet, payload, nonce, tx_fee, anchor_mode)
+}
+
+pub fn encode_contract_publish(
+    contract_name: &ContractName,
+    source: &str,
+    clarity_version: Option<ClarityVersion>,
+    wallet: &Wallet,
+    nonce: u64,
+    tx_fee: u64,
+    anchor_mode: TransactionAnchorMode,
+) -> Result<StacksTransaction, String> {
+    let payload = TransactionSmartContract {
+        name: contract_name.clone(),
+        code_body: StacksString::from_str(source).unwrap(),
+    };
+    sign_transaction_payload(
+        wallet,
+        TransactionPayload::SmartContract(payload, clarity_version),
+        nonce,
+        tx_fee,
+        anchor_mode,
+    )
+}
+
+pub fn get_bip39_seed_from_mnemonic(mnemonic: &str, password: &str) -> Result<Vec<u8>, String> {
+    const PBKDF2_ROUNDS: u32 = 2048;
+    const PBKDF2_BYTES: usize = 64;
+    let salt = format!("mnemonic{}", password);
+    let mut seed = vec![0u8; PBKDF2_BYTES];
+
+    pbkdf2::<Hmac<Sha512>>(
+        mnemonic.as_bytes(),
+        salt.as_bytes(),
+        PBKDF2_ROUNDS,
+        &mut seed,
+    );
+    Ok(seed)
+}

--- a/components/stacks-rpc-client/src/crypto.rs
+++ b/components/stacks-rpc-client/src/crypto.rs
@@ -31,13 +31,10 @@ impl Wallet {
 
 pub struct Keypair {
     pub secret_key: Secp256k1PrivateKey,
-    pub public_key: PublicKey
+    pub public_key: PublicKey,
 }
 
-pub fn compute_stacks_address(
-    public_key: &PublicKey,
-    mainnet: bool,
-) -> StacksAddress {
+pub fn compute_stacks_address(public_key: &PublicKey, mainnet: bool) -> StacksAddress {
     let wrapped_public_key =
         Secp256k1PublicKey::from_slice(&public_key.serialize_compressed()).unwrap();
 
@@ -66,7 +63,7 @@ pub fn compute_keypair(wallet: &Wallet) -> Keypair {
     let public_key = PublicKey::from_secret_key(&secret_key);
     Keypair {
         secret_key: wrapped_secret_key,
-        public_key
+        public_key,
     }
 }
 

--- a/components/stacks-rpc-client/src/lib.rs
+++ b/components/stacks-rpc-client/src/lib.rs
@@ -16,4 +16,6 @@ pub mod clarity {
 
 pub mod rpc_client;
 
+pub mod crypto;
+
 pub use rpc_client::{PoxInfo, StacksRpc};


### PR DESCRIPTION
In this PR, we are moving some code to the stacks-rpc crate.
Ultimately we get rid of all the on chain logic present in the deployment plan crate (onchain.rs), and have deployment plans relying on this lib instead.