### PR TITLE
refactor: improve global settings management

### DIFF
--- a/components/clarinet-cli/src/frontend/clarinetrc.rs
+++ b/components/clarinet-cli/src/frontend/clarinetrc.rs
@@ -1,0 +1,53 @@
+use std::fs::{self};
+
+use std::env;
+
+#[derive(Serialize, Deserialize, Default)]
+pub struct GlobalSettings {
+    pub enable_hints: Option<bool>,
+    pub enable_telemetry: Option<bool>,
+}
+
+impl GlobalSettings {
+    pub fn get_settings_file_path() -> &'static str {
+        "~/.clarinet/clarinetrc.toml"
+    }
+
+    pub fn from_global_file() -> Self {
+        let home_dir = dirs::home_dir();
+
+        if let Some(path) = home_dir.map(|home_dir| home_dir.join(".clarinet/clarinetrc.toml")) {
+            if path.exists() {
+                match fs::read_to_string(path) {
+                    Ok(content) => match toml::from_str::<GlobalSettings>(&content) {
+                        Ok(res) => return res,
+                        Err(_) => {
+                            println!(
+                                "{} {}",
+                                format_warn!("unable to parse"),
+                                Self::get_settings_file_path()
+                            );
+                        }
+                    },
+                    Err(_) => {
+                        println!(
+                            "{} {}",
+                            format_warn!("unable to read file"),
+                            Self::get_settings_file_path()
+                        );
+                    }
+                }
+            }
+        };
+
+        // Keep backwards compatibility with ENV var
+        let enable_hints = match env::var("CLARINET_DISABLE_HINTS") {
+            Ok(v) => Some(v == "1"),
+            Err(_) => None,
+        };
+        Self {
+            enable_hints,
+            ..Default::default()
+        }
+    }
+}

--- a/components/clarinet-cli/src/frontend/mod.rs
+++ b/components/clarinet-cli/src/frontend/mod.rs
@@ -1,3 +1,5 @@
+mod clarinetrc;
+
 pub mod cli;
 pub mod dap;
 #[cfg(feature = "telemetry")]

--- a/components/clarity-repl/src/repl/debug/cli.rs
+++ b/components/clarity-repl/src/repl/debug/cli.rs
@@ -554,7 +554,7 @@ fn print_help_breakpoint() {
         r#"Set a breakpoint using 'b' or 'break' and one of these formats
   b <principal?>.<contract>:<linenum>:<colnum>
     SP000000000000000000002Q6VF78.bns:604:9
-        Break at line 604, column 9 of the bns contract deployed by 
+        Break at line 604, column 9 of the bns contract deployed by
           SP000000000000000000002Q6VF78
 
   b <principal?>.<contract>:<linenum>


### PR DESCRIPTION
Follow up #1208 

@tippenein I might have approved your previous PR a bit too quickly.
In your implementation, if telemetry is disabled globally, it would still ask for each project to enable telemetry Y/n, while i think it shouldn't.
I took this liberty to work on the follow-up PR to make sure we can ship it in 2.0 👌 
I also updated the setting file to be `~/.clarinet/clarinetrc.toml`, this way, we can more easily provide a json schema file for it in the future if we want to (vs `Settings.toml` that seems to generic)

This PR also updates the hints messages

Fixes: #205 

