### PR TITLE
ci: use rust toolchain v1.71.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,16 +6,16 @@ on:
       - develop
       - rc/next
     paths-ignore:
-      - '**/CHANGELOG.md'
-      - 'docs/**'
+      - "**/CHANGELOG.md"
+      - "docs/**"
   push:
     branches:
       - main
       - develop
       - rc/next
     paths-ignore:
-      - '**/CHANGELOG.md'
-      - 'docs/**'
+      - "**/CHANGELOG.md"
+      - "docs/**"
 
   workflow_dispatch:
 
@@ -77,7 +77,7 @@ jobs:
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.71.0
           profile: minimal
           components: rustfmt
           override: true
@@ -221,7 +221,7 @@ jobs:
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.71.0
           target: ${{ matrix.target }}
           profile: minimal
           components: llvm-tools-preview
@@ -410,7 +410,7 @@ jobs:
         if: github.event_name != 'pull_request' || matrix.target == 'x86_64-unknown-linux-gnu'
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.71.0
           target: ${{ matrix.target }}
           profile: minimal
           components: llvm-tools-preview
@@ -522,7 +522,7 @@ jobs:
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.71.0
           target: x86_64-unknown-linux-gnu
           profile: minimal
           components: llvm-tools-preview

--- a/dockerfiles/components/clarinet-dev.dockerfile
+++ b/dockerfiles/components/clarinet-dev.dockerfile
@@ -4,7 +4,7 @@ WORKDIR /src
 
 RUN apt update && apt install -y ca-certificates pkg-config libssl-dev
 
-RUN rustup update 1.67.0 && rustup default 1.67.0
+RUN rustup update 1.71.0 && rustup default 1.71.0
 
 COPY . .
 

--- a/dockerfiles/components/clarinet.dockerfile
+++ b/dockerfiles/components/clarinet.dockerfile
@@ -2,6 +2,8 @@ FROM debian:bookworm-slim
 
 RUN apt update && apt install -y libssl-dev
 
+RUN rustup update 1.71.0 && rustup default 1.71.0
+
 COPY clarinet /bin/
 
 WORKDIR /workspace

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.70.0"
+channel = "1.71.0"


### PR DESCRIPTION
The recent issue in the CI is caused by the fact that our version of v8 doesn't build with the latest rustc version (1.72.0 that became the stable release 2 weeks ago).

Let's fix the version to 1.71.0 (latest version able to build clarinet) both in the CI and locally (rust-toolchain file).

In the future, I think we should always use stable (both in CI and locally).
This will be possible once we remove deno and v8 from the dependencies (in the coming weeks)