### PR TITLE
Edit typos and language fixes in the 'Clarinet Deployment Plans' doc

### DIFF
--- a/docs/feature-guides/clarinet-deploy.md
+++ b/docs/feature-guides/clarinet-deploy.md
@@ -4,7 +4,7 @@ title: Clarinet Deployment Plans
 
 ## Overview
 
-Deployment Plans are reproducible deployment steps that publish a collection of on-chain transactions and one or more contracts to a network, whether a local developer network, the public testnet, or into production on mainnet. Deployment plans minimize the inherent complexity of deployments, such as smart contract dependencies and interactions, transaction chaining limits, deployment costs, and more, while ensuring reproducible deployments critical for testing and automation purposes.
+Deployment Plans are reproducible deployment steps that publish a collection of on-chain transactions and one or more contracts to a network, whether a local developer network, the public testnet, or into production on mainnet. Deployment plans minimize the inherent complexity of deployments, such as smart-contract dependencies and interactions, transaction chaining limits, deployment costs, and more, while ensuring reproducible deployments critical for testing and automation purposes.
 
 *Topics covered in this guide*:
 
@@ -14,23 +14,23 @@ Deployment Plans are reproducible deployment steps that publish a collection of 
 
 ## Design
 
-The default deployment plan of every Clarinet project is contained within specifications set inside certain files. In addition to this default deployment plan, the user can manually configure each plan, adding additional transactions or contract calls, across multiple Stacks or Bitcoin blocks.
+The default deployment plan of every Clarinet project is contained within specifications set inside certain files. In addition to this default deployment plan, the user can manually configure each plan, adding additional transactions or contract calls across multiple Stacks or Bitcoin blocks.
 
-You can commit, audit, and test contracts without including any secrets in the Deployment Plan, and share these contracts without exposing any sensitive information.
+You can commit, audit, and test contracts without including any secrets in the Deployment Plan and share these contracts without exposing any sensitive information.
 
 ## Deployment plan primitives
 
 | Transaction primitive | Typical usage |
 |---|---|
 | publish contracts | - deploy a contract to an in-memory simulated Stacks chain or an integrate Stacks-Bitcoin environment <br /> - deploy to a public testnet or mainnet <br /> - deploy an external contract to your local network for testing |
-| call contract functions | - call a contract deployed to any of your local devnets or public networks, chain transactions |
+| call contract functions | - call a contract deployed to any of your local devnets or public networks |
 | send BTC | - Perform a simple bitcoin transfer from a p2pkh address to a p2pkh address (devnet/testnet/mainnet)  |
 | wait for block | - Test or automate contract deployment across multiple Stacks or Bitcoin blocks  |
 | send STX | - send stacks to an address or contract |
 
 ## References
 
-For a more detailed discussion of how to use Deployment Plans, please see the following resources:
+For a more detailed discussion on how to use Deployment Plans, please see the following resources:
 
 - [How To Guide for deployment plans](../how-to-guides/how-to-use-deployment-plans.md).
 


### PR DESCRIPTION
### Description
Edit typos and language fixes in the 'Clarinet Deployment Plans' doc

- **Please note**: Noticed the text `chain transactions` in the `call contract functions` row in the `Deployment plan primitives` table. Suggested removing it since it did not seem relevant in the context of that sentence.

#### Breaking change?
No
