### PR TITLE
refactor(sdk): rename vm to simnet

### DIFF
--- a/components/clarinet-sdk/README.md
+++ b/components/clarinet-sdk/README.md
@@ -18,19 +18,19 @@ npm install @hirosystems/clarinet-sdk
 ### Usage
 
 ```ts
-import { initVM } from "@hirosystems/clarinet-sdk";
+import { initSimnet } from "@hirosystems/clarinet-sdk";
 import { Cl } from "@stacks/transactions";
 
 async function main() {
-  const vm = await initVM();
+  const simnet = await initSimnet();
 
-  const accounts = vm.getAccounts();
+  const accounts = simnet.getAccounts();
   const w1 = accounts.get("wallet_1")!;
 
-  const call = vm.callPublicFn("counter", "add", [Cl.uint(1)], w1);
+  const call = simnet.callPublicFn("counter", "add", [Cl.uint(1)], w1);
   console.log(call.result); // Cl.int(Cl.ok(true))
 
-  const counter = vm.getDataVar("counter", "counter");
+  const counter = simnet.getDataVar("counter", "counter");
   console.log(counter); // Cl.int(2)
 }
 
@@ -40,7 +40,7 @@ main();
 By default, the SDK will look for a Clarinet.toml file in the current working directory.
 It's also possible to provide the path to the manifest like so:
 ```ts
