### PR TITLE
feat: call private function in simnet

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -3,3 +3,6 @@ clarinet-install = "install --path components/clarinet-cli --locked --force"
 tst = "nextest run --workspace --locked --exclude clarinet-sdk-wasm --exclude clarity-jupyter-kernel"
 cov = "llvm-cov nextest --workspace --locked --exclude clarinet-sdk-wasm --exclude clarity-jupyter-kernel --lcov --output-path lcov.info"
 cov-dev = "llvm-cov nextest --workspace --locked --exclude clarinet-sdk-wasm --exclude clarity-jupyter-kernel --html"
+
+[patch.'https://github.com/stacks-network/stacks-core.git']
+clarity = { path = "../stacks-core/clarity" }

--- a/.cargo/config
+++ b/.cargo/config
@@ -3,6 +3,3 @@ clarinet-install = "install --path components/clarinet-cli --locked --force"
 tst = "nextest run --workspace --locked --exclude clarinet-sdk-wasm --exclude clarity-jupyter-kernel"
 cov = "llvm-cov nextest --workspace --locked --exclude clarinet-sdk-wasm --exclude clarity-jupyter-kernel --lcov --output-path lcov.info"
 cov-dev = "llvm-cov nextest --workspace --locked --exclude clarinet-sdk-wasm --exclude clarity-jupyter-kernel --html"
