### PR TITLE
feat: add new features to hiro-system-kit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2251,6 +2251,7 @@ dependencies = [
  "slog-json",
  "slog-scope",
  "slog-term",
+ "time",
  "tokio",
 ]
 

--- a/components/hiro-system-kit/Cargo.toml
+++ b/components/hiro-system-kit/Cargo.toml
@@ -18,6 +18,7 @@ slog-scope = { version = "4.4.0", optional = true }
 slog-term = { version = "2.9.0", optional = true }
 slog-async = { version = "2.7.0", optional = true }
 slog-atomic = { version = "3.1.0", optional = true }
+time = "0.3.34"
 
 [features]
 default = ["tokio_helpers"]

--- a/components/hiro-system-kit/Cargo.toml
+++ b/components/hiro-system-kit/Cargo.toml
@@ -33,4 +33,4 @@ log = [
 debug = ["log", "slog/max_level_trace", "slog/release_max_level_debug"]
 release = ["log", "slog/max_level_info", "slog/release_max_level_info"]
 release_debug = ["log", "slog/max_level_trace", "slog/release_max_level_debug"]
-full_level_prefix = []
+full_log_level_prefix = []

--- a/components/hiro-system-kit/Cargo.toml
+++ b/components/hiro-system-kit/Cargo.toml
@@ -33,3 +33,4 @@ log = [
 debug = ["log", "slog/max_level_trace", "slog/release_max_level_debug"]
 release = ["log", "slog/max_level_info", "slog/release_max_level_info"]
 release_debug = ["log", "slog/max_level_trace", "slog/release_max_level_debug"]
+full_level_prefix = []

--- a/components/hiro-system-kit/Cargo.toml
+++ b/components/hiro-system-kit/Cargo.toml
@@ -32,3 +32,4 @@ log = [
 ]
 debug = ["log", "slog/max_level_trace", "slog/release_max_level_debug"]
 release = ["log", "slog/max_level_info", "slog/release_max_level_info"]
+release_debug = ["log", "slog/max_level_trace", "slog/release_max_level_debug"]

--- a/components/hiro-system-kit/src/log/mod.rs
+++ b/components/hiro-system-kit/src/log/mod.rs
@@ -14,7 +14,7 @@ pub fn setup_logger() -> Logger {
     if cfg!(feature = "release") || cfg!(feature = "release_debug") {
         let drain = slog_json::Json::new(std::io::stderr()).add_default_keys();
 
-        let drain = if cfg!(feature = "full_level_prefix") {
+        let drain = if cfg!(feature = "full_log_level_prefix") {
             drain.add_key_value(o!(
                 "level" => FnValue(move |rinfo : &Record| {
                     rinfo.level().as_str()
@@ -28,7 +28,7 @@ pub fn setup_logger() -> Logger {
     } else {
         let decorator = slog_term::TermDecorator::new().build();
         let drain = slog_term::FullFormat::new(decorator);
-        let drain = if cfg!(feature = "full_level_prefix") {
+        let drain = if cfg!(feature = "full_log_level_prefix") {
             drain
                 .use_custom_header_print(custom_print_msg_header)
                 .build()

--- a/components/hiro-system-kit/src/log/mod.rs
+++ b/components/hiro-system-kit/src/log/mod.rs
@@ -1,4 +1,4 @@
-use slog::{o, Drain, FnValue, Logger, Record};
+use slog::{o, Drain, FnValue, Logger, Record, LOG_LEVEL_NAMES};
 use slog_async;
 use slog_atomic::AtomicSwitch;
 use slog_scope::GlobalLoggerGuard;
@@ -17,7 +17,7 @@ pub fn setup_logger() -> Logger {
         let drain = if cfg!(feature = "full_log_level_prefix") {
             drain.add_key_value(o!(
                 "level" => FnValue(move |rinfo : &Record| {
-                    rinfo.level().as_str()
+                    LOG_LEVEL_NAMES[rinfo.level().as_usize()]
                 }),
             ))
         } else {
@@ -54,7 +54,7 @@ pub fn custom_print_msg_header(
 
     rd.start_level()?;
     if cfg!(feature = "full_log_level_prefix") {
-        write!(rd, "{}", record.level().as_str())?;
+        write!(rd, "{}", LOG_LEVEL_NAMES[record.level().as_usize()])?;
     } else {
         write!(rd, "{}", record.level().as_short_str())?;
     }

--- a/components/hiro-system-kit/src/log/mod.rs
+++ b/components/hiro-system-kit/src/log/mod.rs
@@ -1,9 +1,10 @@
-use slog::{o, Drain, Logger};
+use slog::{o, Drain, FnValue, Logger, Record};
 use slog_async;
 use slog_atomic::AtomicSwitch;
 use slog_scope::GlobalLoggerGuard;
-use slog_term;
-use std::sync::Mutex;
+use slog_term::{self, CountingWriter, RecordDecorator, ThreadSafeTimestampFn};
+use std::io::Write;
+use std::{io, sync::Mutex};
 
 pub fn setup_global_logger(logger: Logger) -> GlobalLoggerGuard {
     slog_scope::set_global_logger(logger)
@@ -11,15 +12,67 @@ pub fn setup_global_logger(logger: Logger) -> GlobalLoggerGuard {
 
 pub fn setup_logger() -> Logger {
     if cfg!(feature = "release") || cfg!(feature = "release_debug") {
-        Logger::root(
-            Mutex::new(slog_json::Json::default(std::io::stderr())).map(slog::Fuse),
-            slog::o!(),
-        )
+        let drain = slog_json::Json::new(std::io::stderr()).add_default_keys();
+
+        let drain = if cfg!(feature = "full_level_prefix") {
+            drain.add_key_value(o!(
+                "level" => FnValue(move |rinfo : &Record| {
+                    rinfo.level().as_str()
+                }),
+            ))
+        } else {
+            drain
+        };
+
+        Logger::root(Mutex::new(drain.build()).map(slog::Fuse), slog::o!())
     } else {
         let decorator = slog_term::TermDecorator::new().build();
-        let drain = Mutex::new(slog_term::FullFormat::new(decorator).build()).fuse();
+        let drain = slog_term::FullFormat::new(decorator);
+        let drain = if cfg!(feature = "full_level_prefix") {
+            drain
+                .use_custom_header_print(custom_print_msg_header)
+                .build()
+        } else {
+            drain.build()
+        };
+        let drain = Mutex::new(drain).fuse();
         let drain = slog_async::Async::new(drain).build().fuse();
         let drain = AtomicSwitch::new(drain);
         Logger::root(drain.fuse(), o!())
     }
+}
+
+pub fn custom_print_msg_header(
+    fn_timestamp: &dyn ThreadSafeTimestampFn<Output = io::Result<()>>,
+    mut rd: &mut dyn RecordDecorator,
+    record: &Record,
+    use_file_location: bool,
+) -> io::Result<bool> {
+    rd.start_timestamp()?;
+    fn_timestamp(&mut rd)?;
+
+    rd.start_whitespace()?;
+    write!(rd, " ")?;
+
+    rd.start_level()?;
+    write!(rd, "{}", record.level().as_str())?;
+
+    if use_file_location {
+        rd.start_location()?;
+        write!(
+            rd,
+            "[{}:{}:{}]",
+            record.location().file,
+            record.location().line,
+            record.location().column
+        )?;
+    }
+
+    rd.start_whitespace()?;
+    write!(rd, " ")?;
+
+    rd.start_msg()?;
+    let mut count_rd = CountingWriter::new(&mut rd);
+    write!(count_rd, "{}", record.msg())?;
+    Ok(count_rd.count() != 0)
 }

--- a/components/hiro-system-kit/src/log/mod.rs
+++ b/components/hiro-system-kit/src/log/mod.rs
@@ -10,7 +10,7 @@ pub fn setup_global_logger(logger: Logger) -> GlobalLoggerGuard {
 }
 
 pub fn setup_logger() -> Logger {
-    if cfg!(feature = "release") {
+    if cfg!(feature = "release") || cfg!(feature = "release_debug") {
         Logger::root(
             Mutex::new(slog_json::Json::default(std::io::stderr())).map(slog::Fuse),
             slog::o!(),


### PR DESCRIPTION
Chainhook needs a debug log level that still uses slog_json when built in release mode. This PR adds a new feature to accomplish this.

Additionally, Grafana has set [log levels](https://grafana.com/docs/grafana/latest/explore/logs-integration/#log-level) that it uses for parsing logs. Currently the devops team has [custom patches](https://github.com/hirosystems/chainhook/pull/524#issuecomment-2023392097) to support parsing logs from hiro system kit, because it abbreviates log prefixes in weird ways (`DEBUG` => `DEBG`, `ERROR` => `ERRO`). This PR also adds a feature, `full_log_level_prefix`, which just has slog log the full prefix, which will allow devops to remove this custom patches.