### PR TITLE
feat: update clarinet generated template to use the sdk

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,10 @@
 {
   "rust-analyzer.check.overrideCommand": [
     "cargo",
-    "check",
+    "clippy",
     "--package=clarinet-cli",
-    "--message-format=json"
+    "--message-format=json",
+    "--",
+    "--no-deps"
   ]
 }

--- a/components/clarinet-cli/src/frontend/cli.rs
+++ b/components/clarinet-cli/src/frontend/cli.rs
@@ -579,11 +579,7 @@ pub fn main() {
         }
     };
 
-    let hints_enabled = if env::var("CLARINET_DISABLE_HINTS") == Ok("1".into()) {
-        false
-    } else {
-        true
-    };
+    let hints_enabled = env::var("CLARINET_DISABLE_HINTS") != Ok("1".into());
 
     match opts.command {
         Command::New(project_opts) => {
@@ -669,11 +665,11 @@ pub fn main() {
             Deployments::GenerateDeployment(cmd) => {
                 let manifest = load_manifest_or_exit(cmd.manifest_path);
 
-                let network = if cmd.devnet == true {
+                let network = if cmd.devnet {
                     StacksNetwork::Devnet
-                } else if cmd.testnet == true {
+                } else if cmd.testnet {
                     StacksNetwork::Testnet
-                } else if cmd.mainnet == true {
+                } else if cmd.mainnet {
                     StacksNetwork::Mainnet
                 } else {
                     StacksNetwork::Simnet
@@ -750,11 +746,11 @@ pub fn main() {
             Deployments::ApplyDeployment(cmd) => {
                 let manifest = load_manifest_or_exit(cmd.manifest_path);
 
-                let network = if cmd.devnet == true {
+                let network = if cmd.devnet {
                     Some(StacksNetwork::Devnet)
-                } else if cmd.testnet == true {
+                } else if cmd.testnet {
                     Some(StacksNetwork::Testnet)
-                } else if cmd.mainnet == true {
+                } else if cmd.mainnet {
                     Some(StacksNetwork::Mainnet)
                 } else {
                     None
@@ -765,7 +761,7 @@ pub fn main() {
                         Err(format!("{}: a flag `--devnet`, `--testnet`, `--mainnet` or `--deployment-plan-path=path/to/yaml` should be provided.", yellow!("Command usage")))
                     }
                     (Some(network), None) => {
-                        let res = load_deployment_if_exists(&manifest, &network, cmd.use_on_disk_deployment_plan, cmd.use_computed_deployment_plan);
+                        let res = load_deployment_if_exists(&manifest, network, cmd.use_on_disk_deployment_plan, cmd.use_computed_deployment_plan);
                         match res {
                             Some(Ok(deployment)) => {
                                 println!(
@@ -777,8 +773,8 @@ pub fn main() {
                             }
                             Some(Err(e)) => Err(e),
                             None => {
-                                let default_deployment_path = get_default_deployment_path(&manifest, &network).unwrap();
-                                let (deployment, _) = match generate_default_deployment(&manifest, &network, false) {
+                                let default_deployment_path = get_default_deployment_path(&manifest, network).unwrap();
+                                let (deployment, _) = match generate_default_deployment(&manifest, network, false) {
                                     Ok(deployment) => deployment,
                                     Err(message) => {
                                         println!("{}", red!(message));
@@ -1142,7 +1138,7 @@ pub fn main() {
             }
 
             if success {
-                println!("{} Syntax of contract successfully checked", green!("✔"),);
+                println!("{} Syntax of contract successfully checked", green!("✔"));
                 return;
             } else {
                 std::process::exit(1);
@@ -1300,7 +1296,7 @@ pub fn main() {
             }
         },
         Command::Completions(cmd) => {
-            let mut app = Opts::command();
+            let app = Opts::command();
             let file_name = cmd.shell.file_name("clarinet");
             let mut file = match File::create(file_name.clone()) {
                 Ok(file) => file,
@@ -1314,7 +1310,7 @@ pub fn main() {
                     std::process::exit(1);
                 }
             };
-            cmd.shell.generate(&mut app, &mut file);
+            cmd.shell.generate(&app, &mut file);
             println!("{} {}", green!("Created file"), file_name.clone());
             println!("Check your shell's documentation for details about using this file to enable completions for clarinet");
         }
@@ -1366,7 +1362,7 @@ fn get_manifest_location_or_warn(path: Option<String>) -> Option<FileLocation> {
 
 fn load_manifest_or_exit(path: Option<String>) -> ProjectManifest {
     let manifest_location = get_manifest_location_or_exit(path);
-    let manifest = match ProjectManifest::from_location(&manifest_location) {
+    match ProjectManifest::from_location(&manifest_location) {
         Ok(manifest) => manifest,
         Err(message) => {
             println!(
@@ -1376,8 +1372,7 @@ fn load_manifest_or_exit(path: Option<String>) -> ProjectManifest {
             );
             process::exit(1);
         }
-    };
-    manifest
+    }
 }
 
 fn load_manifest_or_warn(path: Option<String>) -> Option<ProjectManifest> {
@@ -1413,7 +1408,7 @@ fn load_deployment_and_artifacts_or_exit(
     let result = match deployment_plan_path {
         None => {
             let res = load_deployment_if_exists(
-                &manifest,
+                manifest,
                 &StacksNetwork::Simnet,
                 force_on_disk,
                 force_computed,
@@ -1424,41 +1419,42 @@ fn load_deployment_and_artifacts_or_exit(
                         "{} using deployments/default.simnet-plan.yaml",
                         yellow!("note:")
                     );
-                    let artifacts = setup_session_with_deployment(&manifest, &deployment, None);
+                    let artifacts = setup_session_with_deployment(manifest, &deployment, None);
                     Ok((deployment, None, artifacts))
                 }
                 Some(Err(e)) => Err(format!(
                     "loading deployments/default.simnet-plan.yaml failed with error: {}",
                     e
                 )),
-                None => match generate_default_deployment(&manifest, &StacksNetwork::Simnet, false)
-                {
-                    Ok((deployment, ast_artifacts)) if ast_artifacts.success => {
-                        let mut artifacts = setup_session_with_deployment(
-                            &manifest,
-                            &deployment,
-                            Some(&ast_artifacts.asts),
-                        );
-                        for (contract_id, mut parser_diags) in ast_artifacts.diags.into_iter() {
-                            // Merge parser's diags with analysis' diags.
-                            if let Some(ref mut diags) = artifacts.diags.remove(&contract_id) {
-                                parser_diags.append(diags);
+                None => {
+                    match generate_default_deployment(manifest, &StacksNetwork::Simnet, false) {
+                        Ok((deployment, ast_artifacts)) if ast_artifacts.success => {
+                            let mut artifacts = setup_session_with_deployment(
+                                manifest,
+                                &deployment,
+                                Some(&ast_artifacts.asts),
+                            );
+                            for (contract_id, mut parser_diags) in ast_artifacts.diags.into_iter() {
+                                // Merge parser's diags with analysis' diags.
+                                if let Some(ref mut diags) = artifacts.diags.remove(&contract_id) {
+                                    parser_diags.append(diags);
+                                }
+                                artifacts.diags.insert(contract_id, parser_diags);
                             }
-                            artifacts.diags.insert(contract_id, parser_diags);
+                            Ok((deployment, None, artifacts))
                         }
-                        Ok((deployment, None, artifacts))
+                        Ok((deployment, ast_artifacts)) => Ok((deployment, None, ast_artifacts)),
+                        Err(e) => Err(e),
                     }
-                    Ok((deployment, ast_artifacts)) => Ok((deployment, None, ast_artifacts)),
-                    Err(e) => Err(e),
-                },
+                }
             }
         }
         Some(path) => {
-            let deployment_location = get_absolute_deployment_path(&manifest, &path)
+            let deployment_location = get_absolute_deployment_path(manifest, path)
                 .expect("unable to retrieve deployment");
-            match load_deployment(&manifest, &deployment_location) {
+            match load_deployment(manifest, &deployment_location) {
                 Ok(deployment) => {
-                    let artifacts = setup_session_with_deployment(&manifest, &deployment, None);
+                    let artifacts = setup_session_with_deployment(manifest, &deployment, None);
                     Ok((deployment, Some(deployment_location.to_string()), artifacts))
                 }
                 Err(e) => Err(format!("loading {} failed with error: {}", path, e)),
@@ -1510,11 +1506,7 @@ pub fn should_existing_plan_be_replaced(
     let mut buffer = String::new();
     std::io::stdin().read_line(&mut buffer).unwrap();
 
-    if buffer.starts_with("n") {
-        return false;
-    } else {
-        return true;
-    }
+    !buffer.starts_with('n')
 }
 
 pub fn load_deployment_if_exists(
@@ -1770,7 +1762,7 @@ fn display_hint_footer() {
 }
 
 fn display_post_check_hint() {
-    println!("");
+    println!();
     display_hint_header();
     println!(
         "{}",
@@ -1786,7 +1778,7 @@ fn display_post_check_hint() {
 }
 
 fn display_post_console_hint() {
-    println!("");
+    println!();
     display_hint_header();
     println!(
         "{}",
@@ -1809,7 +1801,7 @@ fn display_post_console_hint() {
 }
 
 fn display_deploy_hint() {
-    println!("");
+    println!();
     display_hint_header();
     println!(
         "{}",

--- a/components/clarinet-cli/src/generate/chainhook.rs
+++ b/components/clarinet-cli/src/generate/chainhook.rs
@@ -38,8 +38,7 @@ impl<'a> GetChangesForNewChainhook<'a> {
     }
 
     fn create_template_bitcoin_chainhook(&mut self) -> Result<(), String> {
-        let content = format!(
-            r#"
+        let content = r#"
 ---
 name: "Bitcoin hook"
 version: 1
@@ -52,12 +51,11 @@ networks:
                 p2pkh:                                          # support hex, p2pkh, p2sh, p2wpkh, p2wsh.
                     equals: muYdXKmX9bByAueDe6KFfHd5Ff1gdN9ErG  # support equals, starts-with, ends-with
         action:
-            http: 
+            http:
                 url: http://localhost:3000/api/v1/<path>
                 method: POST
                 authorization-header: "Bearer cn389ncoiwuencr"
-"#
-        );
+"#.into();
 
         let name = format!("{}.chainhook.yaml", self.chainhook_name);
         let mut new_file = self
@@ -80,8 +78,7 @@ networks:
     }
 
     fn create_template_stacks_chainhook(&mut self) -> Result<(), String> {
-        let content = format!(
-            r#"
+        let content = r#"
 ---
 name: "Stacks hook"
 version: 1
@@ -106,12 +103,12 @@ networks:
             #     contract-identifier: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.cbtc-token
             #     method: mint
         action:
-            http: 
+            http:
                 url: http://localhost:3000/api/v1/<path>
                 method: POST
                 authorization-header: "Bearer cn389ncoiwuencr"
 "#
-        );
+        .into();
 
         let name = format!("{}.chainhook.yaml", self.chainhook_name);
         let mut project_path = self

--- a/components/clarinet-cli/src/generate/contract.rs
+++ b/components/clarinet-cli/src/generate/contract.rs
@@ -20,7 +20,7 @@ impl GetChangesForNewContract {
     ) -> Self {
         Self {
             manifest_location,
-            contract_name: contract_name.replace(".", "_"),
+            contract_name: contract_name.replace('.', "_"),
             source,
             changes: vec![],
         }
@@ -50,7 +50,7 @@ impl GetChangesForNewContract {
 ;;
 
 ;; token definitions
-;; 
+;;
 
 ;; constants
 ;;
@@ -92,38 +92,31 @@ impl GetChangesForNewContract {
     }
 
     fn create_template_test(&mut self) -> Result<(), String> {
-        let content = format!(
-            r#"
-import {{ Clarinet, Tx, Chain, Account, types }} from 'https://deno.land/x/clarinet@v{}/index.ts';
-import {{ assertEquals }} from 'https://deno.land/std@0.170.0/testing/asserts.ts';
+        let content = r#"
+import { describe, expect, it } from "vitest";
 
-Clarinet.test({{
-    name: "Ensure that <...>",
-    async fn(chain: Chain, accounts: Map<string, Account>) {{
-        // arrange: set up the chain, state, and other required elements
-        let wallet_1 = accounts.get("wallet_1")!;
+const accounts = simnet.getAccounts();
+const address1 = accounts.get("wallet_1")!;
 
-        // act: perform actions related to the current test
-        let block = chain.mineBlock([
-            /*
-             * Add transactions with:
-             * Tx.contractCall(...)
-            */
-        ]);
+/*
+  The test below is an example. To learn more, read the testing documentation here:
+  https://docs.hiro.so/clarinet/feature-guides/test-contract-with-clarinet-sdk
+*/
 
-        // assert: review returned data, contract state, and other requirements
-        assertEquals(block.receipts.length, 0);
-        assertEquals(block.height, 2);
+describe("example tests", () => {
+  it("ensures simnet is well initalised", () => {
+    expect(simnet.blockHeight).toBeDefined();
+  });
 
-        // TODO
-        assertEquals("TODO", "a complete test");
-    }},
-}});
-"#,
-            env!("CARGO_PKG_VERSION")
-        );
+  // it("shows an example", () => {
+  //   const { result } = simnet.callReadOnlyFn("counter", "get-counter", [], address1);
+  //   expect(result).toBeUint(0);
+  // });
+});
+"#
+        .into();
 
-        let name = format!("{}_test.ts", self.contract_name);
+        let name = format!("{}.test.ts", self.contract_name);
         let mut new_file = self.manifest_location.get_project_root_location().unwrap();
         new_file.append_path("tests")?;
         new_file.append_path(&name)?;

--- a/components/clarinet-cli/src/generate/project.rs
+++ b/components/clarinet-cli/src/generate/project.rs
@@ -39,6 +39,7 @@ impl GetChangesForNewProject {
         self.create_vscode_settings_json();
         self.create_vscode_tasks_json();
         self.create_gitignore();
+        self.create_nodejs_files();
         Ok(self.changes.clone())
     }
 
@@ -55,51 +56,49 @@ impl GetChangesForNewProject {
     #[allow(dead_code)]
     fn create_clients_directory(&mut self) {
         self.changes
-            .push(self.get_changes_for_new_root_dir(format!("clients")));
+            .push(self.get_changes_for_new_root_dir("clients".into()));
     }
 
     fn create_contracts_directory(&mut self) {
         self.changes
-            .push(self.get_changes_for_new_root_dir(format!("contracts")));
+            .push(self.get_changes_for_new_root_dir("contracts".into()));
     }
 
     #[allow(dead_code)]
     fn create_notebooks_directory(&mut self) {
         self.changes
-            .push(self.get_changes_for_new_root_dir(format!("notebooks")));
+            .push(self.get_changes_for_new_root_dir("notebooks".into()));
     }
 
     #[allow(dead_code)]
     fn create_scripts_directory(&mut self) {
         self.changes
-            .push(self.get_changes_for_new_root_dir(format!("scripts")));
+            .push(self.get_changes_for_new_root_dir("scripts".into()));
     }
 
     fn create_settings_directory(&mut self) {
         self.changes
-            .push(self.get_changes_for_new_root_dir(format!("settings")));
+            .push(self.get_changes_for_new_root_dir("settings".into()));
     }
 
     fn create_tests_directory(&mut self) {
         self.changes
-            .push(self.get_changes_for_new_root_dir(format!("tests")));
+            .push(self.get_changes_for_new_root_dir("tests".into()));
     }
 
     fn create_vscode_directory(&mut self) {
         self.changes
-            .push(self.get_changes_for_new_root_dir(format!(".vscode")));
+            .push(self.get_changes_for_new_root_dir(".vscode".into()));
     }
 
     fn create_vscode_settings_json(&mut self) {
-        let content = format!(
-            r#"
-{{
-    "deno.enable": true,
+        let content = r#"
+{
     "files.eol": "\n"
-}}
+}
 "#
-        );
-        let name = format!("settings.json");
+        .into();
+        let name = "settings.json".into();
         let path = format!(
             "{}/{}/.vscode/{}",
             self.project_path, self.project_name, name
@@ -119,28 +118,28 @@ impl GetChangesForNewProject {
     }
 
     fn create_vscode_tasks_json(&mut self) {
-        let content = format!(
-            r#"
-{{
-    "version": "2.0.0",
-    "tasks": [
-        {{
-            "label": "check contracts",
-            "group": "test",
-            "type": "shell",
-            "command": "clarinet check"
-        }},
-        {{
-            "label": "test contracts",
-            "group": "test",
-            "type": "shell",
-            "command": "clarinet test"
-        }}
-    ]
-}}
+        let content = r#"
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "check contracts",
+      "group": "test",
+      "type": "shell",
+      "command": "clarinet check"
+    },
+    {{
+      "type": "npm",
+      "script": "test",
+      "group": "test",
+      "problemMatcher": [],
+      "label": "npm test"
+    }
+  ]
+}
 "#
-        );
-        let name = format!("tasks.json");
+        .into();
+        let name = "tasks.json".into();
         let path = format!(
             "{}/{}/.vscode/{}",
             self.project_path, self.project_name, name
@@ -160,15 +159,22 @@ impl GetChangesForNewProject {
     }
 
     fn create_gitignore(&mut self) {
-        let content = format!(
-            r#"
+        let content = r#"
 **/settings/Mainnet.toml
 **/settings/Testnet.toml
 .cache/**
 history.txt
-"#,
-        );
-        let name = format!(".gitignore");
+
+logs
+*.log
+npm-debug.log*
+coverage
+*.info
+costs-reports.json
+node_modules
+"#
+        .into();
+        let name = ".gitignore".into();
         let path = format!("{}/{}/{}", self.project_path, self.project_name, name);
         let change = FileCreation {
             comment: format!("{} {}/{}", green!("Created file"), self.project_name, name),
@@ -206,7 +212,7 @@ check_checker = {{ trusted_sender = false, trusted_caller = false, callee_filter
 "#,
             self.project_name, self.telemetry_enabled
         );
-        let name = format!("Clarinet.toml");
+        let name = "Clarinet.toml".into();
         let path = format!("{}/{}/{}", self.project_path, self.project_name, name);
         let change = FileCreation {
             comment: format!("{} {}/{}", green!("Created file"), self.project_name, name),
@@ -218,8 +224,7 @@ check_checker = {{ trusted_sender = false, trusted_caller = false, callee_filter
     }
 
     fn create_environment_testnet_toml(&mut self) {
-        let content = format!(
-            r#"[network]
+        let content = r#"[network]
 name = "testnet"
 stacks_node_rpc_address = "https://api.testnet.hiro.so"
 deployment_fee_rate = 10
@@ -227,8 +232,8 @@ deployment_fee_rate = 10
 [accounts.deployer]
 mnemonic = "<YOUR PRIVATE TESTNET MNEMONIC HERE>"
 "#
-        );
-        let name = format!("Testnet.toml");
+        .into();
+        let name = "Testnet.toml".into();
         let path = format!(
             "{}/{}/settings/{}",
             self.project_path, self.project_name, name
@@ -248,8 +253,7 @@ mnemonic = "<YOUR PRIVATE TESTNET MNEMONIC HERE>"
     }
 
     fn create_environment_mainnet_toml(&mut self) {
-        let content = format!(
-            r#"[network]
+        let content = r#"[network]
 name = "mainnet"
 stacks_node_rpc_address = "https://api.hiro.so"
 deployment_fee_rate = 10
@@ -257,8 +261,8 @@ deployment_fee_rate = 10
 [accounts.deployer]
 mnemonic = "<YOUR PRIVATE MAINNET MNEMONIC HERE>"
 "#
-        );
-        let name = format!("Mainnet.toml");
+        .into();
+        let name = "Mainnet.toml".into();
         let path = format!(
             "{}/{}/settings/{}",
             self.project_path, self.project_name, name
@@ -451,7 +455,7 @@ btc_address = "mvZtbibDAAA3WLpY7zXXFqRa3T4XSknBX7"
             default_epoch_2_3 = DEFAULT_EPOCH_2_3,
             default_epoch_2_4 = DEFAULT_EPOCH_2_4,
         );
-        let name = format!("Devnet.toml");
+        let name = "Devnet.toml".into();
         let path = format!(
             "{}/{}/settings/{}",
             self.project_path, self.project_name, name
@@ -463,6 +467,142 @@ btc_address = "mvZtbibDAAA3WLpY7zXXFqRa3T4XSknBX7"
                 self.project_name,
                 name
             ),
+            name,
+            content,
+            path,
+        };
+        self.changes.push(Changes::AddFile(change));
+    }
+
+    fn create_nodejs_files(&mut self) {
+        self.create_package_json();
+        self.create_ts_config();
+        self.create_vitest_config();
+    }
+
+    fn create_package_json(&mut self) {
+        let content = format!(
+            r#"
+{{
+  "name": "{}-tests",
+  "version": "1.0.0",
+  "description": "Run unit tests on this project.",
+  "private": true,
+  "scripts": {{
+    "test": "vitest run",
+    "test:report": "vitest run -- --coverage --costs",
+    "test:watch": "chokidar \"unit-tests/**/*.ts\" \"contracts/**/*.clar\" -c \"npm t\""
+  }},
+  "author": "",
+  "license": "ISC",
+  "dependencies": {{
+    "@hirosystems/clarinet-sdk": "^1.0.0",
+    "@stacks/transactions": "^6.9.0",
+    "chokidar-cli": "^3.0.0",
+    "typescript": "^5.2.2",
+    "vite": "^4.4.9",
+    "vitest": "^0.34.4",
+    "vitest-environment-clarinet": "^1.0.0"
+  }}
+}}
+"#,
+            self.project_name
+        );
+        let name = "package.json".into();
+        let path = format!("{}/{}/{}", self.project_path, self.project_name, name);
+        let change = FileCreation {
+            comment: format!("{} {}/{}", green!("Created file"), self.project_name, name),
+            name,
+            content,
+            path,
+        };
+        self.changes.push(Changes::AddFile(change));
+    }
+
+    fn create_ts_config(&mut self) {
+        let content = r#"
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["ESNext"],
+    "skipLibCheck": true,
+
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+
+    "strict": true,
+    "noImplicitAny": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": [
+    "node_modules/@hirosystems/clarinet-sdk/vitest-helpers/src",
+    "tests"
+  ]
+}
+"#
+        .into();
+        let name = "tsconfig.json".into();
+        let path = format!("{}/{}/{}", self.project_path, self.project_name, name);
+        let change = FileCreation {
+            comment: format!("{} {}/{}", green!("Created file"), self.project_name, name),
+            name,
+            content,
+            path,
+        };
+        self.changes.push(Changes::AddFile(change));
+    }
+
+    fn create_vitest_config(&mut self) {
+        let content =
+            r#"
+/// <reference types="vitest" />
+
+import { defineConfig } from "vite";
+import { vitestSetupFilePath, getClarinetVitestsArgv } from "@hirosystems/clarinet-sdk/vitest";
+
+/*
+  In this file, Vitest is configured so that it works seamlessly with Clarinet and the Simnet.
+
+  The `vitest-environment-clarinet` will initialise the clarinet-sdk
+  and make the `simnet` object available globally in the test files.
+
+  `vitestSetupFilePath` points to a file in the `@hirosystems/clarinet-sdk` package that does two things:
+    - run `before` hooks to initialize the simnet and `after` hooks to collect costs and coverage reports.
+    - load custom vitest matchers to work with Clarity values (such as `expect(...).toBeUint()`)
+
+  The `getClarinetVitestsArgv()` will parse options passed to the command `vitest run --`
+    - vitest run -- --manifest ./Clarinet.toml  # pass a custom path
+    - vitest run -- --coverage --costs          # collect coverage and cost reports
+*/
+
+export default defineConfig({
+  test: {
+    environment: "clarinet", // use vitest-environment-clarinet
+    singleThread: true,
+    setupFiles: [
+      vitestSetupFilePath,
+      // custom setup files can be added here
+    ],
+    environmentOptions: {
+      clarinet: {
+        ...getClarinetVitestsArgv(),
+        // add or override options
+      },
+    },
+  },
+});
+"#.into();
+        let name = "vitest.config.js".into();
+        let path = format!("{}/{}/{}", self.project_path, self.project_name, name);
+        let change = FileCreation {
+            comment: format!("{} {}/{}", green!("Created file"), self.project_name, name),
             name,
             content,
             path,


### PR DESCRIPTION
### Description

Generate the right file to use the clarinet-sdk for test.

In this PR, I also slowly started to implement cargo `clippy` instead of `check` 

