### PR TITLE
Update introduction.md: Clean up

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -4,7 +4,6 @@ title: Overview
 ---
 # Clarinet Overview
 
-## What is Clarinet?
 
 [Clarinet](https://www.hiro.so/clarinet) provides a CLI package with a [clarity](https://clarity-lang.org/) runtime, a REPL, and a testing harness. Clarinet includes a Javascript library, a testing environment, and a browser-based Sandbox. With Clarinet, you can rigorously iterate on your smart contracts locally before moving into production.
 


### PR DESCRIPTION
"What is Clarinet?" right under Clarinet Overview is redundant.  The section also dives right into what Clarinet does instead of defining it