### PR TITLE
chore: clarity-sdk-wasm v2.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "clarinet-sdk-wasm"
-version = "2.4.1"
+version = "2.4.2"
 dependencies = [
  "clarinet-deployments",
  "clarinet-files",

--- a/components/clarinet-sdk-wasm/Cargo.toml
+++ b/components/clarinet-sdk-wasm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "clarinet-sdk-wasm"
-version = "2.4.1"
+version = "2.4.2"
 license = "GPL-3.0"
 repository = "https://github.com/hirosystems/clarinet"
 description = "The core lib that powers @hirosystems/clarinet-sdk"


### PR DESCRIPTION
### Description

Patch release of clarinet-sdk-wasm to include the updated pox-4.clar contract (#1409)
The clarinet-sdk doesn't need to be updated for this one
