### PR TITLE
fix: repl: panic at get_current_block_height for unexisting block

### DIFF
--- a/components/clarity-repl/src/repl/datastore.rs
+++ b/components/clarity-repl/src/repl/datastore.rs
@@ -222,7 +222,7 @@ impl ClarityBackingStore for Datastore {
     fn get_current_block_height(&mut self) -> u32 {
         self.height_at_chain_tip
             .get(self.get_chain_tip())
-            .expect("No height stored for current chain tip")
+            .unwrap_or(&u32::MAX)
             .clone()
     }
 


### PR DESCRIPTION
Fix: #1043 

The fix prevent the crash.
At the clarinet level, it's not really feasible to catch this error and return an error or warning on the diagnostic. 