### PR TITLE
fix wasm build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -793,7 +793,7 @@ checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 [[package]]
 name = "clar2wasm"
 version = "0.1.0"
-source = "git+https://github.com/stacks-network/clarity-wasm.git#b7b65b9e928ac4b893d57c24151d64918b77d840"
+source = "git+https://github.com/stacks-network/clarity-wasm.git#99889364e059c338d090e6a9041f9b160fa9014b"
 dependencies = [
  "clap",
  "clarity",
@@ -950,15 +950,13 @@ dependencies = [
 [[package]]
 name = "clarity"
 version = "2.2.0"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-next#5956df38f851fa46204d4e57614bf77e633d553b"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-next#7f52960ee613dd7317fce24379ef29cf131541dc"
 dependencies = [
  "integer-sqrt",
  "lazy_static",
  "rand 0.7.3",
  "rand_chacha 0.2.2",
  "regex",
- "rstest",
- "rstest_reuse",
  "rusqlite",
  "serde",
  "serde_derive",
@@ -1057,7 +1055,7 @@ dependencies = [
  "tokio-util",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wsts 5.0.0",
+ "wsts 7.0.0",
 ]
 
 [[package]]
@@ -1935,12 +1933,6 @@ name = "futures-task"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
-
-[[package]]
-name = "futures-timer"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
@@ -4019,44 +4011,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rstest"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de1bb486a691878cd320c2f0d319ba91eeaa2e894066d8b5f8f117c000e9d962"
-dependencies = [
- "futures",
- "futures-timer",
- "rstest_macros",
- "rustc_version 0.4.0",
-]
-
-[[package]]
-name = "rstest_macros"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290ca1a1c8ca7edb7c3283bd44dc35dd54fdec6253a3912e201ba1072018fca8"
-dependencies = [
- "cfg-if",
- "proc-macro2",
- "quote",
- "rustc_version 0.4.0",
- "syn 1.0.107",
- "unicode-ident",
-]
-
-[[package]]
-name = "rstest_reuse"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45f80dcc84beab3a327bbe161f77db25f336a1452428176787c8c79ac79d7073"
-dependencies = [
- "quote",
- "rand 0.8.5",
- "rustc_version 0.4.0",
- "syn 1.0.107",
-]
-
-[[package]]
 name = "rusqlite"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4096,15 +4050,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
  "semver 0.9.0",
-]
-
-[[package]]
-name = "rustc_version"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
-dependencies = [
- "semver 1.0.16",
 ]
 
 [[package]]
@@ -4789,7 +4734,7 @@ dependencies = [
 [[package]]
 name = "stacks-common"
 version = "0.0.2"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-next#5956df38f851fa46204d4e57614bf77e633d553b"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-next#7f52960ee613dd7317fce24379ef29cf131541dc"
 dependencies = [
  "chrono",
  "curve25519-dalek",
@@ -4933,7 +4878,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
 dependencies = [
  "discard",
- "rustc_version 0.2.3",
+ "rustc_version",
  "stdweb-derive",
  "stdweb-internal-macros",
  "stdweb-internal-runtime",
@@ -6429,6 +6374,26 @@ name = "wsts"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c7db3d3fe28c359e0cdb7f7ad83e3316bda0ba982b8cd1bf0fbe73ae4127e4b"
+dependencies = [
+ "aes-gcm",
+ "bs58 0.5.0",
+ "hashbrown 0.14.0",
+ "hex 0.4.3",
+ "num-traits",
+ "p256k1",
+ "polynomial",
+ "primitive-types",
+ "rand_core 0.6.4",
+ "serde",
+ "sha2 0.10.6",
+ "thiserror",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "wsts"
+version = "7.0.0"
 dependencies = [
  "aes-gcm",
  "bs58 0.5.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6394,6 +6394,8 @@ dependencies = [
 [[package]]
 name = "wsts"
 version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c398736468f3322a43b6419be5315e68ae035e6565628603503c2a62ad726f36"
 dependencies = [
  "aes-gcm",
  "bs58 0.5.0",

--- a/components/clarinet-sdk/src/contractInterface.ts
+++ b/components/clarinet-sdk/src/contractInterface.ts
@@ -53,7 +53,9 @@ export type StacksEpochId =
   | "Epoch21"
   | "Epoch22"
   | "Epoch23"
-  | "Epoch24";
+  | "Epoch24"
+  | "Epoch25"
+  | "Epoch30";
 
 export type ClarityVersion = "Clarity1" | "Clarity2";
 

--- a/components/clarinet-sdk/src/index.ts
+++ b/components/clarinet-sdk/src/index.ts
@@ -102,13 +102,14 @@ export type GetDataVar = (contract: string, dataVar: string) => ClarityValue;
 export type GetMapEntry = (contract: string, mapName: string, mapKey: ClarityValue) => ClarityValue;
 export type GetContractAST = (contractId: string) => ContractAST;
 export type GetContractsInterfaces = () => Map<string, ContractInterface>;
+export type RunSnippet = (snippet: string) => ClarityValue | string;
 
 // because the session is wrapped in a proxy the types need to be hardcoded
 export type Simnet = {
   [K in keyof SDK]: K extends "callReadOnlyFn" | "callPublicFn"
     ? CallFn
     : K extends "runSnippet"
-      ? ClarityValue
+      ? RunSnippet
       : K extends "deployContract"
         ? DeployContract
         : K extends "transferSTX"
@@ -174,7 +175,7 @@ const getSessionProxy = () => ({
     }
 
     if (prop === "runSnippet") {
-      return (snippet: string) => {
+      const runSnippet: RunSnippet = (snippet) => {
         const response = session[prop](snippet);
         if (response.startsWith("0x")) {
           return Cl.deserialize(response);
@@ -182,6 +183,7 @@ const getSessionProxy = () => ({
           return response;
         }
       };
+      return runSnippet;
     }
 
     if (prop === "deployContract") {

--- a/components/clarinet-sdk/src/index.ts
+++ b/components/clarinet-sdk/src/index.ts
@@ -107,21 +107,23 @@ export type GetContractsInterfaces = () => Map<string, ContractInterface>;
 export type Simnet = {
   [K in keyof SDK]: K extends "callReadOnlyFn" | "callPublicFn"
     ? CallFn
-    : K extends "deployContract"
-    ? DeployContract
-    : K extends "transferSTX"
-    ? TransferSTX
-    : K extends "mineBlock"
-    ? MineBlock
-    : K extends "getDataVar"
-    ? GetDataVar
-    : K extends "getMapEntry"
-    ? GetMapEntry
-    : K extends "getContractAST"
-    ? GetContractAST
-    : K extends "getContractsInterfaces"
-    ? GetContractsInterfaces
-    : SDK[K];
+    : K extends "runSnippet"
+      ? ClarityValue
+      : K extends "deployContract"
+        ? DeployContract
+        : K extends "transferSTX"
+          ? TransferSTX
+          : K extends "mineBlock"
+            ? MineBlock
+            : K extends "getDataVar"
+              ? GetDataVar
+              : K extends "getMapEntry"
+                ? GetMapEntry
+                : K extends "getContractAST"
+                  ? GetContractAST
+                  : K extends "getContractsInterfaces"
+                    ? GetContractsInterfaces
+                    : SDK[K];
 };
 
 function parseEvents(events: string): ClarityEvent[] {
@@ -169,6 +171,17 @@ const getSessionProxy = () => ({
         return parseTxResponse(response);
       };
       return callFn;
+    }
+
+    if (prop === "runSnippet") {
+      return (snippet: string) => {
+        const response = session[prop](snippet);
+        if (response.startsWith("0x")) {
+          return Cl.deserialize(response);
+        } else {
+          return response;
+        }
+      };
     }
 
     if (prop === "deployContract") {

--- a/components/clarinet-sdk/tests/index.test.ts
+++ b/components/clarinet-sdk/tests/index.test.ts
@@ -20,41 +20,41 @@ describe("basic simnet interactions", async () => {
   it("initialize simnet", async () => {
     expect(simnet.blockHeight).toBe(1);
   });
-});
 
-it("can mine empty blocks", async () => {
-  simnet.mineEmptyBlock();
-  expect(simnet.blockHeight).toBe(2);
-  simnet.mineEmptyBlocks(4);
-  expect(simnet.blockHeight).toBe(6);
-});
+  it("can mine empty blocks", async () => {
+    simnet.mineEmptyBlock();
+    expect(simnet.blockHeight).toBe(2);
+    simnet.mineEmptyBlocks(4);
+    expect(simnet.blockHeight).toBe(6);
+  });
 
-it("exposes devnet stacks accounts", async () => {
-  const accounts = simnet.getAccounts();
+  it("exposes devnet stacks accounts", async () => {
+    const accounts = simnet.getAccounts();
 
-  expect(accounts).toHaveLength(4);
-  expect(accounts.get("deployer")).toBe(deployerAddr);
-  expect(accounts.get("wallet_1")).toBe(address1);
-});
+    expect(accounts).toHaveLength(4);
+    expect(accounts.get("deployer")).toBe(deployerAddr);
+    expect(accounts.get("wallet_1")).toBe(address1);
+  });
 
-it("expose assets maps", async () => {
-  const assets = simnet.getAssetsMap();
-  expect(assets.get("STX")).toHaveLength(4);
-  expect(assets.get("STX")?.get(address1)).toBe(100000000000000n);
-});
+  it("expose assets maps", async () => {
+    const assets = simnet.getAssetsMap();
+    expect(assets.get("STX")).toHaveLength(4);
+    expect(assets.get("STX")?.get(address1)).toBe(100000000000000n);
+  });
 
-it("can get and set epoch", async () => {
-  // should be 2.4 by default
-  expect(simnet.currentEpoch).toBe("2.4");
+  it("can get and set epoch", async () => {
+    // should be 2.4 by default
+    expect(simnet.currentEpoch).toBe("2.4");
 
-  simnet.setEpoch("2.0");
-  expect(simnet.currentEpoch).toBe("2.0");
+    simnet.setEpoch("2.0");
+    expect(simnet.currentEpoch).toBe("2.0");
 
-  // @ts-ignore
-  // "0" is an invalid epoch
-  // it logs that 0 is invalid and defaults to 2.4
-  simnet.setEpoch("0");
-  expect(simnet.currentEpoch).toBe("2.4");
+    // @ts-ignore
+    // "0" is an invalid epoch
+    // it logs that 0 is invalid and defaults to 2.4
+    simnet.setEpoch("0");
+    expect(simnet.currentEpoch).toBe("2.4");
+  });
 });
 
 describe("simnet can run arbitrary snippets", async () => {

--- a/components/clarinet-sdk/tests/index.test.ts
+++ b/components/clarinet-sdk/tests/index.test.ts
@@ -20,40 +20,53 @@ describe("basic simnet interactions", async () => {
   it("initialize simnet", async () => {
     expect(simnet.blockHeight).toBe(1);
   });
+});
 
-  it("can mine empty blocks", async () => {
-    simnet.mineEmptyBlock();
-    expect(simnet.blockHeight).toBe(2);
-    simnet.mineEmptyBlocks(4);
-    expect(simnet.blockHeight).toBe(6);
+it("can mine empty blocks", async () => {
+  simnet.mineEmptyBlock();
+  expect(simnet.blockHeight).toBe(2);
+  simnet.mineEmptyBlocks(4);
+  expect(simnet.blockHeight).toBe(6);
+});
+
+it("exposes devnet stacks accounts", async () => {
+  const accounts = simnet.getAccounts();
+
+  expect(accounts).toHaveLength(4);
+  expect(accounts.get("deployer")).toBe(deployerAddr);
+  expect(accounts.get("wallet_1")).toBe(address1);
+});
+
+it("expose assets maps", async () => {
+  const assets = simnet.getAssetsMap();
+  expect(assets.get("STX")).toHaveLength(4);
+  expect(assets.get("STX")?.get(address1)).toBe(100000000000000n);
+});
+
+it("can get and set epoch", async () => {
+  // should be 2.4 by default
+  expect(simnet.currentEpoch).toBe("2.4");
+
+  simnet.setEpoch("2.0");
+  expect(simnet.currentEpoch).toBe("2.0");
+
+  // @ts-ignore
+  // "0" is an invalid epoch
+  // it logs that 0 is invalid and defaults to 2.4
+  simnet.setEpoch("0");
+  expect(simnet.currentEpoch).toBe("2.4");
+});
+
+describe("simnet can run arbitrary snippets", async () => {
+  it("can run simple snippets", () => {
+    const res = simnet.runSnippet("(+ 1 2)");
+    expect(res).toStrictEqual(Cl.int(3));
   });
 
-  it("exposes devnet stacks accounts", async () => {
-    const accounts = simnet.getAccounts();
-
-    expect(accounts).toHaveLength(4);
-    expect(accounts.get("deployer")).toBe(deployerAddr);
-    expect(accounts.get("wallet_1")).toBe(address1);
-  });
-
-  it("expose assets maps", async () => {
-    const assets = simnet.getAssetsMap();
-    expect(assets.get("STX")).toHaveLength(4);
-    expect(assets.get("STX")?.get(address1)).toBe(100000000000000n);
-  });
-
-  it("can get and set epoch", async () => {
-    // should be 2.4 by default
-    expect(simnet.currentEpoch).toBe("2.4");
-
-    simnet.setEpoch("2.0");
-    expect(simnet.currentEpoch).toBe("2.0");
-
-    // @ts-ignore
-    // "0" is an invalid epoch
-    // it logs that 0 is invalid and defaults to 2.4
-    simnet.setEpoch("0");
-    expect(simnet.currentEpoch).toBe("2.4");
+  it("show diagnostic in case of error", () => {
+    const res = simnet.runSnippet("(+ 1 u2)");
+    console.log("res", res);
+    expect(res).toBe("error:\nexpecting expression of type 'int', found 'uint'");
   });
 });
 

--- a/components/clarity-repl/Cargo.toml
+++ b/components/clarity-repl/Cargo.toml
@@ -57,7 +57,7 @@ reqwest = { version = "0.11", default-features = false, features = [
     "json",
     "rustls-tls",
 ] }
-wsts = { path= "../../../wsts", optional = true }
+wsts = { version = "7.0.0", optional = true }
 
 # WASM
 wasm-bindgen = { version = "0.2", optional = true }

--- a/components/clarity-repl/Cargo.toml
+++ b/components/clarity-repl/Cargo.toml
@@ -32,11 +32,11 @@ serde_derive = "1.0"
 integer-sqrt = "0.1.3"
 getrandom = { version = "0.2.3", features = ["js"] }
 atty = "0.2.14"
-wsts = "5.0.0"
 # clarity-vm = "2"
 clarity = { version = "2", default-features = false, optional = true, git = "https://github.com/stacks-network/stacks-core.git", branch = "feat/clarity-wasm-next", package = "clarity" }
-# clarity = { version = "2", default-features = false, optional = true, path ="../../../clarity-wasm/stacks-blockchain/clarity" }
+# clarity = { version = "2", default-features = false, optional = true, path ="../../../clarity-wasm/stacks-core/clarity" }
 clar2wasm = { git = "https://github.com/stacks-network/clarity-wasm.git", optional = true }
+# clar2wasm = { path="../../../clarity-wasm/clar2wasm", optional = true }
 
 # DAP Debugger
 tokio = { version = "1.35.1", features = ["full"], optional = true }
@@ -57,6 +57,7 @@ reqwest = { version = "0.11", default-features = false, features = [
     "json",
     "rustls-tls",
 ] }
+wsts = { path= "../../../wsts", optional = true }
 
 # WASM
 wasm-bindgen = { version = "0.2", optional = true }
@@ -85,6 +86,7 @@ cli = [
     "clarity/log",
     "hiro_system_kit/tokio_helpers",
     "clar2wasm",
+    "wsts"
 ]
 sdk = [
     "clarity/canonical",

--- a/components/clarity-repl/src/lib.rs
+++ b/components/clarity-repl/src/lib.rs
@@ -15,6 +15,7 @@ extern crate hiro_system_kit;
 mod macros;
 
 pub mod analysis;
+#[cfg(feature = "cli")]
 pub mod codec;
 pub mod repl;
 pub mod utils;

--- a/components/clarity-repl/src/repl/session.rs
+++ b/components/clarity-repl/src/repl/session.rs
@@ -186,6 +186,7 @@ impl Session {
         }
     }
 
+    #[cfg(feature = "cli")]
     pub fn handle_command(
         &mut self,
         command: &str,
@@ -1036,9 +1037,9 @@ impl Session {
     #[cfg(not(feature = "cli"))]
     fn run_snippet(&mut self, output: &mut Vec<String>, cost_track: bool, cmd: &str) {
         let (mut result, cost) =
-            match self.formatted_interpretation(cmd.to_string(), None, cost_track, None, None) {
+            match self.formatted_interpretation(cmd.to_string(), None, cost_track, None) {
                 Ok((output, result)) => (output, result.cost.clone()),
-                Err(output) => (output, None),
+                Err((output, _)) => (output, None),
             };
 
         if let Some(cost) = cost {


### PR DESCRIPTION
### Description

- Update clar2wasm and clarity to get the wasm compiliation fixes
- Make wsts optional
- Don't use std::time in wasm
- Some code was lost during a previous (get_block_time)