### PR TITLE
feat: sdk: get contract ast

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1038,6 +1038,7 @@ dependencies = [
  "serde",
  "serde-wasm-bindgen 0.6.0",
  "serde_json",
+ "typescript-type-def",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -7122,6 +7123,29 @@ name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+
+[[package]]
+name = "typescript-type-def"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "356e00027bd9ef773605a353070dc87684b25561a59087ea3ee3dd5fe8854e83"
+dependencies = [
+ "typescript-type-def-derive",
+]
+
+[[package]]
+name = "typescript-type-def-derive"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4e696c28431595138cc53892104528152cbcf26653ae0aa655e4eaede5b9f69"
+dependencies = [
+ "darling",
+ "ident_case",
+ "proc-macro-error",
+ "proc-macro2 1.0.66",
+ "quote 1.0.28",
+ "syn 1.0.107",
+]
 
 [[package]]
 name = "ubyte"

--- a/components/clarinet-sdk/.prettierrc
+++ b/components/clarinet-sdk/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "printWidth": 100,
+  "trailingComma": "all"
+}

--- a/components/clarinet-sdk/Cargo.toml
+++ b/components/clarinet-sdk/Cargo.toml
@@ -21,20 +21,11 @@ serde-wasm-bindgen = { version = "0.6.0", optional = true }
 wasm-bindgen = { version = "0.2", optional = true }
 wasm-bindgen-futures = { version = "0.4", optional = true }
 web-sys = { version = "0.3", features = ["console"], optional = true }
+typescript-type-def = "0.5.8"
 
 [features]
 default = ["wasm"]
-wasm = [
-  "wasm-bindgen",
-  "wasm-bindgen-futures",
-  "serde-wasm-bindgen",
-  "js-sys",
-  "web-sys",
-  "console_error_panic_hook",
-  "clarinet-deployments/wasm",
-  "clarity-repl/wasm",
-  "clarinet-files/wasm",
-]
+wasm = ["wasm-bindgen", "wasm-bindgen-futures", "serde-wasm-bindgen", "js-sys", "web-sys", "console_error_panic_hook", "clarinet-deployments/wasm", "clarity-repl/wasm", "clarinet-files/wasm"]
 
 # DEV
 [profile.dev]

--- a/components/clarinet-sdk/package-lock.json
+++ b/components/clarinet-sdk/package-lock.json
@@ -24,6 +24,7 @@
         "@wasm-tool/wasm-pack-plugin": "^1.7.0",
         "copy-webpack-plugin": "^11.0.0",
         "kolorist": "^1.8.0",
+        "prettier": "^3.0.3",
         "rimraf": "^5.0.1",
         "ts-loader": "^9.4.4",
         "typedoc": "^0.25.1",
