### PR TITLE
Allow requirements for contracts deployed with multisig

### DIFF
--- a/components/clarinet-deployments/src/requirements.rs
+++ b/components/clarinet-deployments/src/requirements.rs
@@ -57,7 +57,7 @@ pub async fn retrieve_contract(
         ));
     }
 
-    let is_mainnet = contract_deployer.starts_with("SP");
+    let is_mainnet = contract_deployer.starts_with("SP") || contract_deployer.starts_with("SM");
     let stacks_node_addr = if is_mainnet {
         "https://api.hiro.so".to_string()
     } else {


### PR DESCRIPTION
### Description

Calling `clarinet check` fails when the Clarinet.toml file includes requirements with contracts deployed from a multisg.

### Example

https://github.com/lisalab-io/liquid-stacking/pull/39
---

### Checklist

- [ ] Tests added in this PR (if applicable)

