### PR TITLE
fix: safety check on invalid line number in coverage

### DIFF
--- a/components/clarity-repl/src/analysis/coverage.rs
+++ b/components/clarity-repl/src/analysis/coverage.rs
@@ -183,18 +183,24 @@ impl CoverageReporter {
                     file_content.push_str(&format!("FNF:{}\n", functions.len()));
                     file_content.push_str(&format!("FNH:{}\n", function_hits.len()));
 
-                    for (line_number, count) in line_execution_counts.iter() {
-                        file_content.push_str(&format!("DA:{},{}\n", line_number, count));
+                    for (line, count) in line_execution_counts.iter() {
+                        // the ast can contain elements with a span starting at line 0 that we want to ignore
+                        if line > &&0 {
+                            file_content.push_str(&format!("DA:{},{}\n", line, count));
+                        }
                     }
 
                     file_content.push_str(&format!("BRF:{}\n", branches.len()));
                     file_content.push_str(&format!("BRH:{}\n", branches_hits.len()));
 
                     for ((line, block_id, branch_nb), count) in branch_execution_counts.iter() {
-                        file_content.push_str(&format!(
-                            "BRDA:{},{},{},{}\n",
-                            line, block_id, branch_nb, count
-                        ));
+                        // the ast can contain elements with a span starting at line 0 that we want to ignore
+                        if line > &&0 {
+                            file_content.push_str(&format!(
+                                "BRDA:{},{},{},{}\n",
+                                line, block_id, branch_nb, count
+                            ));
+                        }
                     }
                 }
                 file_content.push_str("end_of_record\n");


### PR DESCRIPTION
### Description

Fix: #768 

Invalid line number in lcov files (<= 0) can break some coverage renderers (such as the Coverage Gutters extension mentioned here https://github.com/hirosystems/clarinet/issues/1062).

This PR doesn't fix the root cause (we shouldn't have executable line with a span start at line 0) but at least it prevents the renderers to crash. The root cause should be fixed at the VM level (some cases have already been fixed in the past https://github.com/stacks-network/stacks-blockchain/pull/3421) 

#### Breaking change?

/

### Example

/

---

### Checklist

/

