### PR TITLE
chore: update pox-4.clar

### DIFF
--- a/components/clarity-repl/src/repl/boot/pox-4.clar
+++ b/components/clarity-repl/src/repl/boot/pox-4.clar
@@ -316,7 +316,6 @@
           (some delegation-info))))
 
 ;; Get the size of the reward set for a reward cycle.
-;; Note that this does _not_ return duplicate PoX addresses.
 ;; Note that this also _will_ return PoX addresses that are beneath
 ;; the minimum threshold -- i.e. the threshold can increase after insertion.
 ;; Used internally by the Stacks node, which filters out the entries
@@ -563,7 +562,7 @@
 ;; * The Stacker will receive rewards in the reward cycle following `start-burn-ht`.
 ;; Importantly, `start-burn-ht` may not be further into the future than the next reward cycle,
 ;; and in most cases should be set to the current burn block height.
-;;
+;; 
 ;; To ensure that the Stacker is authorized to use the provided `signer-key`, the stacker
 ;; must provide either a signature have an authorization already saved. Refer to
 ;; `verify-signer-key-sig` for more information.
@@ -665,6 +664,12 @@
                 (err ERR_STACKING_INVALID_POX_ADDRESS))
          true)
 
+      (match pox-addr
+         pox-tuple
+            (asserts! (check-pox-addr-hashbytes (get version pox-tuple) (get hashbytes pox-tuple))
+                (err ERR_STACKING_INVALID_POX_ADDRESS))
+         true)
+
       ;; tx-sender must not be delegating
       (asserts! (is-none (get-check-delegation tx-sender))
         (err ERR_STACKING_ALREADY_DELEGATED))
@@ -711,7 +716,7 @@
 ;; the lock period are inflexible, which means that the stacker must confirm their transaction
 ;; during the exact reward cycle and with the exact period that the signature or authorization was
 ;; generated for.
-;;
+;; 
 ;; The `amount` field is checked to ensure it is not larger than `max-amount`, which is
 ;; a field in the authorization. `auth-id` is a random uint to prevent authorization
 ;; replays.
@@ -723,7 +728,7 @@
 ;; When `signer-sig` is present, the public key is recovered from the signature
 ;; and compared to `signer-key`. If `signer-sig` is `none`, the function verifies that an authorization was previously
 ;; added for this key.
-;;
+;; 
 ;; This function checks to ensure that the authorization hasn't been used yet, but it
 ;; does _not_ store the authorization as used. The function `consume-signer-key-authorization`
 ;; handles that, and this read-only function is exposed for client-side verification.
