### PR TITLE
chore: update default epoch to 2.4

### DIFF
--- a/components/clarity-repl/src/repl/mod.rs
+++ b/components/clarity-repl/src/repl/mod.rs
@@ -22,7 +22,7 @@ use clarity::types::StacksEpochId;
 use clarity::vm::ClarityVersion;
 
 pub const DEFAULT_CLARITY_VERSION: ClarityVersion = ClarityVersion::Clarity2;
-pub const DEFAULT_EPOCH: StacksEpochId = StacksEpochId::Epoch21;
+pub const DEFAULT_EPOCH: StacksEpochId = StacksEpochId::Epoch24;
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct ClarityContract {


### PR DESCRIPTION
When a new contract is added with `clarinet contracts new`, this will set the epoch to `2.4` instead of the current `2.1`.