### PR TITLE
feat: run clarity-wasm in a separate session

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -793,7 +793,7 @@ checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 [[package]]
 name = "clar2wasm"
 version = "0.1.0"
-source = "git+https://github.com/stacks-network/clarity-wasm.git#4e06a7b10efde6986ec8d12d4e791e677d033cb1"
+source = "git+https://github.com/stacks-network/clarity-wasm.git#c0de401eb055572c2abd064e219eecdae28d7be9"
 dependencies = [
  "clap",
  "clarity",
@@ -950,7 +950,7 @@ dependencies = [
 [[package]]
 name = "clarity"
 version = "2.2.0"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-next#25b82d1dcc62d7353db1bd4056be8a4538816eae"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-next#5956df38f851fa46204d4e57614bf77e633d553b"
 dependencies = [
  "integer-sqrt",
  "lazy_static",
@@ -1057,7 +1057,7 @@ dependencies = [
  "tokio-util",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wsts",
+ "wsts 5.0.0",
 ]
 
 [[package]]
@@ -1079,7 +1079,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha2 0.10.6",
- "wsts",
+ "wsts 5.0.0",
 ]
 
 [[package]]
@@ -4789,7 +4789,7 @@ dependencies = [
 [[package]]
 name = "stacks-common"
 version = "0.0.2"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-next#25b82d1dcc62d7353db1bd4056be8a4538816eae"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-next#5956df38f851fa46204d4e57614bf77e633d553b"
 dependencies = [
  "chrono",
  "curve25519-dalek",
@@ -4813,7 +4813,7 @@ dependencies = [
  "slog-term",
  "time 0.2.27",
  "winapi",
- "wsts",
+ "wsts 6.1.0",
 ]
 
 [[package]]
@@ -6407,6 +6407,28 @@ name = "wsts"
 version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c250118354755b4abb091a83cb8d659b511c0ae211ccdb3b1254e3db199cb86"
+dependencies = [
+ "aes-gcm",
+ "bs58 0.5.0",
+ "hashbrown 0.14.0",
+ "hex 0.4.3",
+ "num-traits",
+ "p256k1",
+ "polynomial",
+ "primitive-types",
+ "rand_core 0.6.4",
+ "serde",
+ "sha2 0.10.6",
+ "thiserror",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "wsts"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c7db3d3fe28c359e0cdb7f7ad83e3316bda0ba982b8cd1bf0fbe73ae4127e4b"
 dependencies = [
  "aes-gcm",
  "bs58 0.5.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -793,7 +793,7 @@ checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 [[package]]
 name = "clar2wasm"
 version = "0.1.0"
-source = "git+https://github.com/stacks-network/clarity-wasm.git#c0de401eb055572c2abd064e219eecdae28d7be9"
+source = "git+https://github.com/stacks-network/clarity-wasm.git#b7b65b9e928ac4b893d57c24151d64918b77d840"
 dependencies = [
  "clap",
  "clarity",

--- a/components/clarinet-deployments/src/lib.rs
+++ b/components/clarinet-deployments/src/lib.rs
@@ -122,7 +122,7 @@ pub fn update_session_with_contracts_executions(
     for (_, (boot_contract, ast)) in boot_contracts_data {
         session
             .interpreter
-            .run(&boot_contract, &mut Some(ast), false, None)
+            .run_interpreter(&boot_contract, &mut Some(ast), false, None)
             .expect("failed to interprete boot contract");
     }
 

--- a/components/clarity-repl/src/analysis/call_checker.rs
+++ b/components/clarity-repl/src/analysis/call_checker.rs
@@ -221,14 +221,8 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
-            Err(output) => {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
+            Err((output, _)) => {
                 assert_eq!(output.len(), 3);
                 assert_eq!(
                     output[0],
@@ -259,14 +253,8 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
-            Err(output) => {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
+            Err((output, _)) => {
                 assert_eq!(output.len(), 3);
                 assert_eq!(
                     output[0],
@@ -297,14 +285,8 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
-            Err(output) => {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
+            Err((output, _)) => {
                 assert_eq!(output.len(), 3);
                 assert_eq!(
                     output[0],
@@ -335,13 +317,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((_, result)) => {
                 assert_eq!(result.diagnostics.len(), 0);
             }
@@ -358,13 +334,9 @@ mod tests {
 (define-private (kv-set (key int) (value int))
     (map-set kv-store { key: key } { value: value } {value: 0}))"
             .to_string();
-        if let Err(err_output) = session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        if let Err((err_output, _)) =
+            session.formatted_interpretation(snippet, Some("checker".to_string()), false, None)
+        {
             assert_eq!(
                 err_output[0],
                 format!(
@@ -384,13 +356,9 @@ mod tests {
 (define-private (kv-add (key int) (value int))
     (map-insert kv-store { key: key } { value: value } { value: 0}))"
             .to_string();
-        if let Err(err_output) = session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        if let Err((err_output, _)) =
+            session.formatted_interpretation(snippet, Some("checker".to_string()), false, None)
+        {
             assert_eq!(
                 err_output[0],
                 format!(
@@ -410,13 +378,9 @@ mod tests {
 (define-private (kv-del (key int))
     (map-delete kv-store { key: 1 } {value: 0}))"
             .to_string();
-        if let Err(err_output) = session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        if let Err((err_output, _)) =
+            session.formatted_interpretation(snippet, Some("checker".to_string()), false, None)
+        {
             assert_eq!(
                 err_output[0],
                 format!(

--- a/components/clarity-repl/src/analysis/check_checker/mod.rs
+++ b/components/clarity-repl/src/analysis/check_checker/mod.rs
@@ -879,7 +879,6 @@ mod tests {
     #[test]
     fn allow_unchecked_bool_in_private_function_with_unchecked_params_annotation() {
         let mut settings = SessionSettings::default();
-        settings.repl_settings.disable_clarity_wasm(); // TODO(hugo): re-enable when fixed on clarity-wasm
         settings.repl_settings.analysis.passes = vec![Pass::CheckChecker];
         let mut session = Session::new(settings);
         let snippet = "
@@ -893,13 +892,7 @@ mod tests {
     )
 )"
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((output, result)) => {
                 assert_eq!(result.diagnostics.len(), 2);
                 assert_eq!(output.len(), 6);
@@ -941,13 +934,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((_, result)) => {
                 assert_eq!(result.diagnostics.len(), 0);
             }
@@ -966,13 +953,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((output, _)) => {
                 assert_eq!(output.len(), 6);
                 assert_eq!(
@@ -1012,13 +993,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((output, _)) => {
                 assert_eq!(output.len(), 6);
                 assert_eq!(
@@ -1060,13 +1035,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((output, _)) => {
                 assert_eq!(output.len(), 6);
                 assert_eq!(
@@ -1109,13 +1078,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((_, result)) => {
                 assert_eq!(result.diagnostics.len(), 0);
             }
@@ -1137,13 +1100,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((_, result)) => {
                 assert_eq!(result.diagnostics.len(), 0);
             }
@@ -1165,13 +1122,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((_, result)) => {
                 assert_eq!(result.diagnostics.len(), 0);
             }
@@ -1193,13 +1144,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((_, result)) => {
                 assert_eq!(result.diagnostics.len(), 0);
             }
@@ -1220,13 +1165,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((output, _)) => {
                 assert_eq!(output.len(), 9);
                 assert_eq!(
@@ -1287,13 +1226,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((output, _)) => {
                 assert_eq!(output.len(), 6);
                 assert_eq!(
@@ -1340,13 +1273,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((_, result)) => {
                 assert_eq!(result.diagnostics.len(), 0);
             }
@@ -1368,13 +1295,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((_, result)) => {
                 assert_eq!(result.diagnostics.len(), 0);
             }
@@ -1393,13 +1314,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((_, result)) => {
                 assert_eq!(result.diagnostics.len(), 0);
             }
@@ -1418,13 +1333,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((output, _)) => {
                 assert_eq!(output.len(), 6);
                 assert_eq!(
@@ -1466,13 +1375,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((output, _)) => {
                 assert_eq!(output.len(), 6);
                 assert_eq!(
@@ -1512,13 +1415,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((_, result)) => {
                 assert_eq!(result.diagnostics.len(), 0);
             }
@@ -1540,13 +1437,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((output, _)) => {
                 assert_eq!(output.len(), 6);
                 assert_eq!(
@@ -1585,13 +1476,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((output, _)) => {
                 assert_eq!(output.len(), 6);
                 assert_eq!(
@@ -1631,13 +1516,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((_, result)) => {
                 assert_eq!(result.diagnostics.len(), 0);
             }
@@ -1659,13 +1538,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((output, _)) => {
                 assert_eq!(output.len(), 6);
                 assert_eq!(
@@ -1702,13 +1575,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((_, result)) => {
                 assert_eq!(result.diagnostics.len(), 0);
             }
@@ -1730,13 +1597,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((output, _)) => {
                 assert_eq!(output.len(), 12);
                 assert_eq!(
@@ -1783,13 +1644,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((_, result)) => {
                 assert_eq!(result.diagnostics.len(), 0);
             }
@@ -1812,13 +1667,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((output, _)) => {
                 assert_eq!(output.len(), 12);
                 assert_eq!(
@@ -1866,13 +1715,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((_, result)) => {
                 assert_eq!(result.diagnostics.len(), 0);
             }
@@ -1895,13 +1738,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((output, _)) => {
                 assert_eq!(output.len(), 12);
                 assert_eq!(
@@ -1952,13 +1789,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((_, result)) => {
                 assert_eq!(result.diagnostics.len(), 0);
             }
@@ -1981,13 +1812,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((output, _)) => {
                 assert_eq!(output.len(), 12);
                 assert_eq!(
@@ -2038,13 +1863,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((output, _)) => {
                 assert_eq!(output.len(), 12);
                 assert_eq!(
@@ -2095,13 +1914,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((_, result)) => {
                 assert_eq!(result.diagnostics.len(), 0);
             }
@@ -2124,13 +1937,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((output, _)) => {
                 assert_eq!(output.len(), 12);
                 assert_eq!(
@@ -2187,13 +1994,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((_, result)) => {
                 assert_eq!(result.diagnostics.len(), 0);
             }
@@ -2216,13 +2017,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((output, _)) => {
                 assert_eq!(output.len(), 12);
                 assert_eq!(
@@ -2273,13 +2068,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((output, _)) => {
                 assert_eq!(output.len(), 6);
                 assert_eq!(
@@ -2317,13 +2106,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((output, _)) => {
                 assert_eq!(output.len(), 12);
                 assert_eq!(
@@ -2397,13 +2180,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((output, _)) => {
                 assert_eq!(output.len(), 12);
                 assert_eq!(
@@ -2468,13 +2245,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((output, _)) => {
                 assert_eq!(output.len(), 12);
                 assert_eq!(
@@ -2548,13 +2319,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((output, _)) => {
                 assert_eq!(output.len(), 12);
                 assert_eq!(
@@ -2619,13 +2384,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((output, _)) => {
                 assert_eq!(output.len(), 6);
                 assert_eq!(
@@ -2654,7 +2413,6 @@ mod tests {
     #[test]
     fn dynamic_contract_call() {
         let mut settings = SessionSettings::default();
-        settings.repl_settings.disable_clarity_wasm(); // TODO(hugo): re-enable when fixed on clarity-wasm
         settings.repl_settings.analysis.passes = vec![Pass::CheckChecker];
         let mut session = Session::new(settings);
         let snippet = "
@@ -2666,13 +2424,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((output, _)) => {
                 assert_eq!(output.len(), 6);
                 assert_eq!(
@@ -2713,13 +2465,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((_, result)) => {
                 assert_eq!(result.diagnostics.len(), 0);
             }
@@ -2741,13 +2487,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((output, _)) => {
                 assert_eq!(output.len(), 6);
                 assert_eq!(
@@ -2787,13 +2527,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((output, _)) => {
                 assert_eq!(output.len(), 6);
                 assert_eq!(
@@ -2837,13 +2571,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((output, _)) => {
                 assert_eq!(output.len(), 6);
                 assert_eq!(
@@ -2884,13 +2612,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((output, _)) => {
                 assert_eq!(output.len(), 6);
                 assert_eq!(
@@ -2931,13 +2653,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((_, result)) => {
                 assert_eq!(result.diagnostics.len(), 0);
             }
@@ -2960,13 +2676,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((_, result)) => {
                 assert_eq!(result.diagnostics.len(), 0);
             }
@@ -2989,13 +2699,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((_, result)) => {
                 assert_eq!(result.diagnostics.len(), 0);
             }
@@ -3018,13 +2722,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((_, result)) => {
                 assert_eq!(result.diagnostics.len(), 0);
             }
@@ -3044,13 +2742,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((_, result)) => {
                 assert_eq!(result.diagnostics.len(), 0);
             }
@@ -3072,13 +2764,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((_, result)) => {
                 assert_eq!(result.diagnostics.len(), 0);
             }
@@ -3098,13 +2784,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((_, result)) => {
                 assert_eq!(result.diagnostics.len(), 0);
             }
@@ -3127,13 +2807,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((output, _)) => {
                 assert_eq!(output.len(), 6);
                 assert_eq!(
@@ -3177,13 +2851,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((output, _)) => {
                 assert_eq!(output.len(), 6);
                 assert_eq!(
@@ -3234,13 +2902,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((_, result)) => {
                 assert_eq!(result.diagnostics.len(), 0);
             }
@@ -3274,13 +2936,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((_, result)) => {
                 assert_eq!(result.diagnostics.len(), 0);
             }
@@ -3304,13 +2960,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((_, result)) => {
                 assert_eq!(result.diagnostics.len(), 0);
             }
@@ -3334,13 +2984,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((_, result)) => {
                 assert_eq!(result.diagnostics.len(), 0);
             }
@@ -3364,13 +3008,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((_, result)) => {
                 assert_eq!(result.diagnostics.len(), 0);
             }
@@ -3394,13 +3032,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((_, result)) => {
                 assert_eq!(result.diagnostics.len(), 0);
             }
@@ -3425,13 +3057,7 @@ mod tests {
 )
         "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((output, _)) => {
                 assert_eq!(output.len(), 6);
                 assert_eq!(
@@ -3466,7 +3092,6 @@ mod tests {
     #[test]
     fn filter_trait() {
         let mut settings = SessionSettings::default();
-        settings.repl_settings.disable_clarity_wasm(); // TODO(hugo): re-enable when fixed on clarity-wasm
         settings.repl_settings.analysis.passes = vec![Pass::CheckChecker];
         let mut session = Session::new(settings);
         let snippet = "
@@ -3487,13 +3112,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((_, result)) => {
                 assert_eq!(result.diagnostics.len(), 0);
             }
@@ -3516,13 +3135,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((_, result)) => {
                 assert_eq!(result.diagnostics.len(), 0);
             }
@@ -3552,13 +3165,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((_, result)) => {
                 assert_eq!(result.diagnostics.len(), 0);
             }
@@ -3582,13 +3189,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((_, result)) => {
                 assert_eq!(result.diagnostics.len(), 0);
             }
@@ -3613,13 +3214,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((_, result)) => {
                 assert_eq!(result.diagnostics.len(), 0);
             }
@@ -3643,13 +3238,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((output, _)) => {
                 assert_eq!(output.len(), 6);
                 assert_eq!(
@@ -3691,13 +3280,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((_, result)) => {
                 assert_eq!(result.diagnostics.len(), 0);
             }
@@ -3722,13 +3305,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((_, result)) => {
                 assert_eq!(result.diagnostics.len(), 0);
             }
@@ -3752,13 +3329,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((output, _)) => {
                 assert_eq!(output.len(), 6);
                 assert_eq!(
@@ -3809,13 +3380,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((_, result)) => {
                 assert_eq!(result.diagnostics.len(), 0);
             }
@@ -3849,13 +3414,7 @@ mod tests {
 )
 "
         .to_string();
-        match session.formatted_interpretation(
-            snippet,
-            Some("checker".to_string()),
-            false,
-            None,
-            None,
-        ) {
+        match session.formatted_interpretation(snippet, Some("checker".to_string()), false, None) {
             Ok((output, _)) => {
                 assert_eq!(output.len(), 6);
                 assert_eq!(

--- a/components/clarity-repl/src/bin.rs
+++ b/components/clarity-repl/src/bin.rs
@@ -54,13 +54,13 @@ fn main() {
                 }
             };
 
-            let (_, output) = session.handle_command(&code_str);
+            let (_, output, _) = session.handle_command(&code_str);
             for line in output {
                 println!("{}", line);
             }
         }
         None => loop {
-            let mut terminal = Terminal::new(settings.clone());
+            let mut terminal = Terminal::new(settings.clone(), None);
             if !terminal.start() {
                 break;
             }

--- a/components/clarity-repl/src/frontend/terminal.rs
+++ b/components/clarity-repl/src/frontend/terminal.rs
@@ -1,5 +1,6 @@
 use crate::repl::{settings::SessionSettings, Session};
 
+use clarity::vm::EvaluationResult;
 use rustyline::error::ReadlineError;
 use rustyline::Editor;
 
@@ -73,18 +74,27 @@ fn complete_input(str: &str) -> Result<Input, (char, char)> {
 
 pub struct Terminal {
     pub session: Session,
+    pub session_wasm: Option<Session>,
 }
 
 impl Terminal {
-    pub fn new(session_settings: SessionSettings) -> Terminal {
-        let mut session = Session::new(session_settings);
-        session.is_interactive = true;
-        Terminal { session }
+    pub fn new(
+        session_settings: SessionSettings,
+        session_wasm_settings: Option<SessionSettings>,
+    ) -> Terminal {
+        let session = Session::new(session_settings);
+        let session_wasm = session_wasm_settings.map(Session::new);
+        Terminal {
+            session,
+            session_wasm,
+        }
     }
 
-    pub fn load(mut session: Session) -> Terminal {
-        session.is_interactive = true;
-        Terminal { session }
+    pub fn load(session: Session, session_wasm: Option<Session>) -> Terminal {
+        Terminal {
+            session,
+            session_wasm,
+        }
     }
 
     pub fn start(&mut self) -> bool {
@@ -117,7 +127,57 @@ impl Terminal {
                     let input = input_buffer.join(" ");
                     match complete_input(&input) {
                         Ok(Input::Complete(_)) => {
-                            let (reload, output) = self.session.handle_command(&input);
+                            let (reload, output, result) = self.session.handle_command(&input);
+
+                            if let Some(session_wasm) = &mut self.session_wasm {
+                                let (_, _, result_wasm) = session_wasm.handle_command(&input);
+
+                                if let (Some(result), Some(result_wasm)) = (result, result_wasm) {
+                                    match (result, result_wasm) {
+                                        (Ok(result), Ok(result_wasm)) => {
+                                            let value = match result.result {
+                                                EvaluationResult::Contract(contract_result) => {
+                                                    contract_result.result
+                                                }
+                                                EvaluationResult::Snippet(snippet_result) => {
+                                                    Some(snippet_result.result)
+                                                }
+                                            };
+                                            let value_wasm = match result_wasm.result {
+                                                EvaluationResult::Contract(contract_result) => {
+                                                    contract_result.result
+                                                }
+                                                EvaluationResult::Snippet(snippet_result) => {
+                                                    Some(snippet_result.result)
+                                                }
+                                            };
+                                            if value != value_wasm {
+                                                dbg!(value);
+                                                dbg!(value_wasm);
+                                                print_clarity_wasm_warning();
+                                            };
+                                        }
+                                        (Ok(result), Err(error_wasm)) => {
+                                            dbg!(result);
+                                            dbg!(error_wasm);
+                                            print_clarity_wasm_warning();
+                                        }
+                                        (Err(error), Ok(result_wasm)) => {
+                                            dbg!(error);
+                                            dbg!(result_wasm);
+                                            print_clarity_wasm_warning();
+                                        }
+                                        (Err(error), Err(error_wasm)) => {
+                                            if error != error_wasm {
+                                                dbg!(error);
+                                                dbg!(error_wasm);
+                                                print_clarity_wasm_warning();
+                                            }
+                                        }
+                                    };
+                                }
+                            }
+
                             for line in output {
                                 println!("{}", line);
                             }
@@ -162,4 +222,11 @@ impl Terminal {
             .unwrap();
         reload
     }
+}
+
+pub fn print_clarity_wasm_warning() {
+    println!("{} https://github.com/stacks-network/clarity-wasm/issues/new/choose {}",
+        yellow!("It appears that Clarity-Wasm is returning an unexpected result.\nPlease help improve the Stacks network by reporting this issue at"),
+        yellow!("and include the errors above along with the source code that triggered this.\n")
+    );
 }

--- a/components/clarity-repl/src/repl/interpreter.rs
+++ b/components/clarity-repl/src/repl/interpreter.rs
@@ -6,12 +6,10 @@ use crate::analysis::{self};
 use crate::repl::datastore::BurnDatastore;
 use crate::repl::datastore::Datastore;
 use crate::repl::Settings;
-#[cfg(all(feature = "cli", not(feature = "wasm")))]
-use clar2wasm::Module;
 use clarity::consts::CHAIN_ID_TESTNET;
 use clarity::vm::analysis::ContractAnalysis;
 use clarity::vm::ast::{build_ast_with_diagnostics, ContractAST};
-#[cfg(all(feature = "cli", not(feature = "wasm")))]
+#[cfg(feature = "cli")]
 use clarity::vm::clarity_wasm::{call_function, initialize_contract};
 use clarity::vm::contexts::{CallStack, ContractContext, Environment, GlobalContext, LocalContext};
 use clarity::vm::contracts::Contract;
@@ -30,7 +28,7 @@ use clarity::vm::{ContractEvaluationResult, EvalHook};
 use clarity::vm::{CostSynthesis, ExecutionResult, ParsedContract};
 
 use super::datastore::StacksConstants;
-use super::{ClarityContract, ContractDeployer, DEFAULT_EPOCH};
+use super::{ClarityContract, DEFAULT_EPOCH};
 
 pub const BLOCK_LIMIT_MAINNET: ExecutionCost = ExecutionCost {
     write_length: 15_000_000,
@@ -44,10 +42,10 @@ pub const BLOCK_LIMIT_MAINNET: ExecutionCost = ExecutionCost {
 pub struct ClarityInterpreter {
     pub datastore: Datastore,
     pub burn_datastore: BurnDatastore,
+    pub repl_settings: Settings,
     tx_sender: StandardPrincipalData,
     accounts: BTreeSet<String>,
     tokens: BTreeMap<String, BTreeMap<String, u128>>,
-    repl_settings: Settings,
 }
 
 #[derive(Debug)]
@@ -118,61 +116,6 @@ impl ClarityInterpreter {
         }
     }
 
-    pub fn run_both(
-        &mut self,
-        contract: &ClarityContract,
-        ast: &mut Option<ContractAST>,
-        cost_track: bool,
-        eval_hooks: Option<Vec<&mut dyn EvalHook>>,
-    ) -> Result<ExecutionResult, Vec<Diagnostic>> {
-        let result = self.run(contract, ast, cost_track, eval_hooks);
-
-        // when running clarity-repl/wasm (ie. not natively), we can't run clar2wasm
-        #[cfg(all(feature = "cli", not(feature = "wasm")))]
-        if self.repl_settings.is_clarity_wasm_enabled() {
-            let mut contract_wasm = contract.clone();
-            contract_wasm.deployer =
-                ContractDeployer::Address("ST3NBRSFKX28FQ2ZJ1MAKX58HKHSDGNV5N7R21XCP".into());
-            let result_wasm = self.run_wasm(&contract_wasm, ast, cost_track, None);
-            match (result.clone(), result_wasm) {
-                (Ok(result), Ok(result_wasm)) => {
-                    let value = match result.result {
-                        EvaluationResult::Contract(contract_result) => contract_result.result,
-                        EvaluationResult::Snippet(snippet_result) => Some(snippet_result.result),
-                    };
-                    let value_wasm = match result_wasm.result {
-                        EvaluationResult::Contract(contract_result) => contract_result.result,
-                        EvaluationResult::Snippet(snippet_result) => Some(snippet_result.result),
-                    };
-                    if value != value_wasm {
-                        println!("values do not match");
-                        println!("value: {:?}", value);
-                        println!("value_wasm: {:?}", value_wasm);
-                    };
-                }
-                (Ok(result), Err(error_wasm)) => {
-                    println!("values do not match");
-                    println!("wasm error: {:?}", error_wasm);
-                    println!("result: {:?}", result);
-                }
-                (Err(error), Ok(result_wasm)) => {
-                    println!("values do not match");
-                    println!("result error: {:?}", error);
-                    println!("result_wasm: {:?}", result_wasm);
-                }
-                (Err(error), Err(error_wasm)) => {
-                    if error != error_wasm {
-                        println!("values do not match");
-                        println!("result error: {:?}", error);
-                        println!("wasm error: {:?}", error_wasm);
-                    }
-                }
-            };
-        }
-
-        result
-    }
-
     pub fn run(
         &mut self,
         contract: &ClarityContract,
@@ -180,7 +123,21 @@ impl ClarityInterpreter {
         cost_track: bool,
         eval_hooks: Option<Vec<&mut dyn EvalHook>>,
     ) -> Result<ExecutionResult, Vec<Diagnostic>> {
-        let (mut ast, mut diagnostics, success) = match ast {
+        if self.repl_settings.clarity_wasm_mode {
+            self.run_wasm(&contract.clone(), &mut ast.clone(), cost_track, None)
+        } else {
+            self.run_interpreter(&contract.clone(), &mut ast.clone(), cost_track, eval_hooks)
+        }
+    }
+
+    pub fn run_interpreter(
+        &mut self,
+        contract: &ClarityContract,
+        ast: &mut Option<ContractAST>,
+        cost_track: bool,
+        eval_hooks: Option<Vec<&mut dyn EvalHook>>,
+    ) -> Result<ExecutionResult, Vec<Diagnostic>> {
+        let (mut ast, mut diagnostics, success) = match ast.take() {
             Some(ast) => (ast.clone(), vec![], true),
             None => self.build_ast(contract),
         };
@@ -221,7 +178,7 @@ impl ClarityInterpreter {
         Ok(result)
     }
 
-    #[cfg(all(feature = "cli", not(feature = "wasm")))]
+    #[cfg(feature = "cli")]
     pub fn run_wasm(
         &mut self,
         contract: &ClarityContract,
@@ -229,74 +186,42 @@ impl ClarityInterpreter {
         cost_track: bool,
         eval_hooks: Option<Vec<&mut dyn EvalHook>>,
     ) -> Result<ExecutionResult, Vec<Diagnostic>> {
-        use clar2wasm::{compile, compile_contract, CompileError, CompileResult};
+        use clar2wasm::compile_contract;
 
-        let contract_id = contract.expect_resolved_contract_identifier(Some(&self.tx_sender));
-        let source = contract.expect_in_memory_code_source();
-        let mut analysis_db = AnalysisDatabase::new(&mut self.datastore);
+        let (mut ast, mut diagnostics, success) = match ast.take() {
+            Some(ast) => (ast.clone(), vec![], true),
+            None => self.build_ast(contract),
+        };
 
-        let (mut ast, mut diagnostics, analysis, mut module) = match ast.take() {
-            Some(mut ast) => {
-                let mut diagnostics = vec![];
-                let (annotations, annotation_diagnostics) =
-                    self.collect_annotations(contract.expect_in_memory_code_source());
-                diagnostics.extend(annotation_diagnostics);
+        let code_source = contract.expect_in_memory_code_source();
 
-                let (analysis, analysis_diagnostics) =
-                    match self.run_analysis(contract, &mut ast, &annotations) {
-                        Ok((analysis, diagnostics)) => (analysis, diagnostics),
-                        Err(diagnostic) => {
-                            diagnostics.push(diagnostic);
-                            return Err(diagnostics.to_vec());
-                        }
-                    };
-                diagnostics.extend(analysis_diagnostics);
+        let (annotations, mut annotation_diagnostics) = self.collect_annotations(code_source);
+        diagnostics.append(&mut annotation_diagnostics);
 
-                let module = match compile_contract(analysis.clone()) {
-                    Ok(res) => res,
-                    Err(e) => {
-                        diagnostics.push(Diagnostic {
-                            level: Level::Error,
-                            message: format!("Wasm Generator Error: {:?}", e),
-                            spans: vec![],
-                            suggestion: None,
-                        });
-                        return Err(diagnostics);
-                    }
-                };
-                (ast, diagnostics, analysis, module)
-            }
-            None => {
-                let CompileResult {
-                    mut ast,
-                    mut diagnostics,
-                    module,
-                    contract_analysis: _,
-                } = match compile(
-                    source,
-                    &contract_id,
-                    LimitedCostTracker::new_free(),
-                    contract.clarity_version,
-                    contract.epoch,
-                    &mut analysis_db,
-                ) {
-                    Ok(res) => res,
-                    Err(CompileError::Generic { diagnostics, .. }) => return Err(diagnostics),
-                };
-                let (annotations, mut annotation_diagnostics) =
-                    self.collect_annotations(contract.expect_in_memory_code_source());
-                diagnostics.append(&mut annotation_diagnostics);
+        let (analysis, mut analysis_diagnostics) =
+            match self.run_analysis(contract, &mut ast, &annotations) {
+                Ok((analysis, diagnostics)) => (analysis, diagnostics),
+                Err(diagnostic) => {
+                    diagnostics.push(diagnostic);
+                    return Err(diagnostics.to_vec());
+                }
+            };
+        diagnostics.append(&mut analysis_diagnostics);
 
-                let (analysis, mut analysis_diagnostics) =
-                    match self.run_analysis(contract, &mut ast, &annotations) {
-                        Ok((analysis, diagnostics)) => (analysis, diagnostics),
-                        Err(diagnostic) => {
-                            diagnostics.push(diagnostic);
-                            return Err(diagnostics);
-                        }
-                    };
-                diagnostics.append(&mut analysis_diagnostics);
-                (ast, diagnostics, analysis, module)
+        if !success {
+            return Err(diagnostics.to_vec());
+        }
+
+        let mut module = match compile_contract(analysis.clone()) {
+            Ok(res) => res,
+            Err(e) => {
+                diagnostics.push(Diagnostic {
+                    level: Level::Error,
+                    message: format!("Wasm Generator Error: {:?}", e),
+                    spans: vec![],
+                    suggestion: None,
+                });
+                return Err(diagnostics);
             }
         };
 
@@ -563,8 +488,9 @@ impl ClarityInterpreter {
             global_context.eval_hooks = Some(hooks);
         }
 
-        global_context.begin();
+        let show_timings = self.repl_settings.show_timings;
 
+        global_context.begin();
         let result = global_context.execute(|g| {
             if contract_ast.expressions.len() == 1 && !snippet.contains("(define-") {
                 let context = LocalContext::new();
@@ -598,23 +524,27 @@ impl ClarityInterpreter {
                                 args.push(evaluated_arg);
                             }
 
-                            // INTERPRETER
                             let start = std::time::Instant::now();
                             let args: Vec<SymbolicExpression> = args
                                 .iter()
                                 .map(|a| SymbolicExpression::atom_value(a.clone()))
                                 .collect();
                             let res = env.execute_contract(&contract_id, &method, &args, false)?;
-                            println!("execute intr: {:?}μs", start.elapsed().as_micros());
+
+                            // println!("execute intr: {:?}μs", start.elapsed().as_micros());
+                            if show_timings {
+                                println!("execution time: {:?}μs", start.elapsed().as_micros());
+                            }
                             return Ok(Some(res));
                         }
                     }
                 };
 
-                // INTERPRETER
                 let start = std::time::Instant::now();
                 let result = eval(&contract_ast.expressions[0], &mut env, &context);
-                println!("execute intr: {:?}μs", start.elapsed().as_micros());
+                if show_timings {
+                    println!("execution time: {:?}μs", start.elapsed().as_micros());
+                }
 
                 return result.map(Some);
             }
@@ -730,13 +660,13 @@ impl ClarityInterpreter {
         Ok(execution_result)
     }
 
-    #[cfg(all(feature = "cli", not(feature = "wasm")))]
+    #[cfg(feature = "cli")]
     fn execute_wasm(
         &mut self,
         contract: &ClarityContract,
         contract_ast: &mut ContractAST,
         analysis: ContractAnalysis,
-        wasm_module: &mut Module,
+        wasm_module: &mut clar2wasm::Module,
         cost_track: bool,
         eval_hooks: Option<Vec<&mut dyn EvalHook>>,
     ) -> Result<ExecutionResult, String> {
@@ -777,8 +707,9 @@ impl ClarityInterpreter {
             global_context.eval_hooks = Some(hooks);
         }
 
-        global_context.begin();
+        let show_timings = self.repl_settings.show_timings;
 
+        global_context.begin();
         let result = global_context.execute(|g| {
             if contract_ast.expressions.len() == 1 && !snippet.contains("(define-") {
                 let context = LocalContext::new();
@@ -815,7 +746,6 @@ impl ClarityInterpreter {
                             let called_contract =
                                 env.global_context.database.get_contract(&contract_id)?;
 
-                            // CLAR2WASM
                             let start = std::time::Instant::now();
 
                             let res = match call_function(
@@ -834,19 +764,24 @@ impl ClarityInterpreter {
                                     return Err(e);
                                 }
                             };
-                            println!("execute wasm: {:?}", start.elapsed());
+                            if show_timings {
+                                println!(
+                                    "execution time (wasm): {:?}μs",
+                                    start.elapsed().as_micros()
+                                );
+                            }
                             return Ok(Some(res));
                         }
                     }
                 };
 
-                // execute code
-                // let start = std::time::Instant::now();
                 let start = std::time::Instant::now();
                 contract_context.set_wasm_module(wasm_module.emit_wasm());
                 let result = initialize_contract(g, &mut contract_context, None, &analysis)
                     .map(|v| v.unwrap_or(Value::none()));
-                println!("execute wasm: {:?}μs", start.elapsed().as_micros());
+                if show_timings {
+                    println!("execution time (wasm): {:?}μs", start.elapsed().as_micros());
+                }
 
                 return result.map(Some);
             }
@@ -1306,7 +1241,7 @@ mod tests {
         let mut interpreter =
             ClarityInterpreter::new(StandardPrincipalData::transient(), Settings::default());
         let contract = ClarityContract::fixture();
-        let result = interpreter.run(&contract, &mut None, false, None);
+        let result = interpreter.run_interpreter(&contract, &mut None, false, None);
         assert!(result.is_ok());
         assert!(result.unwrap().diagnostics.is_empty());
     }
@@ -1321,7 +1256,7 @@ mod tests {
         let contract = ClarityContractBuilder::default()
             .code_source(snippet.into())
             .build();
-        let result = interpreter.run(&contract, &mut None, false, None);
+        let result = interpreter.run_interpreter(&contract, &mut None, false, None);
         assert!(result.is_err());
         let diagnostics = result.unwrap_err();
         assert_eq!(diagnostics.len(), 1);
@@ -1336,7 +1271,7 @@ mod tests {
         let contract = ClarityContractBuilder::default()
             .code_source(snippet.into())
             .build();
-        let result = interpreter.run(&contract, &mut None, false, None);
+        let result = interpreter.run_interpreter(&contract, &mut None, false, None);
         assert!(result.is_err());
 
         let diagnostics = result.unwrap_err();
@@ -1395,12 +1330,12 @@ mod tests {
             ClarityInterpreter::new(StandardPrincipalData::transient(), Settings::default());
 
         let contract = ClarityContract::fixture();
-        let _ = interpreter.run_both(&contract, &mut None, false, None);
+        let _ = interpreter.run(&contract, &mut None, false, None);
 
         let call_contract = ClarityContractBuilder::default()
             .code_source("(contract-call? .contract incr)".to_owned())
             .build();
-        let _ = interpreter.run_both(&call_contract, &mut None, false, None);
+        let _ = interpreter.run(&call_contract, &mut None, false, None);
     }
 
     #[test]

--- a/components/clarity-repl/src/repl/interpreter.rs
+++ b/components/clarity-repl/src/repl/interpreter.rs
@@ -531,7 +531,6 @@ impl ClarityInterpreter {
                                 .collect();
                             let res = env.execute_contract(&contract_id, &method, &args, false)?;
 
-                            // println!("execute intr: {:?}μs", start.elapsed().as_micros());
                             if show_timings {
                                 println!("execution time: {:?}μs", start.elapsed().as_micros());
                             }

--- a/components/clarity-repl/src/repl/session.rs
+++ b/components/clarity-repl/src/repl/session.rs
@@ -96,7 +96,6 @@ pub struct CostsReport {
 
 #[derive(Clone, Debug)]
 pub struct Session {
-    pub is_interactive: bool,
     pub settings: SessionSettings,
     pub contracts: BTreeMap<String, BTreeMap<String, Vec<String>>>,
     pub asts: BTreeMap<QualifiedContractIdentifier, ContractAST>,
@@ -122,7 +121,6 @@ impl Session {
         };
 
         Session {
-            is_interactive: false,
             interpreter: ClarityInterpreter::new(tx_sender, settings.repl_settings.clone()),
             asts: BTreeMap::new(),
             contracts: BTreeMap::new(),
@@ -188,10 +186,16 @@ impl Session {
         }
     }
 
-    pub fn handle_command(&mut self, command: &str) -> (bool, Vec<String>) {
+    pub fn handle_command(
+        &mut self,
+        command: &str,
+    ) -> (
+        bool,
+        Vec<String>,
+        Option<Result<ExecutionResult, Vec<Diagnostic>>>,
+    ) {
         let mut output = Vec::<String>::new();
 
-        #[allow(unused_mut)]
         let mut reload = false;
         match command {
             "::help" => self.display_help(&mut output),
@@ -210,6 +214,7 @@ impl Session {
                 self.parse_and_advance_chain_tip(&mut output, cmd)
             }
             cmd if cmd.starts_with("::toggle_costs") => self.toggle_costs(&mut output),
+            cmd if cmd.starts_with("::toggle_timings") => self.toggle_timings(&mut output),
             cmd if cmd.starts_with("::get_epoch") => self.get_epoch(&mut output),
             cmd if cmd.starts_with("::set_epoch") => self.set_epoch(&mut output, cmd),
             cmd if cmd.starts_with("::encode") => self.encode(&mut output, cmd),
@@ -225,29 +230,40 @@ impl Session {
             cmd if cmd.starts_with("::read") => self.read(&mut output, cmd),
             cmd if cmd.starts_with("::keywords") => self.keywords(&mut output),
 
-            snippet => self.run_snippet(&mut output, self.show_costs, snippet),
+            cmd if cmd.starts_with("::") => {
+                output.push(yellow!(format!("Unknown command: {}", cmd)));
+            }
+
+            snippet => {
+                let execution_result = self.run_snippet(&mut output, self.show_costs, snippet);
+                return (false, output, execution_result);
+            }
         }
 
-        (reload, output)
+        (reload, output, None)
     }
 
     #[cfg(feature = "cli")]
-    fn run_snippet(&mut self, output: &mut Vec<String>, cost_track: bool, cmd: &str) {
-        let (mut result, cost) = match self.formatted_interpretation(
+    fn run_snippet(
+        &mut self,
+        output: &mut Vec<String>,
+        cost_track: bool,
+        cmd: &str,
+    ) -> Option<Result<ExecutionResult, Vec<Diagnostic>>> {
+        let (mut result, cost, execution_result) = match self.formatted_interpretation(
             cmd.to_string(),
             None,
             cost_track,
             None,
-            None,
         ) {
             Ok((mut output, result)) => {
-                if let EvaluationResult::Contract(contract_result) = result.result {
+                if let EvaluationResult::Contract(contract_result) = result.result.clone() {
                     let snippet = format!("→ .{} contract successfully stored. Use (contract-call? ...) for invoking the public functions:", contract_result.contract.contract_identifier.clone());
                     output.push(green!(snippet));
                 };
-                (output, result.cost.clone())
+                (output, result.cost.clone(), Some(Ok(result)))
             }
-            Err(output) => (output, None),
+            Err((err_output, diagnostics)) => (err_output, None, Some(Err(diagnostics))),
         };
 
         if let Some(cost) = cost {
@@ -307,6 +323,7 @@ impl Session {
             output.push(format!("{}", table));
         }
         output.append(&mut result);
+        execution_result
     }
 
     #[cfg(feature = "cli")]
@@ -323,8 +340,7 @@ impl Session {
         name: Option<String>,
         cost_track: bool,
         eval_hooks: Option<Vec<&mut dyn EvalHook>>,
-        _test_name: Option<String>,
-    ) -> Result<(Vec<String>, ExecutionResult), Vec<String>> {
+    ) -> Result<(Vec<String>, ExecutionResult), (Vec<String>, Vec<Diagnostic>)> {
         let result = self.eval(snippet.to_string(), eval_hooks, cost_track);
         let mut output = Vec::<String>::new();
         let formatted_lines: Vec<String> = snippet.lines().map(|l| l.to_string()).collect();
@@ -358,10 +374,10 @@ impl Session {
                 Ok((output, result))
             }
             Err(diagnostics) => {
-                for d in diagnostics {
-                    output.append(&mut output_diagnostic(&d, &contract_name, &formatted_lines));
+                for d in &diagnostics {
+                    output.append(&mut output_diagnostic(d, &contract_name, &formatted_lines));
                 }
-                Err(output)
+                Err((output, diagnostics))
             }
         }
     }
@@ -382,7 +398,6 @@ impl Session {
             None,
             true,
             Some(vec![&mut debugger]),
-            None,
         ) {
             Ok((mut output, result)) => {
                 if let EvaluationResult::Contract(contract_result) = result.result {
@@ -391,7 +406,7 @@ impl Session {
                 };
                 output
             }
-            Err(result) => result,
+            Err((result, _)) => result,
         };
         output.append(&mut result);
     }
@@ -464,7 +479,9 @@ impl Session {
         };
 
         match std::fs::read_to_string(filename) {
-            Ok(snippet) => self.run_snippet(output, self.show_costs, &snippet),
+            Ok(snippet) => {
+                self.run_snippet(output, self.show_costs, &snippet);
+            }
             Err(err) => output.push(red!(format!("unable to read {}: {}", filename, err))),
         };
     }
@@ -513,9 +530,7 @@ impl Session {
         let contract_id =
             contract.expect_resolved_contract_identifier(Some(&self.interpreter.get_tx_sender()));
 
-        let result = self
-            .interpreter
-            .run_both(contract, ast, cost_track, Some(hooks));
+        let result = self.interpreter.run(contract, ast, cost_track, Some(hooks));
 
         match result {
             Ok(result) => {
@@ -571,17 +586,16 @@ impl Session {
         };
 
         self.set_tx_sender(sender.into());
-        let execution =
-            match self
-                .interpreter
-                .run_both(&contract_call, &mut None, true, Some(hooks))
-            {
-                Ok(result) => result,
-                Err(e) => {
-                    self.set_tx_sender(initial_tx_sender);
-                    return Err(e);
-                }
-            };
+        let execution = match self
+            .interpreter
+            .run(&contract_call, &mut None, true, Some(hooks))
+        {
+            Ok(result) => result,
+            Err(e) => {
+                self.set_tx_sender(initial_tx_sender);
+                return Err(e);
+            }
+        };
         self.set_tx_sender(initial_tx_sender);
         self.coverage_reports.push(coverage);
 
@@ -617,7 +631,7 @@ impl Session {
 
         let result = self
             .interpreter
-            .run_both(&contract, &mut None, cost_track, eval_hooks);
+            .run(&contract.clone(), &mut None, cost_track, eval_hooks);
 
         match result {
             Ok(result) => {
@@ -844,6 +858,14 @@ impl Session {
     pub fn toggle_costs(&mut self, output: &mut Vec<String>) {
         self.show_costs = !self.show_costs;
         output.push(green!(format!("Always show costs: {}", self.show_costs)))
+    }
+
+    pub fn toggle_timings(&mut self, output: &mut Vec<String>) {
+        self.interpreter.repl_settings.show_timings = !self.interpreter.repl_settings.show_timings;
+        output.push(green!(format!(
+            "Always show timings: {}",
+            self.interpreter.repl_settings.show_timings
+        )))
     }
 
     pub fn get_epoch(&mut self, output: &mut Vec<String>) {

--- a/components/clarity-repl/src/repl/settings.rs
+++ b/components/clarity-repl/src/repl/settings.rs
@@ -54,21 +54,8 @@ pub struct SessionSettings {
 #[derive(Debug, Default, Clone, Deserialize, Serialize)]
 pub struct Settings {
     pub analysis: analysis::Settings,
-    enable_clarity_wasm: bool,
-}
-
-impl Settings {
-    pub fn enable_clarity_wasm(&mut self) {
-        self.enable_clarity_wasm = true;
-    }
-
-    pub fn disable_clarity_wasm(&mut self) {
-        self.enable_clarity_wasm = false;
-    }
-
-    pub fn is_clarity_wasm_enabled(&self) -> bool {
-        self.enable_clarity_wasm
-    }
+    pub clarity_wasm_mode: bool,
+    pub show_timings: bool,
 }
 
 #[derive(Debug, Default, Clone, Deserialize, Serialize)]
@@ -85,7 +72,8 @@ impl From<SettingsFile> for Settings {
         };
         Self {
             analysis,
-            enable_clarity_wasm: true,
+            clarity_wasm_mode: false,
+            show_timings: false,
         }
     }
 }


### PR DESCRIPTION
### Description

Revamp the way we run the clarity-wasm preview in `clarinet console` . We now run two session in parallel, the second one run in "wasm-mode".

- The second session (the wasm one), can be **disabled** with: 
```console
clarinet console --disable-clarity-wasm
```


- If the interpreter and clarity-wasm return different results, the results are logged and a message asks the users to open an issue
<img width="1285" alt="Screenshot 2024-01-24 at 20 58 11" src="https://github.com/hirosystems/clarinet/assets/911307/0ba135f3-00ff-4cdb-815e-72136e59d899">

- These PR also implements a `::toggle_timings` that give an approximate idea of how long a snippet execution took