@@ -2421,6 +2422,21 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
+      "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-format": {

--- a/components/clarinet-sdk/package.json
+++ b/components/clarinet-sdk/package.json
@@ -68,6 +68,7 @@
     "@wasm-tool/wasm-pack-plugin": "^1.7.0",
     "copy-webpack-plugin": "^11.0.0",
     "kolorist": "^1.8.0",
+    "prettier": "^3.0.3",
     "rimraf": "^5.0.1",
     "ts-loader": "^9.4.4",
     "typedoc": "^0.25.1",

--- a/components/clarinet-sdk/src-ts/bin/index.ts
+++ b/components/clarinet-sdk/src-ts/bin/index.ts
@@ -56,7 +56,7 @@ async function main() {
 
   console.log("\n");
   console.log(
-    green("You are now ready to test your smart contracts with Vitest and the Clarinet SDK")
+    green("You are now ready to test your smart contracts with Vitest and the Clarinet SDK"),
   );
   console.log(green("Open ./tests/contract.test.ts to see an example"));
 }
@@ -66,7 +66,7 @@ async function checkIfProjectDirectoryIsValid() {
   const isClarinetProject = fs.existsSync(path.join(process.cwd(), "Clarinet.toml"));
   if (!isClarinetProject) {
     throw new Error(
-      "Clarinet.toml not found in the current directory. Please run this command in a Clarinet project."
+      "Clarinet.toml not found in the current directory. Please run this command in a Clarinet project.",
     );
   }
 
@@ -122,14 +122,14 @@ function updateClarinetSDKVersion(sdkBinDir: string) {
 function updateGitIgnore() {
   console.log("Updating .gitignore");
   const newLines = ["logs", "*.log", "npm-debug.log*", "coverage", "*.info", "node_modules"].join(
-    "\n"
+    "\n",
   );
 
   const gitIgnorePath = path.join(process.cwd(), ".gitignore");
   if (fs.existsSync(gitIgnorePath)) {
     fs.appendFileSync(
       gitIgnorePath,
-      "\n# Ignore Node and NPM files. Added by the clarinet-sdk migration."
+      "\n# Ignore Node and NPM files. Added by the clarinet-sdk migration.",
     );
     fs.appendFileSync(gitIgnorePath, `\n${newLines}`);
   } else {

--- a/components/clarinet-sdk/src-ts/contractAst.ts
+++ b/components/clarinet-sdk/src-ts/contractAst.ts
@@ -1,0 +1,48 @@
+type Atom = {
+  Atom: String;
+};
+
+type AtomValue = {
+  AtomValue: any;
+};
+
+type List = {
+  List: Expression[];
+};
+
+type LiteralValue = {
+  LiteralValue: any;
+};
+
+type Field = {
+  Field: any;
+};
+
+type TraitReference = {
+  TraitReference: any;
+};
+
+type ExpressionType = Atom | AtomValue | List | LiteralValue | Field | TraitReference;
+
+type Span = {
+  start_line: number;
+  start_column: number;
+  end_line: number;
+  end_column: number;
+};
+
+type Expression = {
+  expr: ExpressionType;
+  id: number;
+  span: Span;
+};
+
+/** ContractAST basic type. To be improved */
+export type ContractAST = {
+  contract_identifier: any;
+  pre_expressions: any[];
+  expressions: Expression[];
+  top_level_expression_sorting: number[];
+  referenced_traits: Map<any, any>;
+  implemented_traits: any[];
+};

--- a/components/clarinet-sdk/src-ts/index.ts
+++ b/components/clarinet-sdk/src-ts/index.ts
@@ -24,7 +24,7 @@ type CallFn = (
   contract: string,
   method: string,
   args: ClarityValue[],
-  sender: string
+  sender: string,
 ) => ParsedTransactionRes;
 
 type DeployContract = (name: string, content: string, sender: string) => ParsedTransactionRes;
@@ -32,7 +32,7 @@ type DeployContract = (name: string, content: string, sender: string) => ParsedT
 type TransferSTX = (
   amount: number | bigint,
   content: string,
-  sender: string
+  sender: string,
 ) => ParsedTransactionRes;
 
 type Tx =
@@ -132,8 +132,8 @@ const getSessionProxy = () => ({
             contract,
             method,
             args.map((a) => Cl.serialize(a)),
-            sender
-          )
+            sender,
+          ),
         );
         return parseTxResult(response);
       };

--- a/components/clarinet-sdk/src-ts/vfs.ts
+++ b/components/clarinet-sdk/src-ts/vfs.ts
@@ -43,13 +43,16 @@ async function readFiles(event: any) {
         console.warn(err);
         return null;
       }
-    })
+    }),
   );
   return Object.fromEntries(
-    files.reduce((acc, f, i) => {
-      if (f === null) return acc;
-      return acc.concat([[event.paths[i], fileArrayToString(f)]]);
-    }, [] as [string, string][])
+    files.reduce(
+      (acc, f, i) => {
+        if (f === null) return acc;
+        return acc.concat([[event.paths[i], fileArrayToString(f)]]);
+      },
+      [] as [string, string][],
+    ),
   );
 }
 

--- a/components/clarinet-sdk/tests/index.test.ts
+++ b/components/clarinet-sdk/tests/index.test.ts
@@ -166,6 +166,17 @@ describe("vm can get contracts info and deploy contracts", async () => {
     expect(noSource).toBeUndefined();
   });
 
+  it("can get contract ast", async () => {
+    const vm = await initVM(manifestPath);
+
+    let counterAst = vm.getContractAST(`${deployerAddr}.counter`);
+    expect(counterAst).toBeDefined();
+    expect(counterAst.expressions).toHaveLength(7);
+
+    let getWithShortAddr = vm.getContractAST("counter");
+    expect(getWithShortAddr).toBeDefined();
+  });
+
   it("can deploy contracts as snippets", async () => {
     const vm = await initVM(manifestPath);
 
@@ -191,5 +202,9 @@ describe("vm can get contracts info and deploy contracts", async () => {
 
     const opSource = vm.getContractSource("op");
     expect(opSource).toBe(source);
+
+    let opASt = vm.getContractAST("op");
+    expect(opASt).toBeDefined();
+    expect(opASt.expressions).toHaveLength(1);
   });
 });


### PR DESCRIPTION
### Description

Slightly change the Rust Struct of `SDK` to hold the whole contracts analysis (instead  of `contracts_sources: Hashmap, contract_asts: Hashmap` etc.

The `ContractAST` typescript type is still very basic (can't easily be transform from Rust to TypeScript because of cyclic properties) and can be greatly improved. For now, I wanted to have to recursive nature of `expr.List`.

The project with missing a prettier config so the formatting could get inconsistent. Add one.

