### PR TITLE
Add test with contracts in parent path

### DIFF
--- a/components/clarinet-sdk/tests/fixtures/with-parent-path/Clarinet.toml
+++ b/components/clarinet-sdk/tests/fixtures/with-parent-path/Clarinet.toml
@@ -1,0 +1,16 @@
+[project]
+name = 'fixtures'
+description = 'sample project to test clarinet-sdk'
+telemetry = false
+cache_dir = './.cache'
+requirements = []
+
+[contracts.multiplier-contract]
+path = 'contracts/multiplier-contract.clar'
+clarity_version = 2
+epoch = 2.4
+
+[contracts.counter]
+path = '../contracts/counter.clar'
+clarity_version = 2
+epoch = 2.4

--- a/components/clarinet-sdk/tests/fixtures/with-parent-path/contracts/multiplier-contract.clar
+++ b/components/clarinet-sdk/tests/fixtures/with-parent-path/contracts/multiplier-contract.clar
@@ -1,0 +1,5 @@
+(impl-trait .multiplier-trait.multiplier)
+
+(define-read-only (multiply (a uint) (b uint))
+  (ok (* a b))
+)

--- a/components/clarinet-sdk/tests/fixtures/with-parent-path/settings/Devnet.toml
+++ b/components/clarinet-sdk/tests/fixtures/with-parent-path/settings/Devnet.toml
@@ -1,0 +1,58 @@
+[network]
+name = "devnet"
+deployment_fee_rate = 10
+
+[accounts.deployer]
+mnemonic = "twice kind fence tip hidden tilt action fragile skin nothing glory cousin green tomorrow spring wrist shed math olympic multiply hip blue scout claw"
+balance = 100_000_000_000_000
+# secret_key: 753b7cc01a1a2e86221266a154af739463fce51219d97e4f856cd7200c3bd2a601
+# stx_address: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+# btc_address: mqVnk6NPRdhntvfm4hh9vvjiRkFDUuSYsH
+
+[accounts.wallet_1]
+mnemonic = "sell invite acquire kitten bamboo drastic jelly vivid peace spawn twice guilt pave pen trash pretty park cube fragile unaware remain midnight betray rebuild"
+balance = 100_000_000_000_000
+# secret_key: 7287ba251d44a4d3fd9276c88ce34c5c52a038955511cccaf77e61068649c17801
+# stx_address: ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5
+# btc_address: mr1iPkD9N3RJZZxXRk7xF9d36gffa6exNC
+
+[accounts.wallet_2]
+mnemonic = "hold excess usual excess ring elephant install account glad dry fragile donkey gaze humble truck breeze nation gasp vacuum limb head keep delay hospital"
+balance = 100_000_000_000_000
+# secret_key: 530d9f61984c888536871c6573073bdfc0058896dc1adfe9a6a10dfacadc209101
+# stx_address: ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG
+# btc_address: muYdXKmX9bByAueDe6KFfHd5Ff1gdN9ErG
+
+[accounts.faucet]
+mnemonic = "shadow private easily thought say logic fault paddle word top book during ignore notable orange flight clock image wealth health outside kitten belt reform"
+balance = 100_000_000_000_000
+# secret_key: de433bdfa14ec43aa1098d5be594c8ffb20a31485ff9de2923b2689471c401b801
+# stx_address: STNHKEPYEPJ8ET55ZZ0M5A34J0R3N5FM2CMMMAZ6
+# btc_address: mjSrB3wS4xab3kYqFktwBzfTdPg367ZJ2d
+
+[devnet]
+disable_stacks_explorer = false
+disable_stacks_api = false
+
+# For testing in epoch 2.1 / using Clarity2
+# epoch_2_0 = 100
+# epoch_2_05 = 100
+# epoch_2_1 = 101
+# epoch_2_2 = 102
+# epoch_2_3 = 103
+# epoch_2_4 = 104
+
+# Send some stacking orders
+[[devnet.pox_stacking_orders]]
+start_at_cycle = 3
+duration = 12
+wallet = "wallet_1"
+slots = 2
+btc_address = "mr1iPkD9N3RJZZxXRk7xF9d36gffa6exNC"
+
+[[devnet.pox_stacking_orders]]
+start_at_cycle = 3
+duration = 12
+wallet = "wallet_2"
+slots = 1
+btc_address = "muYdXKmX9bByAueDe6KFfHd5Ff1gdN9ErG"

--- a/components/clarinet-sdk/tests/index.test.ts
+++ b/components/clarinet-sdk/tests/index.test.ts
@@ -306,3 +306,17 @@ describe("the sdk handles multiple manifests project", () => {
     }).rejects.toThrow(expectedErr);
   });
 });
+
+describe("simnet can get session reports across different paths", async () => {
+  it("can report", async () => {
+    await initSimnet("tests/fixtures/with-parent-path/Clarinet.toml");
+
+    simnet.callPublicFn("counter", "increment", [], address1);
+    simnet.callPublicFn("counter", "increment", [], address1);
+
+    const reports = simnet.collectReport();
+    console.log({ reports });
+    expect(reports.coverage.startsWith("TN:")).toBe(true);
+    expect(reports.coverage.endsWith("end_of_record\n")).toBe(true);
+  }, 50000);
+});


### PR DESCRIPTION
### Description

stacks-core uses a setup for Clarinet where the contract code lives in a parent folder of Clarinet.toml. The resulting coverage reports generate unreadable html due to missing css files living in the coverage folder not reachable from the source code folder.

This PR adds a test for this setup.

### Checklist

- [ ] Tests added in this PR (if applicable)

