### PR TITLE
replace . with _ for contract names

### DIFF
--- a/components/clarinet-cli/src/generate/contract.rs
+++ b/components/clarinet-cli/src/generate/contract.rs
@@ -20,7 +20,7 @@ impl GetChangesForNewContract {
     ) -> Self {
         Self {
             manifest_location,
-            contract_name,
+            contract_name: contract_name.replace(".", "_"),
             source,
             changes: vec![],
         }


### PR DESCRIPTION
### Description

fixes #1031 by replacing `.` with `_` in contract file names

#### Breaking change?

N/A

### Example

![Screenshot 2023-10-11 at 4 01 54 PM](https://github.com/hirosystems/clarinet/assets/1235263/93b4e126-0176-4707-8540-269e921bf3df)

---

### Checklist

- [ ] Tests added in this PR (if applicable)

If there are applicable tests to add, I'm glad to do that. I was unable to find them tho, so I added the screenshots above

