### PR TITLE
fix: clarity repl build (sdk)

### DIFF
--- a/components/clarity-repl/Cargo.toml
+++ b/components/clarity-repl/Cargo.toml
@@ -93,6 +93,7 @@ sdk = [
     "clarity/developer-mode",
     "clarity/log",
     "hiro_system_kit/tokio_helpers",
+    "wsts"
 ]
 dap = [
     "tokio",

--- a/components/clarity-repl/src/lib.rs
+++ b/components/clarity-repl/src/lib.rs
@@ -15,7 +15,7 @@ extern crate hiro_system_kit;
 mod macros;
 
 pub mod analysis;
-#[cfg(feature = "cli")]
+#[cfg(not(feature = "wasm"))]
 pub mod codec;
 pub mod repl;
 pub mod utils;


### PR DESCRIPTION
### Description

Fix regression
The stacks-rpc-client build was broken, because it requires the repl with no-default-features and the feature `sdk`
https://github.com/hirosystems/clarinet/blob/develop/components/stacks-rpc-client/Cargo.toml#L23-L25

I broke it in #1295 by making wsts optional for "wasm" and forgot to include it in "sdk"

Also need to create an issue check the stacks-rpc-client build status in CI


