### PR TITLE
Refactor/fix tuple items sorting in tests

### DIFF
--- a/components/clarinet-sdk/package-lock.json
+++ b/components/clarinet-sdk/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@hirosystems/clarinet-sdk",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hirosystems/clarinet-sdk",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "GPL-3.0",
       "dependencies": {
         "@hirosystems/clarinet-sdk-wasm": "^2.2.0",
-        "@stacks/transactions": "^6.9.0",
+        "@stacks/transactions": "^6.12.0",
         "kolorist": "^1.8.0",
         "prompts": "^2.4.2",
         "vitest": "^1.0.4",
@@ -692,9 +692,9 @@
       }
     },
     "node_modules/@stacks/transactions": {
-      "version": "6.11.3",
-      "resolved": "https://registry.npmjs.org/@stacks/transactions/-/transactions-6.11.3.tgz",
-      "integrity": "sha512-Zb7ONYt8OJPTTdXQHobWqZ2mwTALpGt43PEsy2FpDgQzOodGk1lWDo1Jhzs3hhw/2ib5FE3iDMc6jptKe9miCg==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@stacks/transactions/-/transactions-6.12.0.tgz",
+      "integrity": "sha512-gRP3SfTaAIoTdjMvOiLrMZb/senqB8JQlT5Y4C3/CiHhiprYwTx7TbOCSa7WsNOU99H4aNfHvatmymuggXQVkA==",
       "dependencies": {
         "@noble/hashes": "1.1.5",
         "@noble/secp256k1": "1.7.1",

--- a/components/clarinet-sdk/package.json
+++ b/components/clarinet-sdk/package.json
@@ -59,7 +59,7 @@
   "readme": "./README.md",
   "dependencies": {
     "@hirosystems/clarinet-sdk-wasm": "^2.2.0",
-    "@stacks/transactions": "^6.9.0",
+    "@stacks/transactions": "^6.12.0",
     "kolorist": "^1.8.0",
     "prompts": "^2.4.2",
     "vitest": "^1.0.4",

--- a/components/clarinet-sdk/vitest-helpers/src/clarityValuesMatchers.ts
+++ b/components/clarinet-sdk/vitest-helpers/src/clarityValuesMatchers.ts
@@ -351,28 +351,14 @@ expect.extend({
       return errorToAssertionResult.call(this, e);
     }
 
-    // to properly display the diff, the keys of actual and expected tuples must be sorted
-    const orderedActual = Cl.tuple(
-      Object.fromEntries(Object.entries(actual.data).toSorted((a, b) => a[0].localeCompare(b[0]))),
-    );
-
     const isTupleData = checkIsTupleData(expectedData);
-    const expected = isTupleData
-      ? Cl.prettyPrint(
-          Cl.tuple(
-            Object.fromEntries(
-              Object.entries(expectedData).toSorted((a, b) => a[0].localeCompare(b[0])),
-            ),
-          ),
-          2,
-        )
-      : expectedData;
+    const expected = isTupleData ? Cl.prettyPrint(Cl.tuple(expectedData), 2) : expectedData;
 
     return {
       pass: this.equals(actual.data, expectedData, undefined, true),
       // note: throw a simple message and rely on `actual` and `expected` to display the diff
       message: () => `the received Tuple does ${this.isNot ? "" : "not "}match the expected one`,
-      actual: Cl.prettyPrint(orderedActual, 2),
+      actual: Cl.prettyPrint(actual, 2),
       expected,
     };
   },

--- a/components/clarinet-sdk/vitest-helpers/tests/clarityValueMatchers.test.ts
+++ b/components/clarinet-sdk/vitest-helpers/tests/clarityValueMatchers.test.ts
@@ -343,6 +343,38 @@ describe("tests tuple", () => {
       expect(e.expected).toBe("{\n  a: 2,\n  b: 1,\n  c: 1\n}");
     }
   });
+
+  it("properly orders tuple keys even in nested types", () => {
+    // keys in non-alphabetical order
+    const value = Cl.some(
+      Cl.tuple({
+        b: Cl.int(1),
+        a: Cl.int(1),
+        c: Cl.int(1),
+      }),
+    );
+
+    try {
+      const failingTest = () =>
+        // keys in non-alphabetical order
+        expect(value).toBeSome(
+          Cl.tuple({
+            c: Cl.int(1),
+            b: Cl.int(1),
+            // different value here
+            a: Cl.int(2),
+          }),
+        );
+      expect(failingTest).toThrow();
+      failingTest();
+    } catch (e: any) {
+      expect(e.message).toStrictEqual(
+        "expected (some { a: 1, b: 1, c: 1 }) to be (some { a: 2, b: 1, c: 1 })",
+      );
+      expect(e.actual).toBe("(some {\n  a: 1,\n  b: 1,\n  c: 1\n})");
+      expect(e.expected).toBe("(some {\n  a: 2,\n  b: 1,\n  c: 1\n})");
+    }
+  });
 });
 
 describe("test nested types", () => {


### PR DESCRIPTION
## Description

The clarinet-sdk wasn't properly handling tuples property sorting, leading to complex diff reading in failing tests. (It was only sorting top level tuple properties)
Stacks.js now handles tuples property sorting in pretty print so that Clarinet doesn't have (and it handle nested values out of the box)


Fix #1354 