### PR TITLE
fix(sdk): deserialize events values as clarity values

### DIFF
--- a/components/clarinet-sdk/src/index.ts
+++ b/components/clarinet-sdk/src/index.ts
@@ -20,7 +20,10 @@ BigInt.prototype.toJSON = function () {
   return this.toString();
 };
 
-type ClarityEvent = { event: string; data: { [key: string]: any } };
+type ClarityEvent = {
+  event: string;
+  data: { raw_value?: string; value?: ClarityValue; [key: string]: any };
+};
 export type ParsedTransactionRes = {
   result: ClarityValue;
   events: ClarityEvent[];
@@ -125,6 +128,9 @@ function parseEvents(events: string): ClarityEvent[] {
     // @todo: improve type safety
     return JSON.parse(events).map((e: string) => {
       const { event, data } = JSON.parse(e);
+      if ("raw_value" in data) {
+        data.value = Cl.deserialize(data.raw_value);
+      }
       return {
         event: event,
         data: data,

--- a/components/clarinet-sdk/tests/index.test.ts
+++ b/components/clarinet-sdk/tests/index.test.ts
@@ -84,6 +84,11 @@ describe("vm can call contracts function", async () => {
     expect(res).toHaveProperty("result");
     expect(res).toHaveProperty("events");
     expect(res.result).toStrictEqual(Cl.ok(Cl.bool(true)));
+
+    expect(res.events).toHaveLength(2);
+    const printEvent = res.events[0];
+    expect(printEvent.event).toBe("print_event");
+    expect(printEvent.data.value).toStrictEqual(Cl.stringAscii("call increment"));
   });
 
   it("can call public functions with arguments", async () => {


### PR DESCRIPTION
### Description

Clarity event values should be transform to Stack.js values just like contract call responses

