### PR TITLE
fix(sdk): throw error if invalid deployments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,6 +714,7 @@ dependencies = [
  "clarinet-files",
  "clarinet-utils 1.0.0",
  "clarity-repl 1.8.0",
+ "colored 2.0.4",
  "libsecp256k1 0.7.1",
  "reqwest",
  "serde",
@@ -748,7 +749,7 @@ dependencies = [
 
 [[package]]
 name = "clarinet-sdk-wasm"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "clarinet-deployments",
  "clarinet-files",
@@ -804,7 +805,7 @@ version = "1.0.0"
 dependencies = [
  "chrono",
  "clarity-repl 1.8.0",
- "colored",
+ "colored 1.9.3",
  "dirs",
  "failure",
  "hex 0.3.2",
@@ -976,6 +977,17 @@ dependencies = [
  "atty",
  "lazy_static",
  "winapi",
+]
+
+[[package]]
+name = "colored"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2674ec482fbc38012cf31e6c42ba0177b431a0cb6f15fe40efa5aab1bda516f6"
+dependencies = [
+ "is-terminal",
+ "lazy_static",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/components/clarinet-cli/Cargo.toml
+++ b/components/clarinet-cli/Cargo.toml
@@ -28,9 +28,6 @@ log = { version = "=0.4.17", features = ["serde"] }
 signal-hook-registry = "1.4.0"
 secure_tempfile = { version = "3.8.0", package = "tempfile" }
 tokio-util = { version = "0.7.1", features = ["io"], optional = true }
-clarity_repl = { package = "clarity-repl", path = "../clarity-repl", features = [
-    "cli",
-] }
 libsecp256k1 = "0.7.0"
 hmac = "0.12.0"
 pbkdf2 = { version = "0.11.0", features = ["simple"], default-features = false }
@@ -60,18 +57,22 @@ mac_address = { version = "1.1.2", optional = true }
 tower-lsp = { version = "0.19.0", optional = true }
 hex = "0.4.3"
 serde_yaml = "0.8.23"
-clarinet-files = { path = "../clarinet-files", features = ["cli"] }
-clarity-lsp = { path = "../clarity-lsp", features = ["cli"] }
-clarinet-deployments = { path = "../clarinet-deployments", features = ["cli"] }
-hiro-system-kit = { path = "../hiro-system-kit" }
-clarinet-utils = { path = "../clarinet-utils" }
-stacks-network = { path = "../stacks-network" }
 num_cpus = "1.13.1"
 mio = "0.8"
 similar = "2.1.0"
 crossbeam-channel = "0.5.6"
 chrono = "0.4.31"
 sha2 = "0.10.0"
+
+clarity_repl = { package = "clarity-repl", path = "../clarity-repl", features = [
+    "cli",
+] }
+clarinet-files = { path = "../clarinet-files", features = ["cli"] }
+clarity-lsp = { path = "../clarity-lsp", features = ["cli"] }
+clarinet-deployments = { path = "../clarinet-deployments", features = ["cli"] }
+hiro-system-kit = { path = "../hiro-system-kit" }
+clarinet-utils = { path = "../clarinet-utils" }
+stacks-network = { path = "../stacks-network" }
 
 [dependencies.tui]
 version = "0.18.0"

--- a/components/clarinet-deployments/Cargo.toml
+++ b/components/clarinet-deployments/Cargo.toml
@@ -4,6 +4,7 @@ version = "1.0.1"
 edition = "2021"
 
 [dependencies]
+colored = "2.0.4"
 serde = "1"
 serde_json = "1"
 serde_derive = "1"

--- a/components/clarinet-deployments/src/diagnostic_digest.rs
+++ b/components/clarinet-deployments/src/diagnostic_digest.rs
@@ -1,0 +1,110 @@
+use std::collections::HashMap;
+
+use clarity_repl::{
+    clarity::{
+        diagnostic::{Diagnostic, Level},
+        vm::types::QualifiedContractIdentifier,
+    },
+    repl::diagnostic::output_code,
+};
+use colored::*;
+
+use crate::types::DeploymentSpecification;
+
+#[allow(dead_code)]
+pub struct DiagnosticsDigest {
+    pub message: String,
+    pub errors: usize,
+    pub warnings: usize,
+    pub contracts_checked: usize,
+    full_success: usize,
+    total: usize,
+}
+
+impl DiagnosticsDigest {
+    pub fn new(
+        contracts_diags: &HashMap<QualifiedContractIdentifier, Vec<Diagnostic>>,
+        deployment: &DeploymentSpecification,
+    ) -> DiagnosticsDigest {
+        let mut full_success = 0;
+        let mut warnings = 0;
+        let mut errors = 0;
+        let mut contracts_checked = 0;
+        let mut outputs = vec![];
+        let total = deployment.contracts.len();
+
+        for (contract_id, diags) in contracts_diags.into_iter() {
+            let (source, contract_location) = match deployment.contracts.get(&contract_id) {
+                Some(entry) => {
+                    contracts_checked += 1;
+                    entry
+                }
+                None => {
+                    // `deployment.contracts` only includes contracts from the project, requirements should be ignored
+                    continue;
+                }
+            };
+            if diags.is_empty() {
+                full_success += 1;
+                continue;
+            }
+
+            let lines = source.lines();
+            let formatted_lines: Vec<String> = lines.map(|l| l.to_string()).collect();
+
+            for diagnostic in diags {
+                match diagnostic.level {
+                    Level::Error => {
+                        errors += 1;
+                        outputs.push(format!("{} {}", "error:".red().bold(), diagnostic.message));
+                    }
+                    Level::Warning => {
+                        warnings += 1;
+                        outputs.push(format!(
+                            "{} {}",
+                            "warning:".yellow().bold(),
+                            diagnostic.message
+                        ));
+                    }
+                    Level::Note => {
+                        outputs.push(format!("{}: {}", "note:".blue().bold(), diagnostic.message));
+                        outputs.append(&mut output_code(&diagnostic, &formatted_lines));
+                        continue;
+                    }
+                }
+                let contract_path = match contract_location.get_relative_location() {
+                    Ok(contract_path) => contract_path,
+                    _ => contract_location.to_string(),
+                };
+
+                if let Some(span) = diagnostic.spans.first() {
+                    outputs.push(format!(
+                        "{} {}:{}:{}",
+                        "-->".blue().bold(),
+                        contract_path,
+                        span.start_line,
+                        span.start_column
+                    ));
+                }
+                outputs.append(&mut output_code(&diagnostic, &formatted_lines));
+
+                if let Some(ref suggestion) = diagnostic.suggestion {
+                    outputs.push(format!("{}", suggestion));
+                }
+            }
+        }
+
+        DiagnosticsDigest {
+            full_success,
+            errors,
+            warnings,
+            total,
+            contracts_checked,
+            message: outputs.join("\n").to_string(),
+        }
+    }
+
+    pub fn has_feedbacks(&self) -> bool {
+        self.errors > 0 || self.warnings > 0
+    }
+}

--- a/components/clarinet-deployments/src/lib.rs
+++ b/components/clarinet-deployments/src/lib.rs
@@ -7,6 +7,7 @@ extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 
+pub mod diagnostic_digest;
 #[cfg(feature = "onchain")]
 pub mod onchain;
 pub mod requirements;

--- a/components/clarinet-sdk-wasm/Cargo.toml
+++ b/components/clarinet-sdk-wasm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "clarinet-sdk-wasm"
-version = "1.0.2"
+version = "1.0.3"
 license = "GPL-3.0"
 repository = "https://github.com/hirosystems/clarinet"
 description = "The core lib that powers @hirosystems/clarinet-sdk"

--- a/components/clarinet-sdk/src/index.ts
+++ b/components/clarinet-sdk/src/index.ts
@@ -242,8 +242,6 @@ function memoizedInit() {
   return async (manifestPath = "./Clarinet.toml") => {
     if (!simnet) {
       const module = await wasmModule;
-
-      console.log("init stacks simnet");
       simnet = new Proxy(new module.SDK(vfs), getSessionProxy()) as unknown as Simnet;
     }
 

--- a/components/clarinet-sdk/tests/fixtures/InvalidManifest.toml
+++ b/components/clarinet-sdk/tests/fixtures/InvalidManifest.toml
@@ -1,0 +1,11 @@
+[project]
+name = 'invalid'
+description = 'invalid project to test clarinet-sdk'
+telemetry = false
+cache_dir = './.cache'
+requirements = []
+
+[contracts.invalid]
+path = 'contracts/invalid.clar'
+clarity_version = 2
+epoch = 2.4

--- a/components/clarinet-sdk/tests/fixtures/contracts/invalid.clar
+++ b/components/clarinet-sdk/tests/fixtures/contracts/invalid.clar
@@ -1,0 +1,5 @@
+(define-data-var count uint u0)
+
+(define-read-only  (get-count)
+  (ok { count: (var-get count) })
+)) ;; extra `)`

--- a/components/clarinet-sdk/tests/index.test.ts
+++ b/components/clarinet-sdk/tests/index.test.ts
@@ -1,24 +1,26 @@
-import { Cl, ClarityType } from "@stacks/transactions";
-import { describe, expect, it } from "vitest";
+import { Cl } from "@stacks/transactions";
+import { describe, expect, it, beforeEach, beforeAll } from "vitest";
 
 // test the built package and not the source code
 // makes it simpler to handle wasm build
-import { initSimnet, tx } from "../";
+import { Simnet, initSimnet, tx } from "../";
 
 const deployerAddr = "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM";
 const address1 = "ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5";
 const address2 = "ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG";
 
-const manifestPath = "tests/fixtures/Clarinet.toml";
+let simnet: Simnet;
+
+beforeEach(async () => {
+  simnet = await initSimnet("tests/fixtures/Clarinet.toml");
+});
 
 describe("basic simnet interactions", async () => {
   it("initialize simnet", async () => {
-    const simnet = await initSimnet(manifestPath);
     expect(simnet.blockHeight).toBe(1);
   });
 
   it("can mine empty blocks", async () => {
-    const simnet = await initSimnet(manifestPath);
     simnet.mineEmptyBlock();
     expect(simnet.blockHeight).toBe(2);
     simnet.mineEmptyBlocks(4);
@@ -26,7 +28,6 @@ describe("basic simnet interactions", async () => {
   });
 
   it("exposes devnet stacks accounts", async () => {
-    const simnet = await initSimnet(manifestPath);
     const accounts = simnet.getAccounts();
 
     expect(accounts).toHaveLength(4);
@@ -35,16 +36,12 @@ describe("basic simnet interactions", async () => {
   });
 
   it("expose assets maps", async () => {
-    const simnet = await initSimnet(manifestPath);
-
     const assets = simnet.getAssetsMap();
     expect(assets.get("STX")).toHaveLength(4);
     expect(assets.get("STX")?.get(address1)).toBe(100000000000000n);
   });
 
   it("can get and set epoch", async () => {
-    const simnet = await initSimnet(manifestPath);
-
     // should be 2.4 by default
     expect(simnet.currentEpoch).toBe("2.4");
 
@@ -61,7 +58,6 @@ describe("basic simnet interactions", async () => {
 
 describe("simnet can call contracts function", async () => {
   it("can call read only functions", async () => {
-    const simnet = await initSimnet(manifestPath);
     const res = simnet.callReadOnlyFn("counter", "get-count", [], address1);
 
     expect(res).toHaveProperty("result");
@@ -70,7 +66,6 @@ describe("simnet can call contracts function", async () => {
   });
 
   it("does not increase block height when calling read-only functions", async () => {
-    const simnet = await initSimnet(manifestPath);
     const initalBH = simnet.blockHeight;
 
     simnet.callReadOnlyFn("counter", "get-count", [], address1);
@@ -79,7 +74,6 @@ describe("simnet can call contracts function", async () => {
   });
 
   it("can call public functions", async () => {
-    const simnet = await initSimnet(manifestPath);
     const res = simnet.callPublicFn("counter", "increment", [], address1);
 
     expect(res).toHaveProperty("result");
@@ -93,7 +87,6 @@ describe("simnet can call contracts function", async () => {
   });
 
   it("can call public functions with arguments", async () => {
-    const simnet = await initSimnet(manifestPath);
     const res = simnet.callPublicFn("counter", "add", [Cl.uint(2)], address1);
 
     expect(res).toHaveProperty("result");
@@ -102,7 +95,6 @@ describe("simnet can call contracts function", async () => {
   });
 
   it("increases block height when calling public functions", async () => {
-    const simnet = await initSimnet(manifestPath);
     const initalBH = simnet.blockHeight;
 
     simnet.callPublicFn("counter", "increment", [], address1);
@@ -111,7 +103,6 @@ describe("simnet can call contracts function", async () => {
   });
 
   it("can call public functions in the same block", async () => {
-    const simnet = await initSimnet(manifestPath);
     const initalBH = simnet.blockHeight;
 
     const res = simnet.mineBlock([
@@ -132,8 +123,6 @@ describe("simnet can call contracts function", async () => {
   });
 
   it("can get updated assets map", async () => {
-    const simnet = await initSimnet(manifestPath);
-
     simnet.callPublicFn("counter", "increment", [], address1);
     simnet.callPublicFn("counter", "increment", [], address1);
 
@@ -145,16 +134,12 @@ describe("simnet can call contracts function", async () => {
   });
 
   it("can pass principals as arguments", async () => {
-    const simnet = await initSimnet(manifestPath);
-
     const to = Cl.standardPrincipal(address2);
     const { result } = simnet.callPublicFn("counter", "transfer-100", [to], address1);
     expect(result).toStrictEqual(Cl.ok(Cl.bool(true)));
   });
 
   it("can pass traits as arguments", async () => {
-    const simnet = await initSimnet(manifestPath);
-
     const trait = Cl.contractPrincipal(simnet.deployer, "multiplier-contract");
     const { result } = simnet.callPublicFn("counter", "call-multiply", [trait], address1);
     expect(result).toStrictEqual(Cl.ok(Cl.uint(4)));
@@ -163,15 +148,11 @@ describe("simnet can call contracts function", async () => {
 
 describe("simnet can read contracts data vars and maps", async () => {
   it("can get data-vars", async () => {
-    const simnet = await initSimnet(manifestPath);
-
     const counter = simnet.getDataVar("counter", "count");
     expect(counter).toStrictEqual(Cl.uint(0));
   });
 
   it("can get map entry", async () => {
-    const simnet = await initSimnet(manifestPath);
-
     // add a participant in the map
     simnet.callPublicFn("counter", "increment", [], address1);
 
@@ -182,8 +163,6 @@ describe("simnet can read contracts data vars and maps", async () => {
 
 describe("simnet can get contracts info and deploy contracts", async () => {
   it("can get contract interfaces", async () => {
-    const simnet = await initSimnet(manifestPath);
-
     const contractInterfaces = simnet.getContractsInterfaces();
     expect(contractInterfaces).toHaveLength(3);
 
@@ -195,8 +174,6 @@ describe("simnet can get contracts info and deploy contracts", async () => {
   });
 
   it("can get contract source", async () => {
-    const simnet = await initSimnet(manifestPath);
-
     const counterSource = simnet.getContractSource(`${deployerAddr}.counter`);
     expect(counterSource?.startsWith("(define-data-var count")).toBe(true);
 
@@ -208,8 +185,6 @@ describe("simnet can get contracts info and deploy contracts", async () => {
   });
 
   it("can get contract ast", async () => {
-    const simnet = await initSimnet(manifestPath);
-
     const counterAst = simnet.getContractAST(`${deployerAddr}.counter`);
     expect(counterAst).toBeDefined();
     expect(counterAst.expressions).toHaveLength(10);
@@ -219,8 +194,6 @@ describe("simnet can get contracts info and deploy contracts", async () => {
   });
 
   it("can deploy contracts as snippets", async () => {
-    const simnet = await initSimnet(manifestPath);
-
     const res = simnet.deployContract("temp", "(+ 24 18)", null, deployerAddr);
     expect(res.result).toStrictEqual(Cl.int(42));
 
@@ -229,8 +202,6 @@ describe("simnet can get contracts info and deploy contracts", async () => {
   });
 
   it("can deploy contracts", async () => {
-    const simnet = await initSimnet(manifestPath);
-
     const source = "(define-public (add (a uint) (b uint)) (ok (+ a b)))\n";
     const deployRes = simnet.deployContract("op", source, null, deployerAddr);
     expect(deployRes.result).toStrictEqual(Cl.bool(true));
@@ -250,8 +221,6 @@ describe("simnet can get contracts info and deploy contracts", async () => {
   });
 
   it("can deploy contract with a given clarity_version", async () => {
-    const simnet = await initSimnet(manifestPath);
-
     const source = "(define-public (add (a uint) (b uint)) (ok (+ a b)))\n";
 
     simnet.deployContract("contract1", source, { clarityVersion: 1 }, deployerAddr);
@@ -274,8 +243,6 @@ describe("simnet can get contracts info and deploy contracts", async () => {
 
 describe("simnet can transfer stx", () => {
   it("can transfer stx", async () => {
-    const simnet = await initSimnet(manifestPath);
-
     simnet.transferSTX(1000, address2, address1);
     const stxBalances = simnet.getAssetsMap().get("STX");
     const stxAddress1 = stxBalances?.get(address1);
@@ -287,8 +254,6 @@ describe("simnet can transfer stx", () => {
 
 describe("simnet can get session reports", async () => {
   it("can get line coverage", async () => {
-    const simnet = await initSimnet(manifestPath);
-
     simnet.callPublicFn("counter", "increment", [], address1);
     simnet.callPublicFn("counter", "increment", [], address1);
 
@@ -298,8 +263,6 @@ describe("simnet can get session reports", async () => {
   });
 
   it("can get costs", async () => {
-    const simnet = await initSimnet(manifestPath);
-
     simnet.callPublicFn("counter", "increment", [], address1);
 
     const reports = simnet.collectReport();
@@ -312,5 +275,16 @@ describe("simnet can get session reports", async () => {
     expect(report.contract_id).toBe(`${simnet.deployer}.counter`);
     expect(report.method).toBe("increment");
     expect(report.cost_result.total.write_count).toBe(3);
+  });
+});
+
+describe("the sdk handles multiple manifests project", () => {
+  it("handle invalid project", () => {
+    const expectedErr =
+      "error: unexpected ')'\n--> /Users/hugo/Sites/hiro/clarinet/components/clarinet-sdk/tests/fixtures/contracts/invalid.clar:5:2\n)) ;; extra `)`\n";
+
+    expect(async () => {
+      await initSimnet("tests/fixtures/InvalidManifest.toml");
+    }).rejects.toThrow(expectedErr);
   });
 });

--- a/components/clarinet-sdk/tests/index.test.ts
+++ b/components/clarinet-sdk/tests/index.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, beforeEach, beforeAll } from "vitest";
 // test the built package and not the source code
 // makes it simpler to handle wasm build
 import { Simnet, initSimnet, tx } from "../";
+import path from "node:path";
 
 const deployerAddr = "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM";
 const address1 = "ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5";
@@ -280,8 +281,8 @@ describe("simnet can get session reports", async () => {
 
 describe("the sdk handles multiple manifests project", () => {
   it("handle invalid project", () => {
-    const expectedErr =
-      "error: unexpected ')'\n--> /Users/hugo/Sites/hiro/clarinet/components/clarinet-sdk/tests/fixtures/contracts/invalid.clar:5:2\n)) ;; extra `)`\n";
+    const filePath = path.join(process.cwd(), "tests/fixtures/contracts/invalid.clar");
+    const expectedErr = `error: unexpected ')'\n--> ${filePath}:5:2\n)) ;; extra \`)\`\n`;
 
     expect(async () => {
       await initSimnet("tests/fixtures/InvalidManifest.toml");

--- a/components/clarinet-sdk/vitest.config.js
+++ b/components/clarinet-sdk/vitest.config.js
@@ -3,6 +3,7 @@ import { defineConfig } from "vite";
 
 export default defineConfig({
   test: {
+    singleThread: true,
     include: ["./tests/**/*.test.ts", "./vitest-helpers/tests/**/*.test.ts"],
   },
 });

--- a/components/hiro-system-kit/src/macros.rs
+++ b/components/hiro-system-kit/src/macros.rs
@@ -136,6 +136,17 @@ macro_rules! black {
     )
 }
 
+#[macro_export]
+macro_rules! pluralize {
+    ($value:expr, $word:expr) => {
+        if $value > 1 {
+            format!("{} {}s", $value, $word)
+        } else {
+            format!("{} {}", $value, $word)
+        }
+    };
+}
+
 #[allow(unused_macros)]
 #[macro_export]
 macro_rules! format_err {


### PR DESCRIPTION
### Description

Fix: #1191 


- On simnet init, throw an error if the contracts are invalid (ie: there is at least one error in diagnostic)
- While working on the test, I found another error, because of the way I handled the cache, we couldn't load two sessions. This is fixed as well by this PR