### PR TITLE
chore: update clarinet project template

### DIFF
--- a/components/clarinet-sdk/templates/package.json
+++ b/components/clarinet-sdk/templates/package.json
@@ -12,12 +12,12 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@hirosystems/clarinet-sdk": "^1.0.0",
-    "@stacks/transactions": "^6.9.0",
+    "@hirosystems/clarinet-sdk": "^2.3.0",
+    "@stacks/transactions": "^6.12.0",
     "chokidar-cli": "^3.0.0",
-    "typescript": "^5.2.2",
-    "vite": "^5.0.6",
-    "vitest": "^1.0.1",
-    "vitest-environment-clarinet": "^1.1.0"
+    "typescript": "^5.3.3",
+    "vite": "^5.1.4",
+    "vitest": "^1.3.1",
+    "vitest-environment-clarinet": "^2.0.0"
   }
 }

--- a/components/clarinet-sdk/templates/vitest.config.js
+++ b/components/clarinet-sdk/templates/vitest.config.js
@@ -21,7 +21,12 @@ import { vitestSetupFilePath, getClarinetVitestsArgv } from "@hirosystems/clarin
 export default defineConfig({
   test: {
     environment: "clarinet", // use vitest-environment-clarinet
-    singleThread: true,
+    pool: "forks",
+    poolOptions: {
+      threads: {
+        singleThread: true,
+      },
+    },
     setupFiles: [
       vitestSetupFilePath,
       // custom setup files can be added here


### PR DESCRIPTION
### Description

Update the package.json and vitest.config 

- clarinet-sdk and vitest-environment-clarinet versions to be released
- the vitest `pool: "forks"` option seems to be more stable (and I didn't notice significant decrease of performances). The previous version doesn't apparently lead to issues very often, but could do. According to the [documentation,](https://vitest.dev/guide/common-errors.html#failed-to-terminate-worker), it could be do to the fact the `clarinet_sdk_bg.wasm` file is fetched with node `fetch` 
---

### Checklist

- [ ] Tests added in this PR (if applicable)