- const vm = await initVM("./path/to/Clarinet.toml");
+ const simnet = await initSimnet("./path/to/Clarinet.toml");
 ```
 
 ## Tests

--- a/components/clarinet-sdk/package-lock.json
+++ b/components/clarinet-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hirosystems/clarinet-sdk",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hirosystems/clarinet-sdk",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "GPL-3.0",
       "dependencies": {
         "@hirosystems/clarinet-sdk-wasm": "^1.0.0",

--- a/components/clarinet-sdk/package.json
+++ b/components/clarinet-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hirosystems/clarinet-sdk",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "A SDK to interact with Clarity Smart Contracts",
   "repository": {
     "type": "git",

--- a/components/clarinet-sdk/templates/tests/contract.test.ts
+++ b/components/clarinet-sdk/templates/tests/contract.test.ts
@@ -1,6 +1,6 @@
-import { beforeAll, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
-const accounts = vm.getAccounts();
+const accounts = simnet.getAccounts();
 const address1 = accounts.get("wallet_1")!;
 
 /*
@@ -9,12 +9,12 @@ const address1 = accounts.get("wallet_1")!;
 */
 
 describe("example tests", () => {
-  it("ensures vm is well initalise", () => {
-    expect(vm.blockHeight).toBe(1);
+  it("ensures simnet is well initalise", () => {
+    expect(simnet.blockHeight).toBe(1);
   });
 
   // it("shows an example", () => {
-  //   const { result } = vm.callReadOnlyFn("counter", "get-counter", [], w1);
+  //   const { result } = simnet.callReadOnlyFn("counter", "get-counter", [], address1);
   //   expect(result).toBeUint(0);
   // });
 });

--- a/components/clarinet-sdk/tests/index.test.ts
+++ b/components/clarinet-sdk/tests/index.test.ts
@@ -10,23 +10,23 @@ const address1 = "ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5";
 
 const manifestPath = "tests/fixtures/Clarinet.toml";
 
-describe("basic vm interactions", async () => {
-  it("initialize vm", async () => {
-    const vm = await initSimnet(manifestPath);
-    expect(vm.blockHeight).toBe(1);
+describe("basic simnet interactions", async () => {
+  it("initialize simnet", async () => {
+    const simnet = await initSimnet(manifestPath);
+    expect(simnet.blockHeight).toBe(1);
   });
 
   it("can mine empty blocks", async () => {
-    const vm = await initSimnet(manifestPath);
-    vm.mineEmptyBlock();
-    expect(vm.blockHeight).toBe(2);
-    vm.mineEmptyBlocks(4);
-    expect(vm.blockHeight).toBe(6);
+    const simnet = await initSimnet(manifestPath);
+    simnet.mineEmptyBlock();
+    expect(simnet.blockHeight).toBe(2);
+    simnet.mineEmptyBlocks(4);
+    expect(simnet.blockHeight).toBe(6);
   });
 
   it("exposes devnet stacks accounts", async () => {
-    const vm = await initSimnet(manifestPath);
-    const accounts = vm.getAccounts();
+    const simnet = await initSimnet(manifestPath);
+    const accounts = simnet.getAccounts();
 
     expect(accounts).toHaveLength(4);
     expect(accounts.get("deployer")).toBe(deployerAddr);
@@ -34,34 +34,34 @@ describe("basic vm interactions", async () => {
   });
 
   it("expose assets maps", async () => {
-    const vm = await initSimnet(manifestPath);
+    const simnet = await initSimnet(manifestPath);
 
-    const assets = vm.getAssetsMap();
+    const assets = simnet.getAssetsMap();
     expect(assets.get("STX")).toHaveLength(4);
     expect(assets.get("STX")?.get(address1)).toBe(100000000000000n);
   });
 
   it("can get and set epoch", async () => {
-    const vm = await initSimnet(manifestPath);
+    const simnet = await initSimnet(manifestPath);
 
     // should be 2.4 by default
-    expect(vm.currentEpoch).toBe("2.4");
+    expect(simnet.currentEpoch).toBe("2.4");
 
-    vm.setEpoch("2.0");
-    expect(vm.currentEpoch).toBe("2.0");
+    simnet.setEpoch("2.0");
+    expect(simnet.currentEpoch).toBe("2.0");
 
     // @ts-ignore
     // "0" is an invalid epoch
     // it logs that 0 is invalid and defaults to 2.4
-    vm.setEpoch("0");
-    expect(vm.currentEpoch).toBe("2.4");
+    simnet.setEpoch("0");
+    expect(simnet.currentEpoch).toBe("2.4");
   });
 });
 
-describe("vm can call contracts function", async () => {
+describe("simnet can call contracts function", async () => {
   it("can call read only functions", async () => {
-    const vm = await initSimnet(manifestPath);
-    const res = vm.callReadOnlyFn("counter", "get-count", [], address1);
+    const simnet = await initSimnet(manifestPath);
+    const res = simnet.callReadOnlyFn("counter", "get-count", [], address1);
 
     expect(res).toHaveProperty("result");
     expect(res).toHaveProperty("events");
@@ -69,17 +69,17 @@ describe("vm can call contracts function", async () => {
   });
 
   it("does not increase block height when calling read-only functions", async () => {
-    const vm = await initSimnet(manifestPath);
-    const initalBH = vm.blockHeight;
+    const simnet = await initSimnet(manifestPath);
+    const initalBH = simnet.blockHeight;
 
-    vm.callReadOnlyFn("counter", "get-count", [], address1);
-    vm.callReadOnlyFn("counter", "get-count", [], address1);
-    expect(vm.blockHeight).toBe(initalBH);
+    simnet.callReadOnlyFn("counter", "get-count", [], address1);
+    simnet.callReadOnlyFn("counter", "get-count", [], address1);
+    expect(simnet.blockHeight).toBe(initalBH);
   });
 
   it("can call public functions", async () => {
-    const vm = await initSimnet(manifestPath);
-    const res = vm.callPublicFn("counter", "increment", [], address1);
+    const simnet = await initSimnet(manifestPath);
+    const res = simnet.callPublicFn("counter", "increment", [], address1);
 
     expect(res).toHaveProperty("result");
     expect(res).toHaveProperty("events");
@@ -92,8 +92,8 @@ describe("vm can call contracts function", async () => {
   });
 
   it("can call public functions with arguments", async () => {
-    const vm = await initSimnet(manifestPath);
-    const res = vm.callPublicFn("counter", "add", [Cl.uint(2)], address1);
+    const simnet = await initSimnet(manifestPath);
+    const res = simnet.callPublicFn("counter", "add", [Cl.uint(2)], address1);
 
     expect(res).toHaveProperty("result");
     expect(res).toHaveProperty("events");
@@ -101,19 +101,19 @@ describe("vm can call contracts function", async () => {
   });
 
   it("increases block height when calling public functions", async () => {
-    const vm = await initSimnet(manifestPath);
-    const initalBH = vm.blockHeight;
+    const simnet = await initSimnet(manifestPath);
+    const initalBH = simnet.blockHeight;
 
-    vm.callPublicFn("counter", "increment", [], address1);
-    vm.callPublicFn("counter", "increment", [], address1);
-    expect(vm.blockHeight).toBe(initalBH + 2);
+    simnet.callPublicFn("counter", "increment", [], address1);
+    simnet.callPublicFn("counter", "increment", [], address1);
+    expect(simnet.blockHeight).toBe(initalBH + 2);
   });
 
   it("can call public functions in the same block", async () => {
-    const vm = await initSimnet(manifestPath);
-    const initalBH = vm.blockHeight;
+    const simnet = await initSimnet(manifestPath);
+    const initalBH = simnet.blockHeight;
 
-    const res = vm.mineBlock([
+    const res = simnet.mineBlock([
       tx.callPublicFn("counter", "increment", [], address1),
       tx.callPublicFn("counter", "increment", [], address1),
     ]);
@@ -124,19 +124,19 @@ describe("vm can call contracts function", async () => {
     expect(res[0].result).toStrictEqual(Cl.ok(Cl.bool(true)));
     expect(res[1].result).toStrictEqual(Cl.ok(Cl.bool(true)));
 
-    const counterVal = vm.callReadOnlyFn("counter", "get-count", [], address1);
+    const counterVal = simnet.callReadOnlyFn("counter", "get-count", [], address1);
     expect(counterVal.result).toStrictEqual(Cl.ok(Cl.tuple({ count: Cl.uint(2) })));
 
-    expect(vm.blockHeight).toStrictEqual(initalBH + 1);
+    expect(simnet.blockHeight).toStrictEqual(initalBH + 1);
   });
 
   it("can get updated assets map", async () => {
-    const vm = await initSimnet(manifestPath);
+    const simnet = await initSimnet(manifestPath);
 
-    vm.callPublicFn("counter", "increment", [], address1);
-    vm.callPublicFn("counter", "increment", [], address1);
+    simnet.callPublicFn("counter", "increment", [], address1);
+    simnet.callPublicFn("counter", "increment", [], address1);
 
-    const assets = vm.getAssetsMap();
+    const assets = simnet.getAssetsMap();
     const STX = assets.get("STX")!;
     expect(STX).toHaveLength(5);
     expect(STX.get(address1)).toStrictEqual(99999998000000n);
@@ -144,30 +144,30 @@ describe("vm can call contracts function", async () => {
   });
 });
 
-describe("vm can read contracts data vars and maps", async () => {
+describe("simnet can read contracts data vars and maps", async () => {
   it("can get data-vars", async () => {
-    const vm = await initSimnet(manifestPath);
+    const simnet = await initSimnet(manifestPath);
 
-    const counter = vm.getDataVar("counter", "count");
+    const counter = simnet.getDataVar("counter", "count");
     expect(counter).toStrictEqual(Cl.uint(0));
   });
 
   it("can get map entry", async () => {
-    const vm = await initSimnet(manifestPath);
+    const simnet = await initSimnet(manifestPath);
 
     // add a participant in the map
-    vm.callPublicFn("counter", "increment", [], address1);
+    simnet.callPublicFn("counter", "increment", [], address1);
 
-    const p = vm.getMapEntry("counter", "participants", Cl.standardPrincipal(address1));
+    const p = simnet.getMapEntry("counter", "participants", Cl.standardPrincipal(address1));
     expect(p).toStrictEqual(Cl.some(Cl.bool(true)));
   });
 });
 
-describe("vm can get contracts info and deploy contracts", async () => {
+describe("simnet can get contracts info and deploy contracts", async () => {
   it("can get contract interfaces", async () => {
-    const vm = await initSimnet(manifestPath);
+    const simnet = await initSimnet(manifestPath);
 
-    const contractInterfaces = vm.getContractsInterfaces();
+    const contractInterfaces = simnet.getContractsInterfaces();
     expect(contractInterfaces).toHaveLength(1);
 
     const counterInterface = contractInterfaces.get(`${deployerAddr}.counter`);
@@ -178,108 +178,108 @@ describe("vm can get contracts info and deploy contracts", async () => {
   });
 
   it("can get contract source", async () => {
-    const vm = await initSimnet(manifestPath);
+    const simnet = await initSimnet(manifestPath);
 
-    const counterSource = vm.getContractSource(`${deployerAddr}.counter`);
+    const counterSource = simnet.getContractSource(`${deployerAddr}.counter`);
     expect(counterSource?.startsWith("(define-data-var count")).toBe(true);
 
-    const counterSourceShortAddr = vm.getContractSource("counter");
+    const counterSourceShortAddr = simnet.getContractSource("counter");
     expect(counterSourceShortAddr).toBe(counterSource);
 
-    const noSource = vm.getContractSource(`${deployerAddr}.not-counter`);
+    const noSource = simnet.getContractSource(`${deployerAddr}.not-counter`);
     expect(noSource).toBeUndefined();
   });
 
   it("can get contract ast", async () => {
-    const vm = await initSimnet(manifestPath);
+    const simnet = await initSimnet(manifestPath);
 
-    const counterAst = vm.getContractAST(`${deployerAddr}.counter`);
+    const counterAst = simnet.getContractAST(`${deployerAddr}.counter`);
     expect(counterAst).toBeDefined();
     expect(counterAst.expressions).toHaveLength(7);
 
-    const getWithShortAddr = vm.getContractAST("counter");
+    const getWithShortAddr = simnet.getContractAST("counter");
     expect(getWithShortAddr).toBeDefined();
   });
 
   it("can deploy contracts as snippets", async () => {
-    const vm = await initSimnet(manifestPath);
+    const simnet = await initSimnet(manifestPath);
 
-    const res = vm.deployContract("temp", "(+ 24 18)", null, deployerAddr);
+    const res = simnet.deployContract("temp", "(+ 24 18)", null, deployerAddr);
     expect(res.result).toStrictEqual(Cl.int(42));
 
-    const contractInterfaces = vm.getContractsInterfaces();
+    const contractInterfaces = simnet.getContractsInterfaces();
     expect(contractInterfaces).toHaveLength(1);
   });
 
   it("can deploy contracts", async () => {
-    const vm = await initSimnet(manifestPath);
+    const simnet = await initSimnet(manifestPath);
 
     const source = "(define-public (add (a uint) (b uint)) (ok (+ a b)))\n";
-    const deployRes = vm.deployContract("op", source, null, deployerAddr);
+    const deployRes = simnet.deployContract("op", source, null, deployerAddr);
     expect(deployRes.result).toStrictEqual(Cl.bool(true));
 
-    const contractInterfaces = vm.getContractsInterfaces();
+    const contractInterfaces = simnet.getContractsInterfaces();
     expect(contractInterfaces).toHaveLength(2);
 
-    const addRes = vm.callPublicFn("op", "add", [Cl.uint(13), Cl.uint(29)], address1);
+    const addRes = simnet.callPublicFn("op", "add", [Cl.uint(13), Cl.uint(29)], address1);
     expect(addRes.result).toStrictEqual(Cl.ok(Cl.uint(42)));
 
-    const opSource = vm.getContractSource("op");
+    const opSource = simnet.getContractSource("op");
     expect(opSource).toBe(source);
 
-    const opASt = vm.getContractAST("op");
+    const opASt = simnet.getContractAST("op");
     expect(opASt).toBeDefined();
     expect(opASt.expressions).toHaveLength(1);
   });
 
   it("can deploy contract with a given clarity_version", async () => {
-    const vm = await initSimnet(manifestPath);
+    const simnet = await initSimnet(manifestPath);
 
     const source = "(define-public (add (a uint) (b uint)) (ok (+ a b)))\n";
 
-    vm.deployContract("contract1", source, { clarityVersion: 1 }, deployerAddr);
-    const contract1Interface = vm.getContractsInterfaces().get(`${vm.deployer}.contract1`)!;
+    simnet.deployContract("contract1", source, { clarityVersion: 1 }, deployerAddr);
+    const contract1Interface = simnet.getContractsInterfaces().get(`${simnet.deployer}.contract1`)!;
     expect(contract1Interface.epoch).toBe("Epoch24");
     expect(contract1Interface.clarity_version).toBe("Clarity1");
 
-    vm.deployContract("contract2", source, { clarityVersion: 2 }, deployerAddr);
-    const contract2Interface = vm.getContractsInterfaces().get(`${vm.deployer}.contract2`)!;
+    simnet.deployContract("contract2", source, { clarityVersion: 2 }, deployerAddr);
+    const contract2Interface = simnet.getContractsInterfaces().get(`${simnet.deployer}.contract2`)!;
     expect(contract2Interface.epoch).toBe("Epoch24");
     expect(contract2Interface.clarity_version).toBe("Clarity2");
 
-    vm.setEpoch("2.0");
-    vm.deployContract("contract3", source, { clarityVersion: 1 }, deployerAddr);
-    const contract3Interface = vm.getContractsInterfaces().get(`${vm.deployer}.contract3`)!;
+    simnet.setEpoch("2.0");
+    simnet.deployContract("contract3", source, { clarityVersion: 1 }, deployerAddr);
+    const contract3Interface = simnet.getContractsInterfaces().get(`${simnet.deployer}.contract3`)!;
     expect(contract3Interface.epoch).toBe("Epoch20");
     expect(contract3Interface.clarity_version).toBe("Clarity1");
   });
 });
 
-describe("vm can get session reports", async () => {
+describe("simnet can get session reports", async () => {
   it("can get line coverage", async () => {
-    const vm = await initSimnet(manifestPath);
+    const simnet = await initSimnet(manifestPath);
 
-    vm.callPublicFn("counter", "increment", [], address1);
-    vm.callPublicFn("counter", "increment", [], address1);
+    simnet.callPublicFn("counter", "increment", [], address1);
+    simnet.callPublicFn("counter", "increment", [], address1);
 
-    const reports = vm.collectReport();
+    const reports = simnet.collectReport();
     expect(reports.coverage.startsWith("TN:")).toBe(true);
     expect(reports.coverage.endsWith("end_of_record\n")).toBe(true);
   });
 
   it("can get costs", async () => {
-    const vm = await initSimnet(manifestPath);
+    const simnet = await initSimnet(manifestPath);
 
-    vm.callPublicFn("counter", "increment", [], address1);
+    simnet.callPublicFn("counter", "increment", [], address1);
 
-    const reports = vm.collectReport();
+    const reports = simnet.collectReport();
     expect(() => JSON.parse(reports.costs)).not.toThrow();
 
     const parsedReports = JSON.parse(reports.costs);
     expect(parsedReports).toHaveLength(1);
 
     const report = parsedReports[0];
-    expect(report.contract_id).toBe(`${vm.deployer}.counter`);
+    expect(report.contract_id).toBe(`${simnet.deployer}.counter`);
     expect(report.method).toBe("increment");
     expect(report.cost_result.total.write_count).toBe(3);
   });

--- a/components/clarinet-sdk/vitest-helpers/src/global.d.ts
+++ b/components/clarinet-sdk/vitest-helpers/src/global.d.ts
@@ -1,7 +1,7 @@
-import type { ClarityVM } from "../../dist/esm";
+import type { Simnet } from "../../dist/esm";
 
 declare global {
-  var vm: ClarityVM;
+  var simnet: Simnet;
   var testEnvironment: string;
   var coverageReports: string[];
   var costsReports: string[];

--- a/components/clarinet-sdk/vitest-helpers/src/vitest.setup.ts
+++ b/components/clarinet-sdk/vitest-helpers/src/vitest.setup.ts
@@ -21,13 +21,13 @@ beforeEach(async (ctx) => {
   const { coverage, initBeforeEach, manifestPath } = global.options.clarinet;
 
   if (initBeforeEach) {
-    await vm.initSession(process.cwd(), manifestPath);
+    await simnet.initSession(process.cwd(), manifestPath);
   }
 
   if (coverage) {
     const suiteTestNames = getFullTestName(ctx.task, []);
     const fullName = [ctx.task.file?.name || "", ...suiteTestNames].join("__");
-    vm.setCurrentTestName(fullName);
+    simnet.setCurrentTestName(fullName);
   }
 });
 
@@ -35,7 +35,7 @@ afterEach(async () => {
   const { coverage, costs, initBeforeEach } = global.options.clarinet;
 
   if (initBeforeEach && (coverage || costs)) {
-    const report = vm.collectReport();
+    const report = simnet.collectReport();
     if (coverage) coverageReports.push(report.coverage);
     if (costs) costsReports.push(report.costs);
   }
@@ -45,7 +45,7 @@ beforeAll(async () => {
   const { initBeforeEach, manifestPath } = global.options.clarinet;
 
   if (!initBeforeEach) {
-    await vm.initSession(process.cwd(), manifestPath);
+    await simnet.initSession(process.cwd(), manifestPath);
   }
 });
 
@@ -53,7 +53,7 @@ afterAll(() => {
   const { coverage, costs, initBeforeEach } = global.options.clarinet;
 
   if (!initBeforeEach && (coverage || costs)) {
-    const report = vm.collectReport();
+    const report = simnet.collectReport();
     if (coverage) coverageReports.push(report.coverage);
     if (costs) costsReports.push(report.costs);
   }


### PR DESCRIPTION
### Description

In the the clarinet-sdk, the naming `vm` as in `initVM` and `ClarityVM` where never satisfying. But we kept it lacking better alternative.

After talking with Ludo, we agreed that `simnet` was a better option
- it'll explicit tell developers what the `simnet` (it's basically what you interact with when using the SDK)
- it's not super intuitive, but `vm` wasn't either
- `simnet.mineBlock()` makes wayyy more sense than `vm.mineBlock()` (which doesn't make any)

This PR only changes the JS layer since the rust code doesn't make any mention of the `VM` wording in this context.

The Rust layer (components/clarinet-sdk-wasm) exposes a SDK constructor (which could be improved but is kind of okay. And isn't visible to end user since it's abstracted by the JS layer). It exposes an `init_session` methods that matches the rest of the clarinet code base, such as `initiate_session_from_deployment`). This method isn't meant to be used by end developers either

