### PR TITLE
Updated epoch in clarinet.toml files

### DIFF
--- a/components/clarinet-cli/examples/billboard/Clarinet.toml
+++ b/components/clarinet-cli/examples/billboard/Clarinet.toml
@@ -5,4 +5,4 @@ requirements = []
 [contracts.billboard]
 path = "contracts/billboard.clar"
 clarity_version = 1
-epoch = "2.05"
+epoch = "2.4"

--- a/components/clarinet-cli/examples/cbtc/Clarinet.toml
+++ b/components/clarinet-cli/examples/cbtc/Clarinet.toml
@@ -10,7 +10,7 @@ contract_id = "SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE.sip-010-trait-ft-standa
 [contracts.cbtc-token]
 path = "contracts/cbtc-token.clar"
 clarity_version = 1
-epoch = "2.05"
+epoch = "2.4"
 
 [repl]
 costs_version = 2

--- a/components/clarinet-cli/examples/counter/Clarinet.toml
+++ b/components/clarinet-cli/examples/counter/Clarinet.toml
@@ -7,12 +7,12 @@ telemetry = false
 [contracts.counter]
 path = "contracts/counter.clar"
 clarity_version = 1
-epoch = "2.05"
+epoch = "2.4"
 
 [contracts.counter-2]
 path = "contracts/counter-v2.clar"
 clarity_version = 2
-epoch = "2.1"
+epoch = "2.4"
 
 [repl.analysis]
 passes = ["check_checker"]

--- a/components/clarinet-cli/examples/simple-nft/Clarinet.toml
+++ b/components/clarinet-cli/examples/simple-nft/Clarinet.toml
@@ -6,13 +6,13 @@ cache_dir = "./.cache"
 [contracts.simple-nft]
 path = "contracts/simple-nft.clar"
 clarity_version = 1
-epoch = "2.05"
+epoch = "2.4"
 
 # EXTERNAL CONTRACTS
 [contracts.sip-009-trait-ft-standard]
 path = "contracts/external/sip-009-nft-trait-standard.clar"
 clarity_version = 1
-epoch = "2.05"
+epoch = "2.4"
 
 [repl.analysis]
 passes = ["check_checker"]

--- a/components/clarity-vscode/test-data/simple/Clarinet.toml
+++ b/components/clarity-vscode/test-data/simple/Clarinet.toml
@@ -13,12 +13,12 @@ clarity_version = 1
 [contracts.counter]
 path = "contracts/counter.clar"
 clarity_version = 2
-epoch = 2.1
+epoch = 2.4
 
 [contracts.empty]
 path = "contracts/empty.clar"
 clarity_version = 2
-epoch = 2.1
+epoch = 2.4
 
 [repl.analysis]
 passes = ["check_checker"]

--- a/components/clarity-vscode/test-data/test-cases/Clarinet.toml
+++ b/components/clarity-vscode/test-data/test-cases/Clarinet.toml
@@ -13,32 +13,32 @@ contract_id = 'SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE.sip-010-trait-ft-standa
 [contracts.bns]
 path = 'contracts/bns.clar'
 clarity_version = 2
-epoch = 2.1
+epoch = 2.4
 
 [contracts.contract]
 path = 'contracts/contract.clar'
 clarity_version = 2
-epoch = 2.1
+epoch = 2.4
 
 [contracts.ft-project]
 path = 'contracts/ft-project.clar'
 clarity_version = 2
-epoch = 2.1
+epoch = 2.4
 
 [contracts.iterators]
 path = 'contracts/iterators.clar'
 clarity_version = 1
-epoch = 2.0
+epoch = 2.4
 
 [contracts.nft-project]
 path = 'contracts/nft-project.clar'
 clarity_version = 2
-epoch = 2.1
+epoch = 2.4
 
 [contracts.syntax-highlighting-test]
 path = 'contracts/syntax-highlighting-test.clar'
 clarity_version = 2
-epoch = 2.1
+epoch = 2.4
 
 [repl.analysis]
 passes = ['check_checker']


### PR DESCRIPTION
Updated `epoch` to 2.4 to use in the example files.
Fixes https://github.com/hirosystems/clarinet/issues/1097