@@ -873,7 +878,11 @@
 ;;
 (define-public (stack-aggregation-increase (pox-addr { version: (buff 1), hashbytes: (buff 32) })
                                            (reward-cycle uint)
-                                           (reward-cycle-index uint))
+                                           (reward-cycle-index uint)
+                                           (signer-sig (optional (buff 65)))
+                                           (signer-key (buff 33))
+                                           (max-amount uint)
+                                           (auth-id uint))
   (let ((partial-stacked
          ;; fetch the partial commitments
          (unwrap! (map-get? partial-stacked-by-cycle { pox-addr: pox-addr, sender: tx-sender, reward-cycle: reward-cycle })
@@ -887,21 +896,22 @@
     (asserts! (> reward-cycle (current-pox-reward-cycle))
               (err ERR_STACKING_INVALID_LOCK_PERIOD))
 
-    (let ((amount-ustx (get stacked-amount partial-stacked))
+    (let ((partial-amount-ustx (get stacked-amount partial-stacked))
           ;; reward-cycle must point to an existing record in reward-cycle-total-stacked
           ;; infallible; getting something from partial-stacked-by-cycle succeeded so this must succeed
-          (existing-total (unwrap-panic (map-get? reward-cycle-total-stacked { reward-cycle: reward-cycle })))
+          (existing-cycle (unwrap-panic (map-get? reward-cycle-total-stacked { reward-cycle: reward-cycle })))
           ;; reward-cycle and reward-cycle-index must point to an existing record in reward-cycle-pox-address-list
           (existing-entry (unwrap! (map-get? reward-cycle-pox-address-list { reward-cycle: reward-cycle, index: reward-cycle-index })
                           (err ERR_DELEGATION_NO_REWARD_SLOT)))
-          (increased-ustx (+ (get total-ustx existing-entry) amount-ustx))
-          (total-ustx (+ (get total-ustx existing-total) amount-ustx)))
+          (increased-entry-total (+ (get total-ustx existing-entry) partial-amount-ustx))
+          (increased-cycle-total (+ (get total-ustx existing-cycle) partial-amount-ustx))
+          (existing-signer-key (get signer existing-entry)))
 
           ;; must be stackable
-          (try! (minimal-can-stack-stx pox-addr total-ustx reward-cycle u1))
+          (try! (minimal-can-stack-stx pox-addr increased-entry-total reward-cycle u1))
 
           ;; new total must exceed the stacking minimum
-          (asserts! (<= (get-stacking-minimum) total-ustx)
+          (asserts! (<= (get-stacking-minimum) increased-entry-total)
                     (err ERR_STACKING_THRESHOLD_NOT_MET))
 
           ;; there must *not* be a stacker entry (since this is a delegator)
@@ -912,19 +922,28 @@
           (asserts! (is-eq pox-addr (get pox-addr existing-entry))
                     (err ERR_DELEGATION_WRONG_REWARD_SLOT))
 
+          ;; Validate that amount is less than or equal to `max-amount`
+          (asserts! (>= max-amount increased-entry-total) (err ERR_SIGNER_AUTH_AMOUNT_TOO_HIGH))
+
+          ;; Validate that signer-key matches the existing signer-key
+          (asserts! (is-eq existing-signer-key signer-key) (err ERR_INVALID_SIGNER_KEY))
+
+          ;; Verify signature from delegate that allows this sender for this cycle
+          ;; 'lock-period' param set to one period, same as aggregation-commit-indexed
+          (try! (consume-signer-key-authorization pox-addr reward-cycle "agg-increase" u1 signer-sig signer-key increased-entry-total max-amount auth-id))
+
           ;; update the pox-address list -- bump the total-ustx
           (map-set reward-cycle-pox-address-list
                    { reward-cycle: reward-cycle, index: reward-cycle-index }
                    { pox-addr: pox-addr,
-                     total-ustx: increased-ustx,
+                     total-ustx: increased-entry-total,
                      stacker: none,
-                     ;; TODO: this must be authorized with a signature, or tx-sender allowance!
-                     signer: (get signer existing-entry) })
+                     signer: signer-key })
 
           ;; update the total ustx in this cycle
           (map-set reward-cycle-total-stacked
                    { reward-cycle: reward-cycle }
-                   { total-ustx: total-ustx })
+                   { total-ustx: increased-cycle-total })
 
           ;; don't update the stacking-state map,
           ;;  because it _already has_ this stacker's state
@@ -1063,10 +1082,10 @@
 ;; *New in Stacks 2.1*
 ;; This method locks up an additional amount of STX from `tx-sender`'s, indicated
 ;; by `increase-by`.  The `tx-sender` must already be Stacking & must not be
-;; straddling more than one signer-key for the cycles effected.
+;; straddling more than one signer-key for the cycles effected. 
 ;; Refer to `verify-signer-key-sig` for more information on the authorization parameters
 ;; included here.
-(define-public (stack-increase
+(define-public (stack-increase 
   (increase-by uint)
   (signer-sig (optional (buff 65)))
   (signer-key (buff 33))
@@ -1125,7 +1144,7 @@
 ;; This method extends the `tx-sender`'s current lockup for an additional `extend-count`
 ;;    and associates `pox-addr` with the rewards, The `signer-key` will be the key
 ;;    used for signing. The `tx-sender` can thus decide to change the key when extending.
-;;
+;; 
 ;; Because no additional STX are locked in this function, the `amount` field used
 ;; to verify the signer key authorization is zero. Refer to `verify-signer-key-sig` for more information.
 (define-public (stack-extend (extend-count uint)
@@ -1160,9 +1179,6 @@
 
     ;; Verify signature from delegate that allows this sender for this cycle
     (try! (consume-signer-key-authorization pox-addr cur-cycle "stack-extend" extend-count signer-sig signer-key u0 max-amount auth-id))
-
-    ;; TODO: add more assertions to sanity check the `stacker-info` values with
-    ;;       the `stacker-state` values
 
     (let ((last-extend-cycle  (- (+ first-extend-cycle extend-count) u1))
           (lock-period (+ u1 (- last-extend-cycle first-reward-cycle)))
@@ -1421,6 +1437,9 @@
                                              (max-amount uint)
                                              (auth-id uint))
   (begin
+    ;; must be called directly by the tx-sender or by an allowed contract-caller
+    (asserts! (check-caller-allowed)
+      (err ERR_NOT_ALLOWED))
     ;; Validate that `tx-sender` has the same pubkey hash as `signer-key`
     (asserts! (is-eq
       (unwrap! (principal-construct? (if is-in-mainnet STACKS_ADDR_VERSION_MAINNET STACKS_ADDR_VERSION_TESTNET) (hash160 signer-key)) (err ERR_INVALID_SIGNER_KEY))

--- a/components/clarity-repl/src/repl/boot/signers-voting.clar
+++ b/components/clarity-repl/src/repl/boot/signers-voting.clar
@@ -148,7 +148,7 @@
             (cached-weight (try! (get-and-cache-total-weight reward-cycle)))
             (threshold-weight (get-threshold-weight reward-cycle))
             (current-round (default-to {
-                votes-count: u0,
+                votes-count: u0, 
                 votes-weight: u0} (map-get? round-data {reward-cycle: reward-cycle, round: round})))
                 )
         ;; Check that the key has not yet been set for this reward cycle

--- a/components/clarity-repl/src/repl/boot/signers.clar
+++ b/components/clarity-repl/src/repl/boot/signers.clar
@@ -12,7 +12,7 @@
 ;; Called internally by the Stacks node.
 ;; Stores the stackerdb signer slots for a given reward cycle.
 ;; Since there is one stackerdb per signer message, the `num-slots` field will always be u1.
-(define-private (stackerdb-set-signer-slots
+(define-private (stackerdb-set-signer-slots 
                    (signer-slots (list 4000 { signer: principal, num-slots: uint }))
                    (reward-cycle uint)
                    (set-at-height uint))
@@ -43,7 +43,7 @@
             (err ERR_NO_SUCH_PAGE))))
 
 ;; Get a signer's signing weight by a given index.
-;; Used by other contracts (e.g. the voting contract)
+;; Used by other contracts (e.g. the voting contract) 
 (define-read-only (get-signer-by-index (cycle uint) (signer-index uint))
 	(ok (element-at (unwrap! (map-get? cycle-signer-set cycle) (err ERR_CYCLE_NOT_SET)) signer-index)))
 
@@ -52,7 +52,7 @@
 (define-read-only (stackerdb-get-config)
 	(ok
 		{ chunk-size: CHUNK_SIZE,
-		  write-freq: u0,
+		  write-freq: u0, 
 		  max-writes: MAX_WRITES,
 		  max-neighbors: u32,
 		  hint-replicas: (list ) }


### PR DESCRIPTION
### Description

Update pox-4.clar with the latest changes.
Update signers.clar and signer-voting.clar so that they are exactly the same as they are in stacks-core (with the extra spaces)