### PR TITLE
chore: prepare 2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# [2.3.1](https://github.com/hirosystems/clarinet/compare/v2.3.0...v2.3.1) (2024-03-04)
+
+##### Bug Fixes
+
+*  Set relative path in simnet deployment plan and fix Vitest templates (#1370) (80abad3c)
+
 # [2.3.0](https://github.com/hirosystems/clarinet/compare/v2.2.1...v2.3.0) (2024-03-01)
 
 ##### Chores

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -794,7 +794,7 @@ dependencies = [
 
 [[package]]
 name = "clarinet-cli"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "ansi_term",
  "atty",
@@ -807,7 +807,7 @@ dependencies = [
  "clarinet-files",
  "clarinet-utils",
  "clarity-lsp",
- "clarity-repl 2.3.0",
+ "clarity-repl 2.3.1",
  "crossbeam-channel",
  "crossterm",
  "ctrlc",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "clarinet-deployments"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "base58 0.2.0",
  "base64 0.21.7",
@@ -862,7 +862,7 @@ dependencies = [
  "bitcoincore-rpc-json 0.16.0",
  "clarinet-files",
  "clarinet-utils",
- "clarity-repl 2.3.0",
+ "clarity-repl 2.3.1",
  "colored 2.1.0",
  "libsecp256k1 0.7.1",
  "reqwest",
@@ -870,19 +870,19 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_yaml",
- "stacks-rpc-client 2.3.0",
+ "stacks-rpc-client 2.3.1",
  "tiny-hderive",
 ]
 
 [[package]]
 name = "clarinet-files"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "bip39",
  "bitcoin 0.29.2",
  "chainhook-types",
  "clarinet-utils",
- "clarity-repl 2.3.0",
+ "clarity-repl 2.3.1",
  "js-sys",
  "libsecp256k1 0.7.1",
  "serde",
@@ -898,11 +898,11 @@ dependencies = [
 
 [[package]]
 name = "clarinet-sdk-wasm"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "clarinet-deployments",
  "clarinet-files",
- "clarity-repl 2.3.0",
+ "clarity-repl 2.3.1",
  "colored 2.1.0",
  "console_error_panic_hook",
  "gloo-utils",
@@ -951,7 +951,7 @@ version = "1.0.0"
 dependencies = [
  "clap",
  "clarinet-files",
- "clarity-repl 2.3.0",
+ "clarity-repl 2.3.1",
  "serde",
  "serde_derive",
  "serde_json",
@@ -963,7 +963,7 @@ name = "clarity-jupyter-kernel"
 version = "1.0.0"
 dependencies = [
  "chrono",
- "clarity-repl 2.3.0",
+ "clarity-repl 2.3.1",
  "colored 1.9.3",
  "dirs",
  "failure",
@@ -985,7 +985,7 @@ version = "1.0.0"
 dependencies = [
  "clarinet-deployments",
  "clarinet-files",
- "clarity-repl 2.3.0",
+ "clarity-repl 2.3.1",
  "console_error_panic_hook",
  "js-sys",
  "lazy_static",
@@ -1023,7 +1023,7 @@ dependencies = [
 
 [[package]]
 name = "clarity-repl"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "ansi_term",
  "atty",
@@ -4691,7 +4691,7 @@ dependencies = [
 
 [[package]]
 name = "stacks-devnet-js"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "clarinet-deployments",
  "clarinet-files",
@@ -4707,7 +4707,7 @@ dependencies = [
 
 [[package]]
 name = "stacks-network"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "ansi_term",
  "atty",
@@ -4722,7 +4722,7 @@ dependencies = [
  "clarinet-deployments",
  "clarinet-files",
  "clarinet-utils",
- "clarity-repl 2.3.0",
+ "clarity-repl 2.3.1",
  "crossbeam-channel",
  "crossterm",
  "ctrlc",
@@ -4735,7 +4735,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_yaml",
- "stacks-rpc-client 2.3.0",
+ "stacks-rpc-client 2.3.1",
  "tokio",
  "tracing",
  "tracing-appender",
@@ -4761,9 +4761,9 @@ dependencies = [
 
 [[package]]
 name = "stacks-rpc-client"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
- "clarity-repl 2.3.0",
+ "clarity-repl 2.3.1",
  "hmac 0.12.1",
  "libsecp256k1 0.7.1",
  "pbkdf2",

--- a/components/clarinet-cli/Cargo.toml
+++ b/components/clarinet-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clarinet-cli"
-version = "2.3.0"
+version = "2.3.1"
 authors = ["Ludo Galabru <ludo@hiro.so>", "Brice Dobry <brice@hiro.so>"]
 edition = "2021"
 description = "Clarinet is a simple, modern and opinionated runtime for testing, integrating and deploying Clarity smart contracts."

--- a/components/clarinet-cli/src/generate/project.rs
+++ b/components/clarinet-cli/src/generate/project.rs
@@ -491,7 +491,7 @@ btc_address = "mvZtbibDAAA3WLpY7zXXFqRa3T4XSknBX7"
   "author": "",
   "license": "ISC",
   "dependencies": {{
-    "@hirosystems/clarinet-sdk": "^2.3.0",
+    "@hirosystems/clarinet-sdk": "^2.3.2",
     "@stacks/transactions": "^6.12.0",
     "chokidar-cli": "^3.0.0",
     "typescript": "^5.3.3",

--- a/components/clarinet-deployments/Cargo.toml
+++ b/components/clarinet-deployments/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clarinet-deployments"
-version = "2.3.0"
+version = "2.3.1"
 edition = "2021"
 
 [dependencies]

--- a/components/clarinet-files/Cargo.toml
+++ b/components/clarinet-files/Cargo.toml
@@ -2,7 +2,7 @@
 name = "clarinet-files"
 description = "Clarinet manifests files helpers"
 license = "GPL-3.0"
-version = "2.3.0"
+version = "2.3.1"
 edition = "2021"
 
 [dependencies]

--- a/components/clarinet-sdk-wasm/Cargo.toml
+++ b/components/clarinet-sdk-wasm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "clarinet-sdk-wasm"
-version = "2.3.1"
+version = "2.3.2"
 license = "GPL-3.0"
 repository = "https://github.com/hirosystems/clarinet"
 description = "The core lib that powers @hirosystems/clarinet-sdk"

--- a/components/clarinet-sdk/package-lock.json
+++ b/components/clarinet-sdk/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@hirosystems/clarinet-sdk",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hirosystems/clarinet-sdk",
-      "version": "2.3.1",
+      "version": "2.3.2",
       "license": "GPL-3.0",
       "dependencies": {
-        "@hirosystems/clarinet-sdk-wasm": "^2.3.1",
+        "@hirosystems/clarinet-sdk-wasm": "^2.3.2",
         "@stacks/transactions": "^6.12.0",
         "kolorist": "^1.8.0",
         "prompts": "^2.4.2",
@@ -378,9 +378,9 @@
       }
     },
     "node_modules/@hirosystems/clarinet-sdk-wasm": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@hirosystems/clarinet-sdk-wasm/-/clarinet-sdk-wasm-2.3.1.tgz",
-      "integrity": "sha512-2x5cdnhMrYu5mJrtB0/LCkSX8gLAWFoB8juzjQVoPj+Q3oi+9586COyvqCzqJdFPf1mZhuWYgtWQvk5rm3d4XA=="
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@hirosystems/clarinet-sdk-wasm/-/clarinet-sdk-wasm-2.3.2.tgz",
+      "integrity": "sha512-Uz5RX06hRB05S6JPyS5j1F7HOPmmRArqR8c+61IUlOarPwYxum2MmLW7DnmsKWuC/m6wD8zbxUN22xRpHLFJWA=="
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",

--- a/components/clarinet-sdk/package.json
+++ b/components/clarinet-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hirosystems/clarinet-sdk",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "A SDK to interact with Clarity Smart Contracts",
   "homepage": "https://docs.hiro.so/clarinet/feature-guides/clarinet-js-sdk",
   "repository": {
@@ -58,7 +58,7 @@
   "license": "GPL-3.0",
   "readme": "./README.md",
   "dependencies": {
-    "@hirosystems/clarinet-sdk-wasm": "^2.3.1",
+    "@hirosystems/clarinet-sdk-wasm": "^2.3.2",
     "@stacks/transactions": "^6.12.0",
     "kolorist": "^1.8.0",
     "prompts": "^2.4.2",

--- a/components/clarinet-sdk/templates/package.json
+++ b/components/clarinet-sdk/templates/package.json
@@ -12,7 +12,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@hirosystems/clarinet-sdk": "^2.3.0",
+    "@hirosystems/clarinet-sdk": "^2.3.2",
     "@stacks/transactions": "^6.12.0",
     "chokidar-cli": "^3.0.0",
     "typescript": "^5.3.3",

--- a/components/clarity-repl/Cargo.toml
+++ b/components/clarity-repl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clarity-repl"
-version = "2.3.0"
+version = "2.3.1"
 description = "Clarity REPL"
 authors = [
     "Ludo Galabru <ludo@hiro.so>",

--- a/components/stacks-devnet-js/Cargo.toml
+++ b/components/stacks-devnet-js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stacks-devnet-js"
-version = "2.3.0"
+version = "2.3.1"
 license = "ISC"
 edition = "2018"
 exclude = ["index.node"]

--- a/components/stacks-devnet-js/package.json
+++ b/components/stacks-devnet-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hirosystems/stacks-devnet-js",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "stacks-devnet-js is a library for writing end to end tests for protocols interacting with the Stacks blockchain and the Bitcoin blockchain.",
   "author": "Ludo Galabru",
   "repository": "https://github.com/hirosystems/clarinet/tree/main/components/stacks-devnet-js",

--- a/components/stacks-network/Cargo.toml
+++ b/components/stacks-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stacks-network"
-version = "2.3.0"
+version = "2.3.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/components/stacks-rpc-client/Cargo.toml
+++ b/components/stacks-rpc-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stacks-rpc-client"
-version = "2.3.0"
+version = "2.3.1"
 description = "HTTP Client for the Stacks blockchain"
 license = "GPL-3.0"
 edition = "2021"


### PR DESCRIPTION
### Description

- CLI: Update the vitest template (used in `clarinet new`) to fix the thread issue
- SDK: Update the contracts path in deployment plan to be relative instead of absolute

### Versions

- Upgrade cli to 2.3.1
- Upgrade SDK to 2.3.2

