### PR TITLE
fix: initialize bitcoin before running chain coordinator

### DIFF
--- a/components/stacks-network/src/lib.rs
+++ b/components/stacks-network/src/lib.rs
@@ -152,6 +152,13 @@ pub async fn do_run_devnet(
                 return Err(e.to_string());
             }
 
+            ctx_moved.try_log(|logger| {
+                slog::info!(
+                    logger,
+                    "Bitcoin node initialization complete; starting chain coordinator."
+                )
+            });
+
             let future = start_chains_coordinator(
                 config,
                 chains_coordinator_tx,

--- a/components/stacks-network/src/main.rs
+++ b/components/stacks-network/src/main.rs
@@ -67,7 +67,7 @@ fn main() {
         logger: Some(logger),
         tracer: false,
     };
-    ctx.try_log(|logger| slog::info!(logger, "startin devnet coordinator"));
+    ctx.try_log(|logger| slog::info!(logger, "Starting devnet coordinator"));
 
     let (orchestrator_terminated_tx, _) = channel();
     let res = hiro_system_kit::nestable_block_on(do_run_devnet(


### PR DESCRIPTION
We need the chain coordinator to handle conditions in which the stacks node is started before the bitcoin node and chain coordinator.

Before, if the stacks node started before the chain coordinator, the stacks node would start making requests to the coordinator before the bitcoin node was initialized by the coordinator. These requests would block the coordinator from ever completing the bitcoin initialization.

This PR changes the startup process so that the chain coordinator does not accept requests until after it has initialized the bitcoin node.

The bitcoin initialization code also had some repeated code blocks that were easily abstracted, so I did that; this process also removed an early "bail" in the rust function, instead catching the error, logging it, and retrying.