### PR TITLE
feat: improve clarity wasm deployment comparison

### DIFF
--- a/components/clarinet-cli/src/frontend/cli.rs
+++ b/components/clarinet-cli/src/frontend/cli.rs
@@ -1429,20 +1429,28 @@ fn compare_wasm_artifacts(
     artifacts: &DeploymentGenerationArtifacts,
     wasm_artifacts: &DeploymentGenerationArtifacts,
 ) {
-    if artifacts.success != wasm_artifacts.success {
-        for contract in deployment.contracts.keys() {
-            let empty_diag = vec![];
-            let diag = artifacts.diags.get(contract).unwrap_or(empty_diag.as_ref());
-            let diag_wasm = wasm_artifacts
-                .diags
-                .get(contract)
-                .unwrap_or(empty_diag.as_ref());
-
-            if diag.len() != diag_wasm.len() {
-                dbg!(&diag);
-                dbg!(&diag_wasm);
-            }
+    let mut print_warning = false;
+    for contract in deployment.contracts.keys() {
+        let diags = artifacts.diags.get(contract);
+        let wasm_diags = wasm_artifacts.diags.get(contract);
+        if diags != wasm_diags {
+            print_warning = true;
+            println!("Diagnostics of contract {contract} differs between clarity and clarity-wasm");
+            dbg!(diags);
+            dbg!(wasm_diags);
         }
+        let value = artifacts.results_values.get(contract);
+        let wasm_value = wasm_artifacts.results_values.get(contract);
+        if (diags.is_some() && wasm_diags.is_some()) && (value != wasm_value) {
+            print_warning = true;
+            println!(
+                "Evaluation value of contract {contract} differs between clarity and clarity-wasm"
+            );
+            dbg!(value);
+            dbg!(wasm_value);
+        };
+    }
+    if print_warning {
         print_clarity_wasm_warning();
     }
 }

--- a/components/clarinet-deployments/src/lib.rs
+++ b/components/clarinet-deployments/src/lib.rs
@@ -54,6 +54,7 @@ pub fn setup_session_with_deployment(
 
     let deps = BTreeMap::new();
     let mut diags = HashMap::new();
+    let mut results_values = HashMap::new();
     let mut asts = BTreeMap::new();
     let mut contracts_analysis = HashMap::new();
     let mut success = true;
@@ -62,6 +63,7 @@ pub fn setup_session_with_deployment(
             Ok(execution_result) => {
                 diags.insert(contract_id.clone(), execution_result.diagnostics);
                 if let EvaluationResult::Contract(contract_result) = execution_result.result {
+                    results_values.insert(contract_id.clone(), contract_result.result);
                     asts.insert(contract_id.clone(), contract_result.contract.ast);
                     contracts_analysis.insert(contract_id, contract_result.contract.analysis);
                 }
@@ -77,6 +79,7 @@ pub fn setup_session_with_deployment(
         asts,
         deps,
         diags,
+        results_values,
         success,
         session,
         analysis: contracts_analysis,
@@ -787,6 +790,7 @@ pub async fn generate_default_deployment(
         deps: dependencies,
         diags: contract_diags,
         success: asts_success,
+        results_values: HashMap::new(),
         analysis: HashMap::new(),
         session,
     };

--- a/components/clarinet-deployments/src/types.rs
+++ b/components/clarinet-deployments/src/types.rs
@@ -9,7 +9,7 @@ use clarity_repl::clarity::vm::types::{
 };
 
 use clarity_repl::analysis::ast_dependency_detector::DependencySet;
-use clarity_repl::clarity::{ClarityName, ClarityVersion, ContractName, StacksEpochId};
+use clarity_repl::clarity::{ClarityName, ClarityVersion, ContractName, StacksEpochId, Value};
 use clarity_repl::repl::{Session, DEFAULT_CLARITY_VERSION};
 use serde::{Deserialize, Serialize};
 use serde_yaml;
@@ -73,6 +73,7 @@ pub struct DeploymentGenerationArtifacts {
     pub deps: BTreeMap<QualifiedContractIdentifier, DependencySet>,
     pub diags: HashMap<QualifiedContractIdentifier, Vec<Diagnostic>>,
     pub analysis: HashMap<QualifiedContractIdentifier, ContractAnalysis>,
+    pub results_values: HashMap<QualifiedContractIdentifier, Option<Value>>,
     pub session: Session,
     pub success: bool,
 }


### PR DESCRIPTION
### Description

In clarinet console, we are already doing a complete comparison of the interpreter vs wasm results and diags ([see code](https://github.com/hirosystems/clarinet/blob/abc3458515f890aeee51cfb376e00eadd76dda7c/components/clarity-repl/src/frontend/terminal.rs#L135-L178).
But it wasn't the case for contract deployments (in clarinet check or clarinet console).
This PR fixes it.

It also improves the handling of project with multiple contracts.

### Test

The contract will result in a compile error in clarity wasm:
```clar
(define-map mp {x: uint} {y: (list 20 (response (buff 21) int)) })

(map-insert mp
  {x: u306845443603200851488318099 }
  {y: (list
    (ok 0xac50891b72b93b496d25caedc508e9f65b98727ee6)
    (ok 0x53f588bdbb3495aee902cdaa863d31e2dc42b8215d)
    (ok 0xccc90ca2258d144e11cd32c453599bd36d039120e6)
    (ok 0x032ee22a2028f05e537ebab0eae0fa2b8fc4ba8d1d)
  )}
)
```

This contract will return a different value between the interpreter (returning 7) and clarity-wasm (returning none)
```clar
(+ 3 4)

(define-private (foo) 42)
```

Load these two contracts in the same project to see how it handle errors in multiple contracts
It'll
```> clarinet check                      
✔ 2 contracts checked

> clarinet check --enable-clarity-wasm
Diagnostics of contract ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.test differs between clarity and clarity-wasm
[components/clarinet-cli/src/frontend/cli.rs:1439] diags = Some(
    [],
)
[components/clarinet-cli/src/frontend/cli.rs:1440] wasm_diags = Some(
    [
        Diagnostic {
            level: Error,
            message: "Wasm Runtime Error: Runtime error while interpreting ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.test: Wasm(Runtime(error while executing at wasm backtrace:\n    0: 0x17c5 - <unknown>!<wasm function 60>\n\nCaused by:\n    Wasm(InvalidIndicator(21))))",
            spans: [],
            suggestion: None,
        },
    ],
)
Evaluation value of contract ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.vault differs between clarity and clarity-wasm
[components/clarinet-cli/src/frontend/cli.rs:1449] value = Some(
    Some(
        Int(
            7,
        ),
    ),
)
[components/clarinet-cli/src/frontend/cli.rs:1450] wasm_value = Some(
    None,
)
It appears that Clarity-Wasm is returning an unexpected result.
Please help improve the Stacks network by reporting this issue at https://github.com/stacks-network/clarity-wasm/issues/new/choose and include the errors above along with the source code that triggered this.

✔ 2 contracts checked
```