### PR TITLE
chore: bump clarinet sdk version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -729,7 +729,7 @@ dependencies = [
 
 [[package]]
 name = "clarinet-sdk-wasm"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "clarinet-deployments",
  "clarinet-files",

--- a/components/clarinet-sdk-wasm/Cargo.toml
+++ b/components/clarinet-sdk-wasm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "clarinet-sdk-wasm"
-version = "1.1.0"
+version = "1.2.0"
 license = "GPL-3.0"
 repository = "https://github.com/hirosystems/clarinet"
 description = "The core lib that powers @hirosystems/clarinet-sdk"

--- a/components/clarinet-sdk/package-lock.json
+++ b/components/clarinet-sdk/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@hirosystems/clarinet-sdk",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hirosystems/clarinet-sdk",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "license": "GPL-3.0",
       "dependencies": {
-        "@hirosystems/clarinet-sdk-wasm": "^1.1.0",
+        "@hirosystems/clarinet-sdk-wasm": "^1.2.0",
         "@stacks/transactions": "^6.9.0",
         "kolorist": "^1.8.0",
         "prompts": "^2.4.2",
@@ -363,9 +363,9 @@
       }
     },
     "node_modules/@hirosystems/clarinet-sdk-wasm": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@hirosystems/clarinet-sdk-wasm/-/clarinet-sdk-wasm-1.1.0.tgz",
-      "integrity": "sha512-hGf2Ib6qYVnhV2+idW1GuOsh1Fom4fhp+QYjxHmfGQvx9ptSb037/4YVlep+jbO4hKXHHF2uQJgKMRPwVrtN2g=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@hirosystems/clarinet-sdk-wasm/-/clarinet-sdk-wasm-1.2.0.tgz",
+      "integrity": "sha512-TnJ243lEgIqHSIeMdEHi1hJceFBJ5mWfjfXv86GKaoyVOS6yX1vGL2a6ZuVO9FfWPNxsiSvaQV/FndVuansAVQ=="
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",

--- a/components/clarinet-sdk/package.json
+++ b/components/clarinet-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hirosystems/clarinet-sdk",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "A SDK to interact with Clarity Smart Contracts",
   "homepage": "https://docs.hiro.so/clarinet/feature-guides/clarinet-js-sdk",
   "repository": {
@@ -58,7 +58,7 @@
   "license": "GPL-3.0",
   "readme": "./README.md",
   "dependencies": {
-    "@hirosystems/clarinet-sdk-wasm": "^1.1.0",
+    "@hirosystems/clarinet-sdk-wasm": "^1.2.0",
     "@stacks/transactions": "^6.9.0",
     "kolorist": "^1.8.0",
     "prompts": "^2.4.2",


### PR DESCRIPTION
### Description

Just a version bump to release clarinet-sdk-wasm (and clarinet-sdk), to include #1273 

