### PR TITLE
chore: ugprade clap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -575,29 +575,12 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
-dependencies = [
- "atty",
- "bitflags 1.3.2",
- "clap_derive 3.2.18",
- "clap_lex 0.2.4",
- "indexmap 1.9.2",
- "once_cell",
- "strsim",
- "termcolor",
- "textwrap",
-]
-
-[[package]]
-name = "clap"
 version = "4.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2275f18819641850fa26c89acc84d465c1bf91ce57bc2748b28c420473352f64"
 dependencies = [
  "clap_builder",
- "clap_derive 4.4.7",
+ "clap_derive",
 ]
 
 [[package]]
@@ -608,30 +591,17 @@ checksum = "07cdf1b148b25c1e1f7a42225e30a0d99a615cd4637eae7365548dd4529b95bc"
 dependencies = [
  "anstream",
  "anstyle",
- "clap_lex 0.6.0",
+ "clap_lex",
  "strsim",
 ]
 
 [[package]]
 name = "clap_complete"
-version = "3.2.5"
+version = "4.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f7a2e0a962c45ce25afce14220bc24f9dade0a1787f185cecf96bfba7847cd8"
+checksum = "bffe91f06a11b4b9420f62103854e90867812cd5d01557f853c5ee8e791b12ae"
 dependencies = [
- "clap 3.2.23",
-]
-
-[[package]]
-name = "clap_derive"
-version = "3.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
-dependencies = [
- "heck 0.4.1",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.107",
+ "clap",
 ]
 
 [[package]]
@@ -644,25 +614,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.28",
-]
-
-[[package]]
-name = "clap_generate"
-version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1b28c4a802ac3628604fd267cac62aaea74dc61af3410db6b1c44c03b42599"
-dependencies = [
- "clap 3.2.23",
- "clap_complete",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
 ]
 
 [[package]]
