### PR TITLE
fix: wasm build

### DIFF
--- a/components/clarity-repl/Cargo.toml
+++ b/components/clarity-repl/Cargo.toml
@@ -57,7 +57,7 @@ reqwest = { version = "0.11", default-features = false, features = [
     "json",
     "rustls-tls",
 ] }
-wsts = { version = "7.0.0", default-features = false }
+wsts = { version = "7.0.0", default-features = false, optional = true }
 
 # WASM
 wasm-bindgen = { version = "0.2", optional = true }
@@ -86,12 +86,14 @@ cli = [
     "clarity/log",
     "hiro_system_kit/tokio_helpers",
     "clar2wasm",
+    "wsts"
 ]
 sdk = [
     "clarity/canonical",
     "clarity/developer-mode",
     "clarity/log",
     "hiro_system_kit/tokio_helpers",
+    "wsts"
 ]
 dap = [
     "tokio",


### PR DESCRIPTION
### Description

By [fixing stacks-devnet-js build](https://github.com/hirosystems/clarinet/commit/5b3fdb8a9e686d060ff1da71c5f4ae879f001f39#diff-9afcfd70da92c34f20b65f2c5bd9920d157a54178212aea763c971afe651f78bR60) yesterday, I un-fixed the clarinet-sdk build [fix I made 2 days ago](https://github.com/hirosystems/clarinet/commit/8d8ea7fd2bc3b7d2132431ec01eac751978aa795#diff-9afcfd70da92c34f20b65f2c5bd9920d157a54178212aea763c971afe651f78bR60)

wsts needs to be optional = true AND default-feature = false