### PR TITLE
Update CI - do not rebuild on doc change

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,10 @@ on:
       - main
       - develop
       - rc/next
+    paths-ignore:
+      - '**/CHANGELOG.md'
+      - 'docs/**'
+
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Does not trigger a rebuild when there's a change to the docs directory or changelog.

[[Related Issue]](https://github.com/hirosystems/devops/issues/1270)