### PR TITLE
fix(sdk): Epoch and clarity version mismatch

### DIFF
--- a/components/clarity-repl/src/repl/session.rs
+++ b/components/clarity-repl/src/repl/session.rs
@@ -551,13 +551,16 @@ impl Session {
         test_name: Option<String>,
         ast: &mut Option<ContractAST>,
     ) -> Result<ExecutionResult, Vec<Diagnostic>> {
-        if contract.epoch == StacksEpochId::Epoch20 && contract.clarity_version == ClarityVersion::Clarity2 {
+        if contract.clarity_version > ClarityVersion::default_for_epoch(contract.epoch) {
             let diagnostic = Diagnostic {
-                    level: Level::Error,
-                    message: "Mismatched contract epoch (2.0) and clarity version".to_string(),
-                    spans: vec![],
-                    suggestion: None,
-                };
+                level: Level::Error,
+                message: format!(
+                    "{} can not be used with {}",
+                    contract.clarity_version, contract.epoch
+                ),
+                spans: vec![],
+                suggestion: None,
+            };
             return Err(vec![diagnostic]);
         }
         let mut hooks: Vec<&mut dyn EvalHook> = Vec::new();

--- a/components/clarity-repl/src/repl/session.rs
+++ b/components/clarity-repl/src/repl/session.rs
@@ -1404,6 +1404,24 @@ mod tests {
     }
 
     #[test]
+    fn clarity_epoch_mismatch() {
+        let settings = SessionSettings::default();
+        let mut session = Session::new(settings);
+        session.start().expect("session could not start");
+        let snippet = "(define-data-var x uint u0)";
+        let contract = ClarityContract {
+            code_source: ClarityCodeSource::ContractInMemory(snippet.to_string()),
+            name: "should_error".to_string(),
+            deployer: ContractDeployer::Address("ST000000000000000000002AMW42H".into()),
+            clarity_version: ClarityVersion::Clarity2,
+            epoch: StacksEpochId::Epoch20,
+        };
+
+        let result = session.deploy_contract(&contract, None, false, None, &mut None);
+        assert!(result.is_err(), "Expected error for clarity mismatch");
+    }
+
+    #[test]
     fn evaluate_at_block() {
         let mut settings = SessionSettings::default();
         settings.include_boot_contracts = vec!["costs".into(), "costs-2".into(), "costs-3".into()];

--- a/components/clarity-repl/src/repl/session.rs
+++ b/components/clarity-repl/src/repl/session.rs
@@ -14,7 +14,7 @@ use clarity::types::chainstate::StacksAddress;
 use clarity::types::StacksEpochId;
 use clarity::vm::analysis::ContractAnalysis;
 use clarity::vm::ast::ContractAST;
-use clarity::vm::diagnostic::Diagnostic;
+use clarity::vm::diagnostic::{Diagnostic, Level};
 use clarity::vm::docs::{make_api_reference, make_define_reference, make_keyword_reference};
 use clarity::vm::errors::Error;
 use clarity::vm::functions::define::DefineFunctions;
@@ -551,6 +551,15 @@ impl Session {
         test_name: Option<String>,
         ast: &mut Option<ContractAST>,
     ) -> Result<ExecutionResult, Vec<Diagnostic>> {
+        if contract.epoch == StacksEpochId::Epoch20 && contract.clarity_version == ClarityVersion::Clarity2 {
+            let diagnostic = Diagnostic {
+                    level: Level::Error,
+                    message: "Mismatched contract epoch (2.0) and clarity version".to_string(),
+                    spans: vec![],
+                    suggestion: None,
+                };
+            return Err(vec![diagnostic]);
+        }
         let mut hooks: Vec<&mut dyn EvalHook> = Vec::new();
         let mut coverage = if let Some(test_name) = test_name {
             Some(TestCoverageReport::new(test_name.into()))


### PR DESCRIPTION
 fix: #1164 
 
 - deploy_contract now returns an Err if it's called with Clarity v2 and Epoch 2.0

