### PR TITLE
feat: Add `--allow-read` flag to allow filesystem read access in `clarinet test`

### DIFF
--- a/components/clarinet-cli/src/frontend/cli.rs
+++ b/components/clarinet-cli/src/frontend/cli.rs
@@ -445,6 +445,9 @@ struct Test {
     /// Allow network access
     #[clap(long = "allow-net")]
     pub allow_net: bool,
+    /// Allow read access to project directory
+    #[clap(long = "allow-read")]
+    pub allow_disk_read: bool,
     /// Specify optional Typescript config file
     #[clap(long = "ts-config")]
     pub ts_config: Option<String>,
@@ -1229,7 +1232,7 @@ pub fn main() {
                 cmd.costs_report,
                 cmd.watch,
                 true,
-                false,
+                cmd.allow_disk_read,
                 false,
                 None,
                 None,


### PR DESCRIPTION
Add `--allow-read` to `clarinet test` subcommand in order to allow filesystem reads in tests. This allows us to share configuration between tests by reading data from JSON/YAML files.