### PR TITLE
chore: bump clarinet-sdk version to 2.4.1

### DIFF
--- a/components/clarinet-sdk/package-lock.json
+++ b/components/clarinet-sdk/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "@hirosystems/clarinet-sdk",
-  "version": "2.4.0-beta5",
+  "version": "2.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hirosystems/clarinet-sdk",
-      "version": "2.4.0-beta5",
+      "version": "2.4.0",
       "license": "GPL-3.0",
       "dependencies": {
+        "@hirosystems/clarinet-sdk": "^2.3.2",
         "@hirosystems/clarinet-sdk-wasm": "^2.4.0-beta5",
         "@stacks/encryption": "^6.12.0",
         "@stacks/network": "^6.11.3",
@@ -380,10 +381,29 @@
         "node": ">=12"
       }
     },
+    "node_modules/@hirosystems/clarinet-sdk": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@hirosystems/clarinet-sdk/-/clarinet-sdk-2.3.2.tgz",
+      "integrity": "sha512-l3g9NSf8nGoOwONczLvHYVNOuuaNR1yuFPRTMhLfP+TE5F5q+UI+wtT98ZZSdCXDgTSg98Nc+f7DY67Ibx4yxw==",
+      "dependencies": {
+        "@hirosystems/clarinet-sdk-wasm": "^2.3.2",
+        "@stacks/transactions": "^6.12.0",
+        "kolorist": "^1.8.0",
+        "prompts": "^2.4.2",
+        "vitest": "^1.0.4",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "clarinet-sdk": "dist/cjs/bin/index.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@hirosystems/clarinet-sdk-wasm": {
-      "version": "2.4.0-beta5",
-      "resolved": "https://registry.npmjs.org/@hirosystems/clarinet-sdk-wasm/-/clarinet-sdk-wasm-2.4.0-beta5.tgz",
-      "integrity": "sha512-QnBqbpL8utQ5DtCTD1nD5GidDxVh/+k1sSxLPXIKnwseNGLBkXK8bqzxCq+JCajoAObSBfUcVmI2UptnAZZCBA=="
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@hirosystems/clarinet-sdk-wasm/-/clarinet-sdk-wasm-2.4.0.tgz",
+      "integrity": "sha512-qApXWsnWRtQcj5BsqoKd+AsEtDURA5CJQcRxgCAVjyRSjkbGJXxNgrW9oRnIkfIIKJ6D5mV7JGrr8CQ8BSJ/tg=="
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",

--- a/components/clarinet-sdk/package-lock.json
+++ b/components/clarinet-sdk/package-lock.json
@@ -1,16 +1,15 @@
 {
   "name": "@hirosystems/clarinet-sdk",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hirosystems/clarinet-sdk",
-      "version": "2.4.0",
+      "version": "2.4.1",
       "license": "GPL-3.0",
       "dependencies": {
-        "@hirosystems/clarinet-sdk": "^2.3.2",
-        "@hirosystems/clarinet-sdk-wasm": "^2.4.0-beta5",
+        "@hirosystems/clarinet-sdk-wasm": "^2.4.0",
         "@stacks/encryption": "^6.12.0",
         "@stacks/network": "^6.11.3",
         "@stacks/stacking": "^6.11.4-pr.36558cf.0",
@@ -379,25 +378,6 @@
       ],
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/@hirosystems/clarinet-sdk": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@hirosystems/clarinet-sdk/-/clarinet-sdk-2.3.2.tgz",
-      "integrity": "sha512-l3g9NSf8nGoOwONczLvHYVNOuuaNR1yuFPRTMhLfP+TE5F5q+UI+wtT98ZZSdCXDgTSg98Nc+f7DY67Ibx4yxw==",
-      "dependencies": {
-        "@hirosystems/clarinet-sdk-wasm": "^2.3.2",
-        "@stacks/transactions": "^6.12.0",
-        "kolorist": "^1.8.0",
-        "prompts": "^2.4.2",
-        "vitest": "^1.0.4",
-        "yargs": "^17.7.2"
-      },
-      "bin": {
-        "clarinet-sdk": "dist/cjs/bin/index.js"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@hirosystems/clarinet-sdk-wasm": {

--- a/components/clarinet-sdk/package.json
+++ b/components/clarinet-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hirosystems/clarinet-sdk",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "A SDK to interact with Clarity Smart Contracts",
   "homepage": "https://docs.hiro.so/clarinet/feature-guides/clarinet-js-sdk",
   "repository": {
@@ -58,8 +58,7 @@
   "license": "GPL-3.0",
   "readme": "./README.md",
   "dependencies": {
-    "@hirosystems/clarinet-sdk": "^2.3.2",
-    "@hirosystems/clarinet-sdk-wasm": "^2.4.0-beta5",
+    "@hirosystems/clarinet-sdk-wasm": "^2.4.0",
     "@stacks/encryption": "^6.12.0",
     "@stacks/network": "^6.11.3",
     "@stacks/stacking": "^6.11.4-pr.36558cf.0",

--- a/components/clarinet-sdk/package.json
+++ b/components/clarinet-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hirosystems/clarinet-sdk",
-  "version": "2.4.0-beta5",
+  "version": "2.4.0",
   "description": "A SDK to interact with Clarity Smart Contracts",
   "homepage": "https://docs.hiro.so/clarinet/feature-guides/clarinet-js-sdk",
   "repository": {
@@ -58,6 +58,7 @@
   "license": "GPL-3.0",
   "readme": "./README.md",
   "dependencies": {
+    "@hirosystems/clarinet-sdk": "^2.3.2",
     "@hirosystems/clarinet-sdk-wasm": "^2.4.0-beta5",
     "@stacks/encryption": "^6.12.0",
     "@stacks/network": "^6.11.3",


### PR DESCRIPTION
### Description

Update @hirosytems/clarinet-sdk version (for the manual release on npm)

