### PR TITLE
Add curl to the apt get line in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ You must first [Install Rust](https://www.rust-lang.org/tools/install) to use th
 If you are using Debian and Ubuntu-based distributions, make sure to run the following command to install required packages before building Clarinet.
 
 ```bash
-sudo apt install build-essential pkg-config libssl-dev
+sudo apt install build-essential pkg-config libssl-dev curl
 ```
 
 #### Build Clarinet


### PR DESCRIPTION
When trying to build `clarinet` via `cargo` on `ubuntu-22.04`, the build fails as per #1066 

The problem is that `README.md` doesn't specify `curl` or `python` as a dependency, and it isn't installed by default.  So this PR just adds `curl` to the `apt get` line in `README.md`.  

Fixes #1066 