### PR TITLE
fix: get_costs analyzes commands with spaces

### DIFF
--- a/components/clarity-repl/src/repl/session.rs
+++ b/components/clarity-repl/src/repl/session.rs
@@ -1032,13 +1032,13 @@ impl Session {
 
     pub fn get_costs(&mut self, output: &mut Vec<String>, cmd: &str) {
         let command: String = cmd.to_owned();
-        let v: Vec<&str> = command.split_whitespace().collect();
 
-        if v.len() != 2 {
-            output.push(red!(format!("::get_costs command needs an argument")));
-        } else {
-            self.run_snippet(output, true, &v[1].to_string());
-        }
+        let expr = match cmd.split_once(" ") {
+            Some((_, expr)) => expr,
+            _ => return output.push(red!("Usage: ::get_costs <expr>")),
+        };
+
+        self.run_snippet(output, true, expr);
     }
 
     #[cfg(feature = "cli")]


### PR DESCRIPTION
Fix: #1011 

### Description

The clarity-repl command ::get_costs works with commands such a `42` but when there is a space, in commands such as `(+ u1 u1)`, an error comes.

