### PR TITLE
Build: improve wasm handling in clarinet-sdk

### DIFF
--- a/components/clarinet-sdk/.gitignore
+++ b/components/clarinet-sdk/.gitignore
@@ -1,3 +1,3 @@
 dist/
-src-ts/sdk
+shared
 node_modules/

--- a/components/clarinet-sdk/package-lock.json
+++ b/components/clarinet-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hirosystems/clarinet-sdk",
-  "version": "0.5.3",
+  "version": "0.5.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hirosystems/clarinet-sdk",
-      "version": "0.5.3",
+      "version": "0.5.6",
       "license": "GPL-3.0",
       "dependencies": {
         "@stacks/transactions": "^6.9.0",

--- a/components/clarinet-sdk/package.json
+++ b/components/clarinet-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hirosystems/clarinet-sdk",
-  "version": "0.5.6",
+  "version": "0.6.0",
   "description": "A SDK to interact with Clarity Smart Contracts",
   "repository": {
     "type": "git",
@@ -11,6 +11,7 @@
   },
   "files": [
     "dist",
+    "shared",
     "vitest-helpers/src"
   ],
   "main": "dist/cjs/index.js",

--- a/components/clarinet-sdk/src-ts/index.ts
+++ b/components/clarinet-sdk/src-ts/index.ts
@@ -9,11 +9,11 @@ import {
   DeployContractArgs,
   TransferSTXArgs,
   ContractOptions,
-} from "./sdk";
+} from "../shared/sdk";
 import { ContractAST } from "./contractAst";
 
-type WASMModule = typeof import("./sdk");
-const wasmModule = import("./sdk");
+type WASMModule = typeof import("../shared/sdk");
+const wasmModule = import("../shared/sdk");
 
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt#use_within_json
 // @ts-ignore

--- a/components/clarinet-sdk/webpack.config.js
+++ b/components/clarinet-sdk/webpack.config.js
@@ -16,8 +16,24 @@ const configBase = {
   mode: "production",
   resolve: { extensions: [".ts", ".js"] },
   optimization: {
-    minimize: false,
+    minimize: true,
   },
+};
+
+/** @type WebpackConfig */
+const configWASM = {
+  ...configBase,
+  entry: {
+    index: "./src-ts/index.ts",
+  },
+  target,
+  plugins: [
+    new WasmPackPlugin({
+      crateDirectory: path.resolve(__dirname, "./"),
+      extraArgs: "--release --target=bundler",
+      outDir: path.resolve(__dirname, "./shared/sdk"),
+    }),
+  ],
 };
 
 /** @type WebpackConfig */
@@ -46,16 +62,6 @@ const configESM = {
     asyncWebAssembly: true,
     outputModule: true,
   },
-  plugins: [
-    new WasmPackPlugin({
-      crateDirectory: path.resolve(__dirname, "./"),
-      extraArgs: "--release --target=bundler",
-      outDir: path.resolve(__dirname, "./src-ts/sdk"),
-    }),
-    new CopyPlugin({
-      patterns: [{ from: "./src-ts/sdk/index.d.ts", to: "sdk" }],
-    }),
-  ],
 };
 
 /** @type WebpackConfig */
@@ -88,14 +94,6 @@ const configCJS = {
     outputModule: false,
   },
   plugins: [
-    new WasmPackPlugin({
-      crateDirectory: path.resolve(__dirname, "./"),
-      extraArgs: "--release --target=bundler",
-      outDir: path.resolve(__dirname, "./src-ts/sdk"),
-    }),
-    new CopyPlugin({
-      patterns: [{ from: "./src-ts/sdk/index.d.ts", to: "sdk" }],
-    }),
     new CopyPlugin({
       patterns: [{ from: "./src-ts/bin/templates/", to: "bin/templates/" }],
     }),
@@ -107,4 +105,4 @@ const configCJS = {
   ],
 };
 
-module.exports = [configESM, configCJS];
+module.exports = [configWASM, configESM, configCJS];


### PR DESCRIPTION
### Description

The WASM package was build and bundled twice for ESM and CJS. This PR fixes it (dividing by 2 the package size)