@@ -680,8 +631,8 @@ dependencies = [
  "base58 0.2.0",
  "bitcoin 0.29.2",
  "chrono",
- "clap 3.2.23",
- "clap_generate",
+ "clap",
+ "clap_complete",
  "clarinet-deployments",
  "clarinet-files",
  "clarinet-utils 1.0.0",
@@ -819,7 +770,7 @@ dependencies = [
 name = "clarity-events"
 version = "1.0.0"
 dependencies = [
- "clap 3.2.23",
+ "clap",
  "clarinet-files",
  "clarity-repl 2.0.0",
  "serde",
@@ -2780,12 +2731,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
-name = "os_str_bytes"
-version = "6.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
-
-[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4167,7 +4112,7 @@ dependencies = [
  "bytes",
  "chainhook-sdk",
  "chrono",
- "clap 4.4.8",
+ "clap",
  "clarinet-deployments",
  "clarinet-files",
  "clarinet-utils 1.0.0",
@@ -4403,12 +4348,6 @@ checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"

--- a/components/clarinet-cli/Cargo.toml
+++ b/components/clarinet-cli/Cargo.toml
@@ -18,8 +18,8 @@ categories = [
 
 [dependencies]
 ansi_term = "0.12.1"
-clap = { version = "3.2.23", features = ["derive"], optional = true }
-clap_generate = { version = "3.0.3", optional = true }
+clap = { version = "4.4.8", features = ["derive"], optional = true }
+clap_complete = { version = "4.4.4", optional = true }
 toml = { version = "0.5.6", features = ["preserve_order"] }
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = { version = "1.0.79", features = ["preserve_order"] }
@@ -117,5 +117,5 @@ path = "src/bin.rs"
 
 [features]
 default = ["cli", "telemetry"]
-cli = ["tokio-util", "clap", "clap_generate", "tower-lsp"]
+cli = ["tokio-util", "clap", "clap_complete", "tower-lsp"]
 telemetry = ["segment", "mac_address"]

--- a/components/clarinet-cli/src/frontend/cli.rs
+++ b/components/clarinet-cli/src/frontend/cli.rs
@@ -11,9 +11,8 @@ use crate::generate::{
 };
 use crate::lsp::run_lsp;
 
-use clap::builder::ValueParser;
-use clap::{IntoApp, Parser, Subcommand};
-use clap_generate::{Generator, Shell};
+use clap::{CommandFactory, Parser, Subcommand};
+use clap_complete::{Generator, Shell};
 use clarinet_deployments::diagnostic_digest::DiagnosticsDigest;
 use clarinet_deployments::onchain::{
     apply_on_chain_deployment, get_initial_transactions_trackers, update_deployment_costs,
@@ -30,7 +29,6 @@ use clarinet_files::{
     RequirementConfig,
 };
 use clarity_repl::analysis::call_checker::ContractAnalysis;
-use clarity_repl::analysis::coverage::parse_coverage_str;
 use clarity_repl::clarity::vm::analysis::AnalysisDatabase;
 use clarity_repl::clarity::vm::costs::LimitedCostTracker;
 use clarity_repl::clarity::vm::types::QualifiedContractIdentifier;
@@ -42,7 +40,6 @@ use stacks_network::{self, check_chainhooks, DevnetOrchestrator};
 use std::collections::HashMap;
 use std::fs::{self, File};
 use std::io::prelude::*;
-use std::path::PathBuf;
 use std::{env, process};
 use toml;
 
@@ -64,33 +61,30 @@ struct Opts {
 #[allow(clippy::upper_case_acronyms)]
 #[derive(Subcommand, PartialEq, Clone, Debug)]
 enum Command {
+    /// Generate shell completions scripts
+    #[clap(name = "completions", bin_name = "completions", aliases = &["completion"])]
+    Completions(Completions),
     /// Create and scaffold a new project
     #[clap(name = "new", bin_name = "new")]
     New(GenerateProject),
     /// Subcommands for working with contracts
-    #[clap(subcommand, name = "contracts")]
+    #[clap(subcommand, name = "contracts", aliases = &["contract"])]
     Contracts(Contracts),
     /// Interact with contracts deployed on Mainnet
-    #[clap(subcommand, name = "requirements")]
+    #[clap(subcommand, name = "requirements", aliases = &["requirement"])]
     Requirements(Requirements),
     /// Subcommands for working with chainhooks
-    #[clap(subcommand, name = "chainhooks")]
+    #[clap(subcommand, name = "chainhooks", aliases = &["chainkhook"])]
     Chainhooks(Chainhooks),
     /// Manage contracts deployments on Simnet/Devnet/Testnet/Mainnet
-    #[clap(subcommand, name = "deployments")]
+    #[clap(subcommand, name = "deployments", aliases = &["deployment"])]
     Deployments(Deployments),
     /// Load contracts in a REPL for an interactive session
     #[clap(name = "console", aliases = &["poke"], bin_name = "console")]
     Console(Console),
-    /// Execute test suite
-    #[clap(name = "test", bin_name = "test")]
-    Test(Test),
     /// Check contracts syntax
     #[clap(name = "check", bin_name = "check")]
     Check(Check),
-    /// Execute Clarinet extension
-    #[clap(name = "run", bin_name = "run")]
-    Run(Run),
     /// Start a local Devnet network for interacting with your contracts from your browser
     #[clap(name = "integrate", bin_name = "integrate")]
     Integrate(DevnetStart),
@@ -103,13 +97,9 @@ enum Command {
     /// Step by step debugging and breakpoints from your code editor (VSCode, vim, emacs, etc)
     #[clap(name = "dap", bin_name = "dap")]
     DAP,
-    /// Generate shell completions scripts
-    #[clap(name = "completions", bin_name = "completions")]
-    Completions(Completions),
 }
 
 #[derive(Subcommand, PartialEq, Clone, Debug)]
-#[clap(bin_name = "devnet")]
 enum Devnet {
     /// Generate package of all required devnet artifacts
     #[clap(name = "package", bin_name = "package")]
@@ -121,7 +111,6 @@ enum Devnet {
 }
 
 #[derive(Subcommand, PartialEq, Clone, Debug)]
-#[clap(bin_name = "contract", aliases = &["contract"])]
 enum Contracts {
     /// Generate files and settings for a new contract
     #[clap(name = "new", bin_name = "new")]
@@ -129,7 +118,6 @@ enum Contracts {
 }
 
 #[derive(Subcommand, PartialEq, Clone, Debug)]
-#[clap(bin_name = "req", aliases = &["requirement"])]
 enum Requirements {
     /// Interact with contracts published on Mainnet
     #[clap(name = "add", bin_name = "add")]
@@ -138,7 +126,6 @@ enum Requirements {
 
 #[allow(clippy::enum_variant_names)]
 #[derive(Subcommand, PartialEq, Clone, Debug)]
-#[clap(bin_name = "deployment", aliases = &["deployment"])]
 enum Deployments {
     /// Check deployments format
     #[clap(name = "check", bin_name = "check")]
@@ -153,7 +140,6 @@ enum Deployments {
 
 #[allow(clippy::enum_variant_names)]
 #[derive(Subcommand, PartialEq, Clone, Debug)]
-#[clap(bin_name = "chainhook", aliases = &["chainhook"])]
 enum Chainhooks {
     /// Generate files and settings for a new hook
     #[clap(name = "new", bin_name = "new")]
@@ -180,7 +166,7 @@ struct GenerateProject {
     /// Project's name
     pub name: String,
     /// Do not provide developer usage telemetry for this project
-    #[clap(long = "disable-telemetry", takes_value = false)]
+    #[clap(long = "disable-telemetry")]
     pub disable_telemetry: bool,
 }
 
@@ -257,32 +243,32 @@ struct GenerateDeployment {
     /// Compute and set cost, using low priority (network connection required)
     #[clap(
         long = "low-cost",
-        conflicts_with = "medium-cost",
-        conflicts_with = "high-cost",
-        conflicts_with = "manual-cost"
+        conflicts_with = "medium_cost",
+        conflicts_with = "high_cost",
+        conflicts_with = "manual_cost"
     )]
     pub low_cost: bool,
     /// Compute and set cost, using medium priority (network connection required)
     #[clap(
-        conflicts_with = "low-cost",
+        conflicts_with = "low_cost",
         long = "medium-cost",
-        conflicts_with = "high-cost",
-        conflicts_with = "manual-cost"
+        conflicts_with = "high_cost",
+        conflicts_with = "manual_cost"
     )]
     pub medium_cost: bool,
     /// Compute and set cost, using high priority (network connection required)
     #[clap(
-        conflicts_with = "low-cost",
-        conflicts_with = "medium-cost",
+        conflicts_with = "low_cost",
+        conflicts_with = "medium_cost",
         long = "high-cost",
-        conflicts_with = "manual-cost"
+        conflicts_with = "manual_cost"
     )]
     pub high_cost: bool,
     /// Leave cost estimation manual
     #[clap(
-        conflicts_with = "low-cost",
-        conflicts_with = "medium-cost",
-        conflicts_with = "high-cost",
+        conflicts_with = "low_cost",
+        conflicts_with = "medium_cost",
+        conflicts_with = "high_cost",
         long = "manual-cost"
     )]
     pub manual_cost: bool,
@@ -325,7 +311,7 @@ struct ApplyDeployment {
     /// Apply default deployment settings/default.devnet-plan.toml
     #[clap(
         long = "devnet",
-        conflicts_with = "deployment-plan-path",
+        conflicts_with = "deployment_plan_path",
         conflicts_with = "testnet",
         conflicts_with = "mainnet"
     )]
@@ -333,7 +319,7 @@ struct ApplyDeployment {
     /// Apply default deployment settings/default.testnet-plan.toml
     #[clap(
         long = "testnet",
-        conflicts_with = "deployment-plan-path",
+        conflicts_with = "deployment_plan_path",
         conflicts_with = "devnet",
         conflicts_with = "mainnet"
     )]
@@ -341,7 +327,7 @@ struct ApplyDeployment {
     /// Apply default deployment settings/default.mainnet-plan.toml
     #[clap(
         long = "mainnet",
-        conflicts_with = "deployment-plan-path",
+        conflicts_with = "deployment_plan_path",
         conflicts_with = "testnet",
         conflicts_with = "devnet"
     )]
@@ -365,14 +351,14 @@ struct ApplyDeployment {
     #[clap(
         long = "use-on-disk-deployment-plan",
         short = 'd',
-        conflicts_with = "use-computed-deployment-plan"
+        conflicts_with = "use_computed_deployment_plan"
     )]
     pub use_on_disk_deployment_plan: bool,
     /// Use computed deployment plan (will overwrite on disk version if any update)
     #[clap(
         long = "use-computed-deployment-plan",
         short = 'c',
-        conflicts_with = "use-on-disk-deployment-plan"
+        conflicts_with = "use_on_disk_deployment_plan"
     )]
     pub use_computed_deployment_plan: bool,
 }
@@ -389,14 +375,14 @@ struct Console {
     #[clap(
         long = "use-on-disk-deployment-plan",
         short = 'd',
-        conflicts_with = "use-computed-deployment-plan"
+        conflicts_with = "use_computed_deployment_plan"
     )]
     pub use_on_disk_deployment_plan: bool,
     /// Use computed deployment plan (will overwrite on disk version if any update)
     #[clap(
         long = "use-computed-deployment-plan",
         short = 'c',
-        conflicts_with = "use-on-disk-deployment-plan"
+        conflicts_with = "use_on_disk_deployment_plan"
     )]
     pub use_computed_deployment_plan: bool,
 }
