### PR TITLE
fix: set relative path in simnet deployment plan

### DIFF
--- a/components/clarinet-deployments/src/types.rs
+++ b/components/clarinet-deployments/src/types.rs
@@ -1025,11 +1025,14 @@ impl DeploymentSpecification {
                                     TransactionSpecification::EmulatedContractCall(EmulatedContractCallSpecification::from_specifications(spec)?)
                                 }
                                 TransactionSpecificationFile::EmulatedContractPublish(spec) => {
-                                    let source = contracts_sources.as_ref().map(|contracts_sources|
+                                    let source = contracts_sources.as_ref().map(|contracts_sources| {
+                                        let contract_path = FileLocation::try_parse(spec.path.as_ref().expect("missing path"), Some(project_root_location))
+                                            .expect("failed to get contract path").to_string();
                                         contracts_sources
-                                            .get(spec.path.as_ref().expect("missing path"))
+                                            .get(&contract_path)
                                             .cloned()
-                                            .expect("missing contract source")
+                                            .unwrap_or_else(|| panic!("missing contract source for {}", spec.path.clone().unwrap_or_default()))
+                                    }
                                     );
 
                                     let spec = EmulatedContractPublishSpecification::from_specifications(spec, project_root_location, source)?;

--- a/components/clarinet-sdk-wasm/src/core.rs
+++ b/components/clarinet-sdk-wasm/src/core.rs
@@ -1,7 +1,8 @@
 use clarinet_deployments::diagnostic_digest::DiagnosticsDigest;
 use clarinet_deployments::types::{
     DeploymentGenerationArtifacts, DeploymentSpecification, DeploymentSpecificationFile,
-    TransactionSpecificationFile,
+    EmulatedContractPublishSpecification, EmulatedContractPublishSpecificationFile,
+    TransactionSpecification, TransactionSpecificationFile,
 };
 use clarinet_deployments::{
     generate_default_deployment, initiate_session_from_deployment, setup_session_with_deployment,
@@ -334,8 +335,15 @@ impl SDK {
                                     .iter()
                                     .filter_map(|t| match t {
                                         TransactionSpecificationFile::EmulatedContractPublish(
-                                            ref deploy,
-                                        ) => deploy.path.clone(),
+                                            EmulatedContractPublishSpecificationFile {
+                                                path: Some(ref path),
+                                                ..
+                                            },
+                                        ) => {
+                                            let contract_path =
+                                                FileLocation::try_parse(path, Some(&project_root));
+                                            contract_path.map(|p| p.to_string())
+                                        }
                                         _ => None,
                                     })
                                     .collect::<Vec<String>>()
@@ -347,7 +355,6 @@ impl SDK {
                     };
 
                     let contracts_sources = self.file_accessor.read_files(contracts_paths).await?;
-
                     let existing_deployment = DeploymentSpecification::from_specifications(
                         &spec_file,
                         &StacksNetwork::Simnet,
@@ -384,7 +391,31 @@ impl SDK {
                     let cache = (default_deployment.clone(), default_artifacts.clone());
                     self.cache.insert(manifest_location, cache.clone());
 
-                    let deployment_file = default_deployment.to_file_content()?;
+                    // we must manually update the location of the contracts in the deployment plan to be relative to the project root
+                    // because the serialize function is not able to get project_root location in wasm, so it falls back to the full path
+                    // https://github.com/hirosystems/clarinet/blob/7a41c0c312148b3a5f0eee28a95bebf2766d2e8d/components/clarinet-files/src/lib.rs#L379
+                    let mut deployment_plan_with_relative_paths = default_deployment.clone();
+                    deployment_plan_with_relative_paths
+                        .plan
+                        .batches
+                        .iter_mut()
+                        .for_each(|batch| {
+                            batch.transactions.iter_mut().for_each(|tx| {
+                                if let TransactionSpecification::EmulatedContractPublish(
+                                    EmulatedContractPublishSpecification { location, .. },
+                                ) = tx
+                                {
+                                    *location = FileLocation::from_path_string(
+                                        &location
+                                            .get_relative_path_from_base(&project_root)
+                                            .unwrap(),
+                                    )
+                                    .unwrap();
+                                }
+                            });
+                        });
+
+                    let deployment_file = deployment_plan_with_relative_paths.to_file_content()?;
                     self.file_accessor
                         .write_file(deployment_plan_location.to_string(), &deployment_file)
                         .await?;

--- a/components/clarinet-sdk/package-lock.json
+++ b/components/clarinet-sdk/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@hirosystems/clarinet-sdk",
-  "version": "2.3.0-rc2",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hirosystems/clarinet-sdk",
-      "version": "2.3.0-rc2",
+      "version": "2.3.0",
       "license": "GPL-3.0",
       "dependencies": {
-        "@hirosystems/clarinet-sdk-wasm": "^2.3.0-rc3",
+        "@hirosystems/clarinet-sdk-wasm": "^2.3.0",
         "@stacks/transactions": "^6.12.0",
         "kolorist": "^1.8.0",
         "prompts": "^2.4.2",
@@ -378,9 +378,9 @@
       }
     },
     "node_modules/@hirosystems/clarinet-sdk-wasm": {
-      "version": "2.3.0-rc3",
-      "resolved": "https://registry.npmjs.org/@hirosystems/clarinet-sdk-wasm/-/clarinet-sdk-wasm-2.3.0-rc3.tgz",
-      "integrity": "sha512-HUhsdC1QlBpMfeD3ox/tXlCD8psx6v5cULhBMg1+y0W1kbOlA5lgSQW30GsDjtT30o4VYELmxCfQS4IzU5EsTQ=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@hirosystems/clarinet-sdk-wasm/-/clarinet-sdk-wasm-2.3.0.tgz",
+      "integrity": "sha512-IfpGcVrOrsWhund77d+S8ETRcMLdCyT0rBczuqTOZP8YJMG+2s58HLtXBWjTc1vC06r3ZcRFbD6qhrQvyEhsHg=="
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -411,15 +411,15 @@
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.4.tgz",
-      "integrity": "sha512-Oud2QPM5dHviZNn4y/WhhYKSXksv+1xLEIsNrAbGcFzUN3ubqWRFT5gwPchNc5NuzILOU4tPBDTZ4VwhL8Y7cw==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+      "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
       "devOptional": true,
       "peer": true,
       "dependencies": {
-        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/set-array": "^1.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
-        "@jridgewell/trace-mapping": "^0.3.9"
+        "@jridgewell/trace-mapping": "^0.3.24"
       },
       "engines": {
         "node": ">=6.0.0"
@@ -436,9 +436,9 @@
       }
     },
     "node_modules/@jridgewell/set-array": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
       "devOptional": true,
       "peer": true,
       "engines": {
@@ -462,9 +462,9 @@
       "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.23",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.23.tgz",
-      "integrity": "sha512-9/4foRoUKp8s96tSkh8DlAAc5A0Ty8vLXld+l9gjKKY6ckwI8G15f0hskGmuLZu78ZlGa1vtsfOa+lnB4vG6Jg==",
+      "version": "0.3.24",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.24.tgz",
+      "integrity": "sha512-+VaWXDa6+l6MhflBvVXjIEAzb59nQ2JUK3bwRp2zRpPtU+8TFRy9Gg/5oIcNlkEL5PGlBFGfemUVvIgLnTzq7Q==",
       "devOptional": true,
       "peer": true,
       "dependencies": {
@@ -675,9 +675,9 @@
       }
     },
     "node_modules/@stacks/common/node_modules/@types/node": {
-      "version": "18.19.20",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.20.tgz",
-      "integrity": "sha512-SKXZvI375jkpvAj8o+5U2518XQv76mAsixqfXiVyWyXZbVWQK25RurFovYpVIxVzul0rZoH58V/3SkEnm7s3qA==",
+      "version": "18.19.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.21.tgz",
+      "integrity": "sha512-2Q2NeB6BmiTFQi4DHBzncSoq/cJMLDdhPaAoJFnFCyD9a8VPZRf7a1GAwp1Edb7ROaZc5Jz/tnZyL6EsWMRaqw==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -713,9 +713,9 @@
       }
     },
     "node_modules/@types/eslint": {
-      "version": "8.56.4",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.4.tgz",
-      "integrity": "sha512-lG1GLUnL5vuRBGb3MgWUWLdGMH2Hps+pERuyQXCfWozuGKdnhf9Pbg4pkcrVUHjKrU7Rl+GCZ/299ObBXZFAxg==",
+      "version": "8.56.5",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.5.tgz",
+      "integrity": "sha512-u5/YPJHo1tvkSF2CE0USEkxon82Z5DBy2xR+qfyYNszpX9qcs4sT6uq2kBbj4BXY1+DBGDPnrhMZV3pKWGNukw==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -747,9 +747,9 @@
       "peer": true
     },
     "node_modules/@types/node": {
-      "version": "20.11.22",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.22.tgz",
-      "integrity": "sha512-/G+IxWxma6V3E+pqK1tSl2Fo1kl41pK1yeCyDsgkF9WlVAme4j5ISYM2zR11bgLFJGLN5sVK40T4RJNuiZbEjA==",
+      "version": "20.11.24",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.24.tgz",
+      "integrity": "sha512-Kza43ewS3xoLgCEpQrsT+xRo/EJej1y0kVYGiLFE1NEODXGzTfwiC6tXTLMQskn1X4/Rjlh0MQUvx9W+L9long==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -1427,9 +1427,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.686",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.686.tgz",
-      "integrity": "sha512-3avY1B+vUzNxEgkBDpKOP8WarvUAEwpRaiCL0He5OKWEFxzaOFiq4WoZEZe7qh0ReS7DiWoHMnYoQCKxNZNzSg==",
+      "version": "1.4.689",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.689.tgz",
+      "integrity": "sha512-GatzRKnGPS1go29ep25reM94xxd1Wj8ritU0yRhCJ/tr1Bg8gKnm6R9O/yPOhGQBoLMZ9ezfrpghNaTw97C/PQ==",
       "dev": true,
       "peer": true
     },

--- a/components/clarinet-sdk/package.json
+++ b/components/clarinet-sdk/package.json
@@ -58,7 +58,7 @@
   "license": "GPL-3.0",
   "readme": "./README.md",
   "dependencies": {
-    "@hirosystems/clarinet-sdk-wasm": "^2.3.0-rc3",
+    "@hirosystems/clarinet-sdk-wasm": "^2.3.0",
     "@stacks/transactions": "^6.12.0",
     "kolorist": "^1.8.0",
     "prompts": "^2.4.2",

--- a/components/clarinet-sdk/tests/fixtures/deployments/custom.simnet-plan.yaml
+++ b/components/clarinet-sdk/tests/fixtures/deployments/custom.simnet-plan.yaml
@@ -34,17 +34,17 @@ plan:
         - emulated-contract-publish:
             contract-name: multiplier-trait
             emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
-            path: /Users/hugo/Sites/hiro/clarinet/components/clarinet-sdk/tests/fixtures/contracts/multiplier-trait.clar
+            path: contracts/multiplier-trait.clar
             clarity-version: 2
         - emulated-contract-publish:
             contract-name: counter
             emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
-            path: /Users/hugo/Sites/hiro/clarinet/components/clarinet-sdk/tests/fixtures/contracts/counter.clar
+            path: contracts/counter.clar
             clarity-version: 2
         - emulated-contract-publish:
             contract-name: multiplier-contract
             emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
-            path: /Users/hugo/Sites/hiro/clarinet/components/clarinet-sdk/tests/fixtures/contracts/multiplier-contract.clar
+            path: contracts/multiplier-contract.clar
             clarity-version: 2
       epoch: "2.4"
     - id: 1


### PR DESCRIPTION
### Description

Hot fix for clarinet-sdk@2.3.0
We get extra-complications in the wasm context because FileLocation relies on `std::Path::exists` which is not available in this context.
So we can't call `FileLocation::get_project_root_location`

It results in this complicated patch. I'm sure we could figured out something better but it would require larger changes on the whole code base. But I'd like to release this hotfix today
