### PR TITLE
chore: bump vscode extension to 1.7.2

### DIFF
--- a/components/clarity-vscode/package-lock.json
+++ b/components/clarity-vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clarity-lsp",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clarity-lsp",
-      "version": "1.7.1",
+      "version": "1.7.2",
       "license": "GPL-3.0-only",
       "workspaces": [
         "client",

--- a/components/clarity-vscode/package.json
+++ b/components/clarity-vscode/package.json
@@ -8,7 +8,7 @@
   "homepage": "https://github.com/hirosystems/clarinet",
   "bugs": "https://github.com/hirosystems/clarinet/issues",
   "license": "GPL-3.0-only",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "workspaces": [
     "client",
     "server",


### PR DESCRIPTION
### Description

This is the vscode release
I published 1.7.1 as a pre-release