@@ -416,127 +402,23 @@ struct DevnetStart {
     #[clap(
         long = "use-on-disk-deployment-plan",
         short = 'd',
-        conflicts_with = "use-computed-deployment-plan"
+        conflicts_with = "use_computed_deployment_plan"
     )]
     pub use_on_disk_deployment_plan: bool,
     /// Use computed deployment plan (will overwrite on disk version if any update)
     #[clap(
         long = "use-computed-deployment-plan",
         short = 'c',
-        conflicts_with = "use-on-disk-deployment-plan"
+        conflicts_with = "use_on_disk_deployment_plan"
     )]
     pub use_computed_deployment_plan: bool,
     /// Path to Package.json produced by 'clarinet devnet package'
     #[clap(
         long = "package",
-        conflicts_with = "use-computed-deployment-plan",
-        conflicts_with = "manifest-path"
+        conflicts_with = "use_computed_deployment_plan",
+        conflicts_with = "manifest_path"
     )]
     pub package: Option<String>,
-}
-
-#[derive(Parser, PartialEq, Clone, Debug)]
-struct Test {
-    /// Generate coverage file, and optionally provide name of generated file (defaults to "coverage.lcov")
-    #[clap(
-        long = "coverage",
-        default_missing_value("coverage.lcov"),
-        value_parser(ValueParser::new(parse_coverage_str))
-    )]
-    pub coverage: Option<PathBuf>,
-    /// Generate costs report
-    #[clap(long = "costs")]
-    pub costs_report: bool,
-    /// Path to Clarinet.toml
-    #[clap(long = "manifest-path", short = 'm')]
-    pub manifest_path: Option<String>,
-    /// Relaunch tests upon updates to contracts
-    #[clap(long = "watch")]
-    pub watch: bool,
-    /// Test files to be included (defaults to all tests found under tests/)
-    pub files: Vec<String>,
-    /// If specified, use this deployment file
-    #[clap(long = "deployment-plan-path", short = 'p')]
-    pub deployment_plan_path: Option<String>,
-    /// Use on disk deployment plan (prevent updates computing)
-    #[clap(
-        long = "use-on-disk-deployment-plan",
-        short = 'd',
-        conflicts_with = "use-computed-deployment-plan"
-    )]
-    pub use_on_disk_deployment_plan: bool,
-    /// Use computed deployment plan (will overwrite on disk version if any update)
-    #[clap(
-        long = "use-computed-deployment-plan",
-        short = 'c',
-        conflicts_with = "use-on-disk-deployment-plan"
-    )]
-    pub use_computed_deployment_plan: bool,
-    /// Stop after N errors. Defaults to stopping after first failure
-    #[clap(long = "fail-fast")]
-    pub fail_fast: Option<u16>,
-    /// Run tests with this string or pattern in the test name
-    #[clap(long = "filter")]
-    pub filter: Option<String>,
-    /// Load import map file from local file or remote URL
-    #[clap(long = "import-map")]
-    pub import_map: Option<String>,
-    /// Allow network access
-    #[clap(long = "allow-net")]
-    pub allow_net: bool,
-    /// Allow read access to project directory
-    #[clap(long = "allow-read")]
-    pub allow_disk_read: bool,
-    /// Specify optional Typescript config file
-    #[clap(long = "ts-config")]
-    pub ts_config: Option<String>,
-    /// Specify relative path of the chainhooks (yaml format) to evaluate
-    #[clap(long = "chainhooks")]
-    pub chainhooks: Vec<String>,
-    /// Add artificial delay (in seconds) when calling `chain.mineBlock(...)`. Useful when testing chainhooks
-    #[clap(long = "mine-block-delay")]
-    pub mine_block_delay: Option<u16>,
-}
-
-#[derive(Parser, PartialEq, Clone, Debug)]
-struct Run {
-    /// Script to run
-    pub script: Option<String>,
-    /// Path to Clarinet.toml
-    #[clap(long = "manifest-path", short = 'm')]
-    pub manifest_path: Option<String>,
-    /// Allow access to wallets
-    #[clap(long = "allow-wallets")]
-    pub allow_wallets: bool,
-    /// Allow write access to project directory
-    #[clap(long = "allow-write")]
-    pub allow_disk_write: bool,
-    /// Allow read access to project directory
-    #[clap(long = "allow-read")]
-    pub allow_disk_read: bool,
-    /// Allows running a specified list of subprocesses. Use the flag multiple times to allow multiple subprocesses
-    #[clap(long = "allow-run")]
-    pub allow_run: Option<Vec<String>>,
-    /// Allows access to a specified list of environment variables. Use the flag multiple times to allow access to multiple variables
-    #[clap(long = "allow-env")]
-    pub allow_env: Option<Vec<String>>,
-    /// If specified, use this deployment file
-    #[clap(long = "deployment-plan-path", short = 'p')]
-    pub deployment_plan_path: Option<String>,
-    /// Use on disk deployment plan (prevent updates computing)
-    #[clap(
-        long = "use-on-disk-deployment-plan",
-        short = 'd',
-        conflicts_with = "use-computed-deployment-plan"
-    )]
-    pub use_on_disk_deployment_plan: bool,
-    /// Use computed deployment plan (will overwrite on disk version if any update)
-    #[clap(
-        long = "use-computed-deployment-plan",
-        short = 'c',
-        conflicts_with = "use-on-disk-deployment-plan"
-    )]
-    pub use_computed_deployment_plan: bool,
 }
 
 #[derive(Parser, PartialEq, Clone, Debug)]