-
-[patch.'https://github.com/stacks-network/stacks-core.git']
-clarity = { path = "../stacks-core/clarity" }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -928,7 +928,6 @@ dependencies = [
 [[package]]
 name = "clarity"
 version = "2.3.0"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-next#2ab366d28d473f204b67a431ba8b522c0c9a8e78"
 dependencies = [
  "getrandom 0.2.8",
  "hashbrown 0.14.3",
@@ -1035,6 +1034,7 @@ dependencies = [
  "tokio-util",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "web-sys",
  "wsts",
 ]
 
@@ -2630,9 +2630,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.68"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
+checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -5649,9 +5649,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -5659,9 +5659,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
 dependencies = [
  "bumpalo",
  "log",
@@ -5686,9 +5686,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5696,9 +5696,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5709,9 +5709,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "wasm-encoder"
@@ -6063,9 +6063,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.61"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
+checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -928,6 +928,7 @@ dependencies = [
 [[package]]
 name = "clarity"
 version = "2.3.0"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-next#2ab366d28d473f204b67a431ba8b522c0c9a8e78"
 dependencies = [
  "getrandom 0.2.8",
  "hashbrown 0.14.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1035,7 +1035,6 @@ dependencies = [
  "tokio-util",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "web-sys",
  "wsts",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "clarinet-sdk-wasm"
-version = "2.4.0-beta2"
+version = "2.4.0-beta4"
 dependencies = [
  "clarinet-deployments",
  "clarinet-files",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -661,7 +661,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "chainhook-sdk"
 version = "0.12.5"
-source = "git+https://github.com/hirosystems/chainhook.git?branch=chore/update-clarinet-and-clarity#ccd1be54d401cec59ac2fb33a2510a3e06b17f6d"
+source = "git+https://github.com/hirosystems/chainhook.git?branch=chore/update-clarinet-and-clarity#e8e7e9e3840c9c10957168d14761abe55e0bb22c"
 dependencies = [
  "base58 0.2.0",
  "base64 0.21.7",
@@ -687,7 +687,7 @@ dependencies = [
  "serde-hex",
  "serde_derive",
  "serde_json",
- "stacks-rpc-client 2.3.1 (git+https://github.com/hirosystems/clarinet.git?branch=feat/update-stacks-core)",
+ "stacks-rpc-client 2.3.1 (git+https://github.com/hirosystems/clarinet.git)",
  "threadpool",
  "tokio",
 ]
@@ -695,7 +695,7 @@ dependencies = [
 [[package]]
 name = "chainhook-types"
 version = "1.3.3"
-source = "git+https://github.com/hirosystems/chainhook.git?branch=chore/update-clarinet-and-clarity#ccd1be54d401cec59ac2fb33a2510a3e06b17f6d"
+source = "git+https://github.com/hirosystems/chainhook.git?branch=chore/update-clarinet-and-clarity#e8e7e9e3840c9c10957168d14761abe55e0bb22c"
 dependencies = [
  "hex 0.4.3",
  "schemars",
@@ -1041,16 +1041,17 @@ dependencies = [
 [[package]]
 name = "clarity-repl"
 version = "2.3.1"
-source = "git+https://github.com/hirosystems/clarinet.git?branch=feat/update-stacks-core#11f77eebff53776838c3f64308423f531b5468c3"
+source = "git+https://github.com/hirosystems/clarinet.git#dbc0178a1957eb507ac1979ffefb7798ddc6614c"
 dependencies = [
  "ansi_term",
  "atty",
  "chrono",
  "clarity",
  "getrandom 0.2.8",
- "hiro-system-kit 0.1.0 (git+https://github.com/hirosystems/clarinet.git?branch=feat/update-stacks-core)",
+ "hiro-system-kit 0.1.0 (git+https://github.com/hirosystems/clarinet.git)",
  "integer-sqrt",
  "lazy_static",
+ "pox-locking",
  "regex",
  "reqwest",
  "serde",
@@ -2264,7 +2265,7 @@ dependencies = [
 [[package]]
 name = "hiro-system-kit"
 version = "0.1.0"
-source = "git+https://github.com/hirosystems/clarinet.git?branch=feat/update-stacks-core#11f77eebff53776838c3f64308423f531b5468c3"
+source = "git+https://github.com/hirosystems/clarinet.git#dbc0178a1957eb507ac1979ffefb7798ddc6614c"
 dependencies = [
  "ansi_term",
  "atty",
@@ -4875,9 +4876,9 @@ dependencies = [
 [[package]]
 name = "stacks-rpc-client"
 version = "2.3.1"
-source = "git+https://github.com/hirosystems/clarinet.git?branch=feat/update-stacks-core#11f77eebff53776838c3f64308423f531b5468c3"
+source = "git+https://github.com/hirosystems/clarinet.git#dbc0178a1957eb507ac1979ffefb7798ddc6614c"
 dependencies = [
- "clarity-repl 2.3.1 (git+https://github.com/hirosystems/clarinet.git?branch=feat/update-stacks-core)",
+ "clarity-repl 2.3.1 (git+https://github.com/hirosystems/clarinet.git)",
  "hmac 0.12.1",
  "libsecp256k1 0.7.1",
  "pbkdf2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -928,7 +928,7 @@ dependencies = [
 [[package]]
 name = "clarity"
 version = "2.3.0"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-next#2ab366d28d473f204b67a431ba8b522c0c9a8e78"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-next#b006cd68da6124c29d48806cde6272a19efdd8ce"
 dependencies = [
  "getrandom 0.2.8",
  "hashbrown 0.14.3",
@@ -3509,7 +3509,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 [[package]]
 name = "pox-locking"
 version = "2.4.0"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-next#2ab366d28d473f204b67a431ba8b522c0c9a8e78"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-next#b006cd68da6124c29d48806cde6272a19efdd8ce"
 dependencies = [
  "clarity",
  "slog",
@@ -4774,7 +4774,7 @@ dependencies = [
 [[package]]
 name = "stacks-common"
 version = "0.0.2"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-next#2ab366d28d473f204b67a431ba8b522c0c9a8e78"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-next#b006cd68da6124c29d48806cde6272a19efdd8ce"
 dependencies = [
  "chrono",
  "curve25519-dalek 2.0.0",

--- a/components/clarinet-sdk-wasm/Cargo.toml
+++ b/components/clarinet-sdk-wasm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "clarinet-sdk-wasm"
-version = "2.4.0-beta2"
+version = "2.4.0-beta4"
 license = "GPL-3.0"
 repository = "https://github.com/hirosystems/clarinet"
 description = "The core lib that powers @hirosystems/clarinet-sdk"

--- a/components/clarinet-sdk-wasm/src/core.rs
+++ b/components/clarinet-sdk-wasm/src/core.rs
@@ -18,7 +18,7 @@ use clarity_repl::clarity::vm::types::QualifiedContractIdentifier;
 use clarity_repl::clarity::{
     ClarityVersion, EvaluationResult, ExecutionResult, ParsedContract, StacksEpochId,
 };
-use clarity_repl::repl::clarity_values::uint8_to_value;
+use clarity_repl::repl::clarity_values::{uint8_to_string, uint8_to_value};
 use clarity_repl::repl::{
     clarity_values, ClarityCodeSource, ClarityContract, ContractDeployer, Session,
     DEFAULT_CLARITY_VERSION, DEFAULT_EPOCH,
@@ -661,10 +661,13 @@ impl SDK {
             Err(diagnostics) => {
                 let mut message = format!(
                     "{}: {}::{}({})",
-                    "Call private fn error",
+                    "Call contract function error",
                     contract,
                     method,
-                    "args" // clarity_args.join(", ")
+                    args.iter()
+                        .map(|a| uint8_to_string(a))
+                        .collect::<Vec<String>>()
+                        .join(", ")
                 );
                 if let Some(diag) = diagnostics.last() {
                     message = format!("{} -> {}", message, diag.message);

--- a/components/clarinet-sdk-wasm/src/core.rs
+++ b/components/clarinet-sdk-wasm/src/core.rs
@@ -18,9 +18,10 @@ use clarity_repl::clarity::vm::types::QualifiedContractIdentifier;
 use clarity_repl::clarity::{
     ClarityVersion, EvaluationResult, ExecutionResult, ParsedContract, StacksEpochId,
 };
+use clarity_repl::repl::clarity_values::{uint8_to_string, uint8_to_value};
 use clarity_repl::repl::{
-    ClarityCodeSource, ClarityContract, ContractDeployer, Session, DEFAULT_CLARITY_VERSION,
-    DEFAULT_EPOCH,
+    clarity_values, ClarityCodeSource, ClarityContract, ContractDeployer, Session,
+    DEFAULT_CLARITY_VERSION, DEFAULT_EPOCH,
 };
 use colored::*;
 use gloo_utils::format::JsValueSerdeExt;
@@ -33,7 +34,6 @@ use std::{panic, path::PathBuf};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsValue;
 
-use crate::utils::clarity_values::{self, uint8_to_string, uint8_to_value};
 use crate::utils::costs::SerializableCostsReport;
 use crate::utils::events::serialize_event;
 
@@ -74,7 +74,7 @@ struct CallContractArgsJSON {
 
 #[derive(Debug, Deserialize)]
 #[wasm_bindgen]
-pub struct CallContractArgs {
+pub struct CallFnArgs {
     contract: String,
     method: String,
     args: Vec<Vec<u8>>,
@@ -82,7 +82,7 @@ pub struct CallContractArgs {
 }
 
 #[wasm_bindgen]
-impl CallContractArgs {
+impl CallFnArgs {
     #[wasm_bindgen(constructor)]
     pub fn new(
         contract: String,
@@ -200,6 +200,7 @@ impl TransferSTXArgs {
 #[serde(rename_all = "camelCase")]
 #[wasm_bindgen]
 pub struct TxArgs {
+    call_private_fn: Option<CallContractArgsJSON>,
     call_public_fn: Option<CallContractArgsJSON>,
     deploy_contract: Option<DeployContractArgs>,
     #[serde(rename(serialize = "transfer_stx", deserialize = "transferSTX"))]
@@ -636,10 +637,10 @@ impl SDK {
 
     fn invoke_contract_call(
         &mut self,
-        call_contract_args: &CallContractArgs,
+        call_contract_args: &CallFnArgs,
         test_name: &str,
     ) -> Result<TransactionRes, String> {
-        let CallContractArgs {
+        let CallFnArgs {
             contract,
             method,
             args,
@@ -676,7 +677,7 @@ impl SDK {
     }
 
     #[wasm_bindgen(js_name=callReadOnlyFn)]
-    pub fn call_read_only_fn(&mut self, args: &CallContractArgs) -> Result<TransactionRes, String> {
+    pub fn call_read_only_fn(&mut self, args: &CallFnArgs) -> Result<TransactionRes, String> {
         let interface = self.get_function_interface(&args.contract, &args.method)?;
         if interface.access != ContractInterfaceFunctionAccess::read_only {
             return Err(format!("{} is not a read-only function", &args.method));
@@ -685,9 +686,9 @@ impl SDK {
         self.invoke_contract_call(args, &self.current_test_name.clone())
     }
 
-    fn call_public_fn_private(
+    fn inner_call_public_fn(
         &mut self,
-        args: &CallContractArgs,
+        args: &CallFnArgs,
         advance_chain_tip: bool,
     ) -> Result<TransactionRes, String> {
         let interface = self.get_function_interface(&args.contract, &args.method)?;
@@ -703,7 +704,56 @@ impl SDK {
         self.invoke_contract_call(args, &self.current_test_name.clone())
     }
 
-    fn transfer_stx_private(
+    fn inner_call_private_fn(
+        &mut self,
+        call_private_fn_args: &CallFnArgs,
+        advance_chain_tip: bool,
+    ) -> Result<TransactionRes, String> {
+        let interface = self
+            .get_function_interface(&call_private_fn_args.contract, &call_private_fn_args.method)?;
+        if interface.access != ContractInterfaceFunctionAccess::private {
+            return Err(format!(
+                "{} is not a private function",
+                &call_private_fn_args.method
+            ));
+        }
+
+        let session = self.get_session_mut();
+        if advance_chain_tip {
+            session.advance_chain_tip(1);
+        }
+
+        let CallFnArgs {
+            contract,
+            method,
+            args,
+            sender,
+        } = call_private_fn_args;
+
+        let test_name = self.current_test_name.clone();
+        let session = self.get_session_mut();
+        let (execution, _) =
+            match session.call_contract_fn(contract, method, args, sender, test_name) {
+                Ok(res) => res,
+                Err(diagnostics) => {
+                    let mut message = format!(
+                        "{}: {}::{}({})",
+                        "Call private fn error",
+                        contract,
+                        method,
+                        "args" // clarity_args.join(", ")
+                    );
+                    if let Some(diag) = diagnostics.last() {
+                        message = format!("{} -> {}", message, diag.message);
+                    }
+                    return Err(message);
+                }
+            };
+
+        Ok(execution_result_to_transaction_res(&execution))
+    }
+
+    fn inner_transfer_stx(
         &mut self,
         args: &TransferSTXArgs,
         advance_chain_tip: bool,
@@ -730,7 +780,7 @@ impl SDK {
         Ok(execution_result_to_transaction_res(&execution))
     }
 
-    fn deploy_contract_private(
+    fn inner_deploy_contract(
         &mut self,
         args: &DeployContractArgs,
         advance_chain_tip: bool,
@@ -775,17 +825,22 @@ impl SDK {
 
     #[wasm_bindgen(js_name=deployContract)]
     pub fn deploy_contract(&mut self, args: &DeployContractArgs) -> Result<TransactionRes, String> {
-        self.deploy_contract_private(args, true)
+        self.inner_deploy_contract(args, true)
     }
 
     #[wasm_bindgen(js_name = "transferSTX")]
     pub fn transfer_stx(&mut self, args: &TransferSTXArgs) -> Result<TransactionRes, String> {
-        self.transfer_stx_private(args, true)
+        self.inner_transfer_stx(args, true)
     }
 
     #[wasm_bindgen(js_name = "callPublicFn")]
-    pub fn call_public_fn(&mut self, args: &CallContractArgs) -> Result<TransactionRes, String> {
-        self.call_public_fn_private(args, true)
+    pub fn call_public_fn(&mut self, args: &CallFnArgs) -> Result<TransactionRes, String> {
+        self.inner_call_public_fn(args, true)
+    }
+
+    #[wasm_bindgen(js_name = "callPrivateFn")]
+    pub fn call_private_fn(&mut self, args: &CallFnArgs) -> Result<TransactionRes, String> {
+        self.inner_call_private_fn(args, true)
     }
 
     #[wasm_bindgen(js_name=mineBlock)]
@@ -797,12 +852,14 @@ impl SDK {
             .map_err(|e| format!("Failed to parse js txs: {:}", e))?;
 
         for tx in txs {
-            let result = if let Some(args) = tx.call_public_fn {
-                self.call_public_fn_private(&CallContractArgs::from_json_args(args), false)
+            let result = if let Some(call_public) = tx.call_public_fn {
+                self.inner_call_public_fn(&CallFnArgs::from_json_args(call_public), false)
+            } else if let Some(call_private) = tx.call_private_fn {
+                self.inner_call_private_fn(&CallFnArgs::from_json_args(call_private), false)
             } else if let Some(transfer_stx) = tx.transfer_stx {
-                self.transfer_stx_private(&transfer_stx, false)
+                self.inner_transfer_stx(&transfer_stx, false)
             } else if let Some(deploy_contract) = tx.deploy_contract {
-                self.deploy_contract_private(&deploy_contract, false)
+                self.inner_deploy_contract(&deploy_contract, false)
             } else {
                 return Err("Invalid tx arguments".into());
             }?;

--- a/components/clarinet-sdk-wasm/src/utils/mod.rs
+++ b/components/clarinet-sdk-wasm/src/utils/mod.rs
@@ -1,3 +1,2 @@
-pub mod clarity_values;
 pub mod costs;
 pub mod events;

--- a/components/clarinet-sdk/package-lock.json
+++ b/components/clarinet-sdk/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@hirosystems/clarinet-sdk",
-  "version": "2.4.0-beta2",
+  "version": "2.4.0-beta4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hirosystems/clarinet-sdk",
-      "version": "2.4.0-beta2",
+      "version": "2.4.0-beta4",
       "license": "GPL-3.0",
       "dependencies": {
-        "@hirosystems/clarinet-sdk-wasm": "^2.4.0-beta2",
+        "@hirosystems/clarinet-sdk-wasm": "^2.4.0-beta3",
         "@stacks/encryption": "^6.12.0",
         "@stacks/network": "^6.11.3",
         "@stacks/stacking": "^6.11.4-pr.36558cf.0",
@@ -381,9 +381,9 @@
       }
     },
     "node_modules/@hirosystems/clarinet-sdk-wasm": {
-      "version": "2.4.0-beta2",
-      "resolved": "https://registry.npmjs.org/@hirosystems/clarinet-sdk-wasm/-/clarinet-sdk-wasm-2.4.0-beta2.tgz",
-      "integrity": "sha512-gKqh5yf5IuLfAosdbLYZusP+mIu2vFac8gztM7y8JoahRdg9dru24B/ycQoQXlTZUN/YzMhr+vMV3jS4vJtZEA=="
+      "version": "2.4.0-beta3",
+      "resolved": "https://registry.npmjs.org/@hirosystems/clarinet-sdk-wasm/-/clarinet-sdk-wasm-2.4.0-beta3.tgz",
+      "integrity": "sha512-m4PHoE38F+YzH5WDwK5CuRs3/RZWGstIPx4bq2vX6ut1ETE2S9LkS8q91RFF4FnZHnI5f8LwxflTbaxE+RSNrA=="
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",

--- a/components/clarinet-sdk/package.json
+++ b/components/clarinet-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hirosystems/clarinet-sdk",
-  "version": "2.4.0-beta2",
+  "version": "2.4.0-beta4",
   "description": "A SDK to interact with Clarity Smart Contracts",
   "homepage": "https://docs.hiro.so/clarinet/feature-guides/clarinet-js-sdk",
   "repository": {
@@ -58,7 +58,7 @@
   "license": "GPL-3.0",
   "readme": "./README.md",
   "dependencies": {
-    "@hirosystems/clarinet-sdk-wasm": "^2.4.0-beta2",
+    "@hirosystems/clarinet-sdk-wasm": "^2.4.0-beta3",
     "@stacks/encryption": "^6.12.0",
     "@stacks/network": "^6.11.3",
     "@stacks/stacking": "^6.11.4-pr.36558cf.0",

--- a/components/clarinet-sdk/src/index.ts
+++ b/components/clarinet-sdk/src/index.ts
@@ -123,7 +123,7 @@ export type RunSnippet = (snippet: string) => ClarityValue | string;
 
 // because the session is wrapped in a proxy the types need to be hardcoded
 export type Simnet = {
-  [K in keyof SDK]: K extends "callReadOnlyFn" | "callPublicFn"
+  [K in keyof SDK]: K extends "callReadOnlyFn" | "callPublicFn" | "callPrivateFn"
     ? CallFn
     : K extends "runSnippet"
       ? RunSnippet

--- a/components/clarinet-sdk/src/index.ts
+++ b/components/clarinet-sdk/src/index.ts
@@ -99,7 +99,7 @@ export const tx = {
     callPublicFn: { contract, method, args, sender },
   }),
   callPrivateFn: (contract: string, method: string, args: ClarityValue[], sender: string): Tx => ({
-    callPublicFn: { contract, method, args, sender },
+    callPrivateFn: { contract, method, args, sender },
   }),
   deployContract: (
     name: string,
@@ -176,24 +176,9 @@ const getSessionProxy = () => ({
     // - serialize clarity values input argument
     // - deserialize output into clarity values
 
-    if (prop === "callReadOnlyFn" || prop === "callPublicFn") {
+    if (prop === "callReadOnlyFn" || prop === "callPublicFn" || prop === "callPrivateFn") {
       const callFn: CallFn = (contract, method, args, sender) => {
         const response = session[prop](
-          new CallFnArgs(
-            contract,
-            method,
-            args.map((a) => Cl.serialize(a)),
-            sender,
-          ),
-        );
-        return parseTxResponse(response);
-      };
-      return callFn;
-    }
-
-    if (prop === "callPrivateFn") {
-      const callFn: CallFn = (contract, method, args, sender) => {
-        const response = session.callPrivateFn(
           new CallFnArgs(
             contract,
             method,
@@ -247,7 +232,15 @@ const getSessionProxy = () => ({
             return {
               callPublicFn: {
                 ...tx.callPublicFn,
-                args_maps: tx.callPublicFn.args.map((a) => Cl.serialize(a)),
+                args_maps: tx.callPublicFn.args.map(Cl.serialize),
+              },
+            };
+          }
+          if (tx.callPrivateFn) {
+            return {
+              callPrivateFn: {
+                ...tx.callPrivateFn,
+                args_maps: tx.callPrivateFn.args.map(Cl.serialize),
               },
             };
           }

--- a/components/clarinet-sdk/tests/fixtures/contracts/counter.clar
+++ b/components/clarinet-sdk/tests/fixtures/contracts/counter.clar
@@ -9,37 +9,22 @@
   (ok { count: (var-get count) })
 )
 
-(define-private (test-priv
-  (a uint)
-  (b (optional uint))
-  (c (optional principal))
-  (d (optional (list 100 uint)))
-  (e (optional (list 100 (string-ascii 100))))
-  (f (optional (list 100 (string-utf8 100))))
-)
-  (ok true)
-)
-
-(define-public (test-pub
-  (a uint)
-  (b (optional uint))
-  (c (optional principal))
-  (d (optional (list 100 uint)))
-  (e (optional (list 100 (string-ascii 100))))
-  (f (optional (list 100 (string-utf8 100))))
-)
-  (ok true)
+(define-private (inner-increment)
+  (begin
+    (print "call inner-increment")
+    (if (is-none (map-get? participants tx-sender))
+      (map-insert participants tx-sender true)
+      (map-set participants tx-sender true)
+    )
+    (var-set count (+ (var-get count) u1))
+  )
 )
 
 (define-public (increment)
   (begin
     (print "call increment")
-    (if (is-none (map-get? participants tx-sender))
-      (map-insert participants tx-sender true)
-      (map-set participants tx-sender true)
-    )
     (try! (stx-transfer? u1000000 tx-sender (as-contract tx-sender)))
-    (ok (var-set count (+ (var-get count) u1)))
+    (ok (inner-increment))
   )
 )
 

--- a/components/clarinet-sdk/tests/fixtures/contracts/counter.clar
+++ b/components/clarinet-sdk/tests/fixtures/contracts/counter.clar
@@ -9,6 +9,28 @@
   (ok { count: (var-get count) })
 )
 
+(define-private (test-priv
+  (a uint)
+  (b (optional uint))
+  (c (optional principal))
+  (d (optional (list 100 uint)))
+  (e (optional (list 100 (string-ascii 100))))
+  (f (optional (list 100 (string-utf8 100))))
+)
+  true
+)
+
+(define-public (test-pub
+  (a uint)
+  (b (optional uint))
+  (c (optional principal))
+  (d (optional (list 100 uint)))
+  (e (optional (list 100 (string-ascii 100))))
+  (f (optional (list 100 (string-utf8 100))))
+)
+  (ok true)
+)
+
 (define-public (increment)
   (begin
     (print "call increment")

--- a/components/clarinet-sdk/tests/fixtures/contracts/counter.clar
+++ b/components/clarinet-sdk/tests/fixtures/contracts/counter.clar
@@ -17,7 +17,7 @@
   (e (optional (list 100 (string-ascii 100))))
   (f (optional (list 100 (string-utf8 100))))
 )
-  true
+  (ok true)
 )
 
 (define-public (test-pub

--- a/components/clarinet-sdk/tests/simnet-usage.test.ts
+++ b/components/clarinet-sdk/tests/simnet-usage.test.ts
@@ -26,42 +26,6 @@ function deleteExistingDeploymentPlan() {
   }
 }
 
-describe.only("bench pub vs priv", () => {
-  // (a uint)
-  // (b (optional uint))
-  // (c (optional principal))
-  // (d (optional (list 100 uint)))
-  // (e (optional (list 100 (string-ascii 100))))
-  // (f (optional (list 100 (string-utf8 100))))
-  const args = () => [
-    Cl.uint(1111111),
-    Cl.some(Cl.uint(2222222)),
-    Cl.some(Cl.principal(address1)),
-    Cl.some(Cl.list(Array(100).fill(Cl.uint(3333333)))),
-    Cl.some(Cl.list(Array(100).fill(Cl.stringAscii("hello")))),
-    Cl.some(Cl.list(Array(100).fill(Cl.stringUtf8("hello world")))),
-  ];
-
-  it("can call both", () => {
-    simnet.callPrivateFn("counter", "test-priv", args(), address1);
-    simnet.callPublicFn("counter", "test-pub", args(), address1);
-  });
-
-  const j = 1;
-
-  it("calls private", () => {
-    for (let i = 0; i < j; i++) {
-      simnet.callPrivateFn("counter", "test-priv", args(), address1);
-    }
-  });
-
-  it("calls public", () => {
-    for (let i = 0; i < j; i++) {
-      simnet.callPublicFn("counter", "test-pub", args(), address1);
-    }
-  });
-});
-
 beforeEach(async () => {
   deleteExistingDeploymentPlan();
   simnet = await initSimnet("tests/fixtures/Clarinet.toml");

--- a/components/clarinet-sdk/tests/simnet-usage.test.ts
+++ b/components/clarinet-sdk/tests/simnet-usage.test.ts
@@ -335,8 +335,6 @@ describe("simnet can get session reports", () => {
 
     const reports = simnet.collectReport();
 
-    console.log("reports.coverage", reports.coverage);
-
     // increment is called twice
     expect(reports.coverage.includes("FNDA:2,increment")).toBe(true);
     // inner-increment is called one time directly and twice by `increment`

--- a/components/clarity-repl/Cargo.toml
+++ b/components/clarity-repl/Cargo.toml
@@ -39,6 +39,8 @@ clar2wasm = { git = "https://github.com/stacks-network/clarity-wasm.git", option
 # clar2wasm = { path="../../../clarity-wasm/clar2wasm", optional = true }
 pox-locking = { git = "https://github.com/stacks-network/stacks-core.git", branch="feat/clarity-wasm-next",  optional = true, default-features = false }
 
+web-sys = { version = "0.3.69" }
+
 # DAP Debugger
 tokio = { version = "1.35.1", features = ["full"], optional = true }
 tokio-util = { version = "0.7.10", features = ["codec"], optional = true }

--- a/components/clarity-repl/Cargo.toml
+++ b/components/clarity-repl/Cargo.toml
@@ -39,8 +39,6 @@ clar2wasm = { git = "https://github.com/stacks-network/clarity-wasm.git", option
 # clar2wasm = { path="../../../clarity-wasm/clar2wasm", optional = true }
 pox-locking = { git = "https://github.com/stacks-network/stacks-core.git", branch="feat/clarity-wasm-next",  optional = true, default-features = false }
 
-web-sys = { version = "0.3.69" }
-
 # DAP Debugger
 tokio = { version = "1.35.1", features = ["full"], optional = true }
 tokio-util = { version = "0.7.10", features = ["codec"], optional = true }

--- a/components/clarity-repl/Cargo.toml
+++ b/components/clarity-repl/Cargo.toml
@@ -110,7 +110,13 @@ dap = [
     "memchr",
     "log",
 ]
-wasm = ["wasm-bindgen", "wasm-bindgen-futures", "clarity/wasm", "pox-locking/wasm"]
+wasm = [
+    "wasm-bindgen",
+    "wasm-bindgen-futures",
+    "clarity/wasm",
+    "clarity/developer-mode",
+    "pox-locking/wasm"
+]
 
 [package.metadata.wasm-pack.profile.release.wasm-bindgen]
 debug-js-glue = false

--- a/components/clarity-repl/src/repl/clarity_values.rs
+++ b/components/clarity-repl/src/repl/clarity_values.rs
@@ -74,12 +74,12 @@ fn value_to_string(value: &Value) -> String {
 #[cfg(test)]
 mod tests {
     use super::value_to_string;
-    use clarity_repl::clarity::vm::types::{
+    use clarity::vm::types::{
         ASCIIData, CharType, ListData, ListTypeData, OptionalData, PrincipalData,
         QualifiedContractIdentifier, ResponseData, SequenceData, SequencedValue,
         StandardPrincipalData, TupleData, TypeSignature, UTF8Data, NONE,
     };
-    use clarity_repl::clarity::vm::{ClarityName, Value};
+    use clarity::vm::{ClarityName, Value};
     use std::convert::TryFrom;
 
     #[test]
@@ -149,7 +149,7 @@ mod tests {
         ))));
         assert_eq!(s, "\"Hello, \"world\"\n\"");
 
-        s = value_to_string(&UTF8Data::to_value(&"Hello, 'world'\n".as_bytes().to_vec()));
+        s = value_to_string(&UTF8Data::to_value(&"Hello, 'world'\n".as_bytes().to_vec()).unwrap());
         assert_eq!(s, "u\"Hello, 'world'\n\"");
 
         s = value_to_string(&Value::Sequence(SequenceData::List(ListData {

--- a/components/clarity-repl/src/repl/clarity_values.rs
+++ b/components/clarity-repl/src/repl/clarity_values.rs
@@ -1,4 +1,4 @@
-use clarity_repl::clarity::{
+use crate::clarity::{
     codec::StacksMessageCodec,
     util::hash,
     vm::types::{CharType, SequenceData},

--- a/components/clarity-repl/src/repl/clarity_values.rs
+++ b/components/clarity-repl/src/repl/clarity_values.rs
@@ -1,9 +1,8 @@
-use crate::clarity::{
-    codec::StacksMessageCodec,
-    util::hash,
-    vm::types::{CharType, SequenceData},
+use clarity::vm::{
+    types::{CharType, SequenceData},
     Value,
 };
+use clarity::{codec::StacksMessageCodec, util::hash};
 
 pub fn to_raw_value(value: &Value) -> String {
     let mut bytes = vec![];

--- a/components/clarity-repl/src/repl/interpreter.rs
+++ b/components/clarity-repl/src/repl/interpreter.rs
@@ -498,7 +498,7 @@ impl ClarityInterpreter {
                 &mut conn,
                 contract.epoch,
             )
-            .expect("failed to initialize cost tracker")
+            .map_err(|e| format!("failed to initialize cost tracker: {e}"))?
         } else {
             LimitedCostTracker::new_free()
         };
@@ -727,7 +727,7 @@ impl ClarityInterpreter {
                 &mut conn,
                 contract.epoch,
             )
-            .expect("failed to initialize cost tracker")
+            .map_err(|e| format!("failed to initialize cost tracker: {e}"))?
         } else {
             LimitedCostTracker::new_free()
         };
@@ -963,7 +963,7 @@ impl ClarityInterpreter {
                 &mut conn,
                 epoch,
             )
-            .expect("failed to initialize cost tracker")
+            .map_err(|e| format!("failed to initialize cost tracker: {e}"))?
         } else {
             LimitedCostTracker::new_free()
         };

--- a/components/clarity-repl/src/repl/interpreter.rs
+++ b/components/clarity-repl/src/repl/interpreter.rs
@@ -32,12 +32,6 @@ use clarity::vm::{CostSynthesis, ExecutionResult, ParsedContract};
 use super::datastore::StacksConstants;
 use super::{ClarityContract, DEFAULT_EPOCH};
 
-macro_rules! log {
-    ( $( $t:tt )* ) => {
-        web_sys::console::log_1(&format!( $( $t )* ).into());
-    }
-}
-
 pub const BLOCK_LIMIT_MAINNET: ExecutionCost = ExecutionCost {
     write_length: 15_000_000,
     write_count: 15_000,
@@ -1010,10 +1004,7 @@ impl ClarityInterpreter {
 
             let result =
                 env.execute_contract_allow_private(contract_id, method, &args_expressions, false);
-            log!(
-                "call_contract_fn: result: {:?}",
-                result.as_ref().map(|v| v.to_string())
-            );
+
             match result {
                 Ok(value) => Value::okay(value),
                 Err(e) => Err(e),

--- a/components/clarity-repl/src/repl/mod.rs
+++ b/components/clarity-repl/src/repl/mod.rs
@@ -1,4 +1,5 @@
 pub mod boot;
+pub mod clarity_values;
 pub mod datastore;
 pub mod diagnostic;
 pub mod interpreter;

--- a/components/clarity-repl/src/repl/session.rs
+++ b/components/clarity-repl/src/repl/session.rs
@@ -620,7 +620,7 @@ impl Session {
         sender: &str,
         allow_private: bool,
         test_name: String,
-    ) -> Result<(ExecutionResult, QualifiedContractIdentifier), Vec<Diagnostic>> {
+    ) -> Result<ExecutionResult, Vec<Diagnostic>> {
         let initial_tx_sender = self.get_tx_sender();
         // Handle fully qualified contract_id and sugared syntax
         let contract_id_str = if contract.starts_with('S') {
@@ -634,7 +634,6 @@ impl Session {
         let mut coverage = TestCoverageReport::new(test_name.clone());
         hooks.push(&mut coverage);
 
-        // epoch: self.current_epoch,
         let clarity_version = ClarityVersion::default_for_epoch(self.current_epoch);
 
         self.set_tx_sender(sender.into());
@@ -653,7 +652,7 @@ impl Session {
                 self.set_tx_sender(initial_tx_sender);
                 return Err(vec![Diagnostic {
                     level: Level::Error,
-                    message: format!("Error calling contract function: {}", e),
+                    message: format!("Error calling contract function: {e}"),
                     spans: vec![],
                     suggestion: None,
                 }]);
@@ -672,7 +671,7 @@ impl Session {
             });
         }
 
-        Ok((execution, contract_id))
+        Ok(execution)
     }
 
     pub fn eval(

--- a/components/clarity-repl/src/repl/session.rs
+++ b/components/clarity-repl/src/repl/session.rs
@@ -618,6 +618,7 @@ impl Session {
         method: &str,
         args: &[Vec<u8>],
         sender: &str,
+        allow_private: bool,
         test_name: String,
     ) -> Result<(ExecutionResult, QualifiedContractIdentifier), Vec<Diagnostic>> {
         let initial_tx_sender = self.get_tx_sender();
@@ -644,6 +645,7 @@ impl Session {
             self.current_epoch,
             clarity_version,
             true,
+            allow_private,
             Some(hooks),
         ) {
             Ok(result) => result,

--- a/components/clarity-repl/src/repl/session.rs
+++ b/components/clarity-repl/src/repl/session.rs
@@ -1,4 +1,5 @@
 use super::boot::{STACKS_BOOT_CODE_MAINNET, STACKS_BOOT_CODE_TESTNET};
+use super::clarity_values::uint8_to_string;
 use super::diagnostic::output_diagnostic;
 use super::{ClarityCodeSource, ClarityContract, ClarityInterpreter, ContractDeployer};
 use crate::analysis::coverage::TestCoverageReport;
@@ -562,7 +563,7 @@ impl Session {
         let contract_id = if contract.starts_with('S') {
             contract.to_string()
         } else {
-            format!("{}.{}", initial_tx_sender, contract,)
+            format!("{}.{}", initial_tx_sender, contract)
         };
 
         let mut hooks: Vec<&mut dyn EvalHook> = vec![];
@@ -609,6 +610,67 @@ impl Session {
         }
 
         Ok((execution, contract_identifier))
+    }
+
+    pub fn call_contract_fn(
+        &mut self,
+        contract: &str,
+        method: &str,
+        args: &[Vec<u8>],
+        sender: &str,
+        test_name: String,
+    ) -> Result<(ExecutionResult, QualifiedContractIdentifier), Vec<Diagnostic>> {
+        let initial_tx_sender = self.get_tx_sender();
+        // Handle fully qualified contract_id and sugared syntax
+        let contract_id_str = if contract.starts_with('S') {
+            contract.to_string()
+        } else {
+            format!("{}.{}", initial_tx_sender, contract)
+        };
+        let contract_id = QualifiedContractIdentifier::parse(&contract_id_str).unwrap();
+
+        let mut hooks: Vec<&mut dyn EvalHook> = vec![];
+        let mut coverage = TestCoverageReport::new(test_name.clone());
+        hooks.push(&mut coverage);
+
+        // epoch: self.current_epoch,
+        let clarity_version = ClarityVersion::default_for_epoch(self.current_epoch);
+
+        self.set_tx_sender(sender.into());
+        let execution = match self.interpreter.call_contract_fn(
+            &contract_id,
+            method,
+            args,
+            self.current_epoch,
+            clarity_version,
+            true,
+            Some(hooks),
+        ) {
+            Ok(result) => result,
+            Err(e) => {
+                self.set_tx_sender(initial_tx_sender);
+                return Err(vec![Diagnostic {
+                    level: Level::Error,
+                    message: format!("Error calling contract function: {}", e),
+                    spans: vec![],
+                    suggestion: None,
+                }]);
+            }
+        };
+        self.set_tx_sender(initial_tx_sender);
+        self.coverage_reports.push(coverage);
+
+        if let Some(ref cost) = execution.cost {
+            self.costs_reports.push(CostsReport {
+                test_name,
+                contract_id: contract_id_str,
+                method: method.to_string(),
+                args: args.iter().map(|a| uint8_to_string(a)).collect(),
+                cost_result: cost.clone(),
+            });
+        }
+
+        Ok((execution, contract_id))
     }
 
     pub fn eval(


### PR DESCRIPTION
Fix: #547 

### Description

Allow to contract private functions from the simnet.
It requires the changes of this PR https://github.com/stacks-network/stacks-core/pull/4520, which have been cherry-picked on feat/clarity-wasm-next.


#### `call_contract_fn`
In the interpreter, there's a new `call_contract_fn` method that can be used instead of `run` or `execute` to perform contract calls.
This method is slightly more performant (it doesn't build an virtual contract and has a better clarity args serialization logic).

This improved way to all contract functions is now used for `callPublicFn` and `callReadOnlyFn` as well



---

### Checklist

- [ ] Tests added in this PR (if applicable)

