### PR TITLE
Bug: fix stacks-blockchain-api faucet integration

### DIFF
--- a/components/stacks-network/src/orchestrator.rs
+++ b/components/stacks-network/src/orchestrator.rs
@@ -1529,6 +1529,7 @@ events_keys = ["*"]
             format!("PG_DATABASE={}", devnet_config.stacks_api_postgres_database),
             format!("STACKS_CHAIN_ID=2147483648"),
             format!("V2_POX_MIN_AMOUNT_USTX=90000000260"),
+            format!("FAUCET_PRIVATE_KEY={}", devnet_config.faucet_secret_key_hex),
             "NODE_ENV=development".to_string(),
         ];
         env.append(&mut devnet_config.stacks_api_env_vars.clone());


### PR DESCRIPTION
This PR fixes the faucet integration when running the local devnet. During devnet orchestration, the stacks-blockchain-api was not provided the faucet secret key for the faucet defined in Devnet.toml. This PR addresses this by adding the `FAUCET_PRIVATE_KEY` environment variable to the `env` used to launch the docker container.