@@ -553,14 +435,14 @@ struct Check {
     #[clap(
         long = "use-on-disk-deployment-plan",
         short = 'd',
-        conflicts_with = "use-computed-deployment-plan"
+        conflicts_with = "use_computed_deployment_plan"
     )]
     pub use_on_disk_deployment_plan: bool,
     /// Use computed deployment plan (will overwrite on disk version if any update)
     #[clap(
         long = "use-computed-deployment-plan",
         short = 'c',
-        conflicts_with = "use-on-disk-deployment-plan"
+        conflicts_with = "use_on_disk_deployment_plan"
     )]
     pub use_computed_deployment_plan: bool,
 }
@@ -568,7 +450,7 @@ struct Check {
 #[derive(Parser, PartialEq, Clone, Debug)]
 struct Completions {
     /// Specify which shell to generation completions script for
-    #[clap(arg_enum, ignore_case = true)]
+    #[clap(ignore_case = true)]
     pub shell: Shell,
 }
 
@@ -576,7 +458,7 @@ pub fn main() {
     let opts: Opts = match Opts::try_parse() {
         Ok(opts) => opts,
         Err(e) => {
-            if e.kind() == clap::ErrorKind::UnknownArgument {
+            if e.kind() == clap::error::ErrorKind::UnknownArgument {
                 let manifest = load_manifest_or_exit(None);
                 if manifest.project.telemetry {
                     #[cfg(feature = "telemetry")]
@@ -597,6 +479,25 @@ pub fn main() {
     let global_settings = GlobalSettings::from_global_file();
 
     match opts.command {
+        Command::Completions(cmd) => {
+            let mut app = Opts::command();
+            let file_name = cmd.shell.file_name("clarinet");
+            let mut file = match File::create(file_name.clone()) {
+                Ok(file) => file,
+                Err(e) => {
+                    println!(
+                        "{} Unable to create file {}: {}",
+                        red!("error:"),
+                        file_name,
+                        e
+                    );
+                    std::process::exit(1);
+                }
+            };
+            clap_complete::generate(cmd.shell, &mut app, "clarinet", &mut file);
+            println!("{} {}", green!("Created file"), file_name.clone());
+            println!("Check your shell's documentation for details about using this file to enable completions for clarinet");
+        }
         Command::New(project_opts) => {
             let current_path = {
                 let current_dir = match env::current_dir() {
@@ -1238,26 +1139,6 @@ pub fn main() {
                 process::exit(1);
             }
         },
-        Command::Completions(cmd) => {
-            let app = Opts::command();
-            let file_name = cmd.shell.file_name("clarinet");
-            let mut file = match File::create(file_name.clone()) {
-                Ok(file) => file,
-                Err(e) => {
-                    println!(
-                        "{} Unable to create file {}: {}",
-                        red!("error:"),
-                        file_name,
-                        e
-                    );
-                    std::process::exit(1);
-                }
-            };
-            cmd.shell.generate(&app, &mut file);
-            println!("{} {}", green!("Created file"), file_name.clone());
-            println!("Check your shell's documentation for details about using this file to enable completions for clarinet");
-        }
-
         Command::Devnet(subcommand) => match subcommand {
             Devnet::Package(cmd) => {
                 let manifest = load_manifest_or_exit(cmd.manifest_path);
@@ -1268,21 +1149,6 @@ pub fn main() {
             }
             Devnet::DevnetStart(cmd) => devnet_start(cmd, global_settings),
         },
-
-        Command::Test(_) => {
-            println!("{} `clarinet test` has been deprecated. Please check this blog post to learn more:", yellow!("warning:"));
-            println!("https://hiro.so/blog/announcing-the-clarinet-sdk-a-javascript-programming-model-for-easy-smart-contract-testing");
-            std::process::exit(1);
-        }
-
-        Command::Run(_) => {
-            println!(
-                "{} `clarinet run` has been deprecated. Please check this blog post to learn more:",
-                yellow!("warning:")
-            );
-            println!("https://hiro.so/blog/announcing-the-clarinet-sdk-a-javascript-programming-model-for-easy-smart-contract-testing");
-            std::process::exit(1);
-        }
     };
 }
 
@@ -1797,13 +1663,13 @@ fn display_deploy_hint() {
     display_hint_footer();
 }
 
-fn devnet_start(cmd: DevnetStart, global_settings: GlobalSettings) -> () {
+fn devnet_start(cmd: DevnetStart, global_settings: GlobalSettings) {
     let manifest = load_manifest_or_exit(cmd.manifest_path);
     println!("Computing deployment plan");
     let result = match cmd.deployment_plan_path {
         None => {
             let res = if let Some(package) = cmd.package {
-                let package_file = match File::open(&package) {
+                let package_file = match File::open(package) {
                     Ok(file) => file,
                     Err(_) => {
                         println!("{} package file not found", red!("error:"));
@@ -1896,5 +1762,39 @@ fn devnet_start(cmd: DevnetStart, global_settings: GlobalSettings) -> () {
     }
     if global_settings.enable_hints.unwrap_or(true) {
         display_deploy_hint();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clap_complete::generate;
+
+    use super::*;
+
+    #[test]
+    fn test_completion_for_shells() {
+        for shell in [
+            Shell::Bash,
+            Shell::Elvish,
+            Shell::Fish,
+            Shell::PowerShell,
+            Shell::Zsh,
+        ] {
+            let result = std::panic::catch_unwind(move || {
+                let mut output_buffer = Vec::new();
+                let mut cmd = Opts::command();
+                generate(shell, &mut cmd, "clarinet", &mut output_buffer);
+                assert!(
+                    output_buffer.len() > 0,
+                    "failed to generate completion for {}",
+                    shell.to_string()
+                );
+            });
+            assert!(
+                result.is_ok(),
+                "failed to generate completion for {}",
+                shell.to_string()
+            );
+        }
     }
 }

--- a/components/clarinet-cli/src/frontend/cli.rs
+++ b/components/clarinet-cli/src/frontend/cli.rs
@@ -74,7 +74,7 @@ enum Command {
     #[clap(subcommand, name = "requirements", aliases = &["requirement"])]
     Requirements(Requirements),
     /// Subcommands for working with chainhooks
-    #[clap(subcommand, name = "chainhooks", aliases = &["chainkhook"])]
+    #[clap(subcommand, name = "chainhooks", aliases = &["chainhook"])]
     Chainhooks(Chainhooks),
     /// Manage contracts deployments on Simnet/Devnet/Testnet/Mainnet
     #[clap(subcommand, name = "deployments", aliases = &["deployment"])]

--- a/components/clarity-events/Cargo.toml
+++ b/components/clarity-events/Cargo.toml
@@ -6,7 +6,7 @@ version = "1.0.0"
 [dependencies]
 clarinet-files = { path = "../clarinet-files", default-features = false, optional = true }
 clarity-repl = { path = "../clarity-repl", default-features = false }
-clap = { version = "3.2.23", features = ["derive"], optional = true }
+clap = { version = "4.4.8", features = ["derive"], optional = true }
 toml = { version = "0.5.6", features = ["preserve_order"], optional = true }
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = { version = "1.0.79", features = ["preserve_order"] }

--- a/components/stacks-network/Cargo.toml
+++ b/components/stacks-network/Cargo.toml
@@ -41,7 +41,7 @@ clarinet-utils = { path = "../clarinet-utils" }
 hiro-system-kit = { path = "../hiro-system-kit", features = ["log"] }
 clarity-repl = { path = "../clarity-repl", features = ["cli"] }
 dirs = { version = "4.0.0" }
-clap = { version = "4.2.7", features = ["derive"] }
+clap = { version = "4.4.8", features = ["derive"] }
 serde_yaml = "0.8.23"
 
 [lib]


### PR DESCRIPTION
### Description

In an effort to keep the project dependencies updated, upgrade clap to the latest version.

- `clap_generate` has been renamed to `clap_complete`
- `conflicts_with` now takes the actual property name (not the `long` form)
- re-arranged a bit the enums and macros (for aliases)
- make everything slightly more consistent

I removed the deprecated `Test` and `Run` commands, it's a bit early bit I'm quite in a quest to remove as much dead code as I can on the repo 