### PR TITLE
Update Github action format for Clarinet 2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,13 +546,22 @@ jobs:
     name: "Test contracts with Clarinet"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: "Execute unit tests"
+      - name: "Checkout code"
+        uses: actions/checkout@v3
+      - name: "Check contract syntax"
         uses: docker://hirosystems/clarinet:latest
         with:
-          args: test --coverage --manifest-path=./Clarinet.toml
-      - name: "Export code coverage"
-        uses: codecov/codecov-action@v1
+          args: check
+      - name: "Setup Node.js"
+        uses: actions/setup-node@v4
+        with:
+          node-version: "18.x"
+      - name: "Prep CI"
+        run: npm ci
+      - name: "Execute unit tests"
+        run: npm run test:report
+      - name: "Upload code coverage"
+        uses: codecov/codecov-action@v3
         with:
           files: ./coverage.lcov
           verbose: true


### PR DESCRIPTION
In the latest version `clarinet test` is deprecated in favor of using the Clarinet SDK for unit testing.

The default steps in the README now will fail because `clarinet test` does not run, see below:

https://github.com/stacks-m2m/contracts/actions/runs/7661218176

By updating the steps to use `clarinet check` first, then install Node + run `npm test`, this version is more in line with the default setup and succeeds:

https://github.com/stacks-m2m/contracts/actions/runs/7661309610

This also updates the checkout and codecov actions to their latest versions.

You can see the file we're using here which is very similar:

https://github.com/stacks-m2m/contracts/blob/main/.github/workflows/clarinet.yml