### PR TITLE
fix: allow epoch 2.5 in clarinet-sdk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "clarinet-sdk-wasm"
-version = "2.4.2"
+version = "2.4.3"
 dependencies = [
  "clarinet-deployments",
  "clarinet-files",

--- a/components/clarinet-sdk-wasm/Cargo.toml
+++ b/components/clarinet-sdk-wasm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "clarinet-sdk-wasm"
-version = "2.4.2"
+version = "2.4.3"
 license = "GPL-3.0"
 repository = "https://github.com/hirosystems/clarinet"
 description = "The core lib that powers @hirosystems/clarinet-sdk"

--- a/components/clarinet-sdk-wasm/src/core.rs
+++ b/components/clarinet-sdk-wasm/src/core.rs
@@ -39,7 +39,7 @@ use crate::utils::events::serialize_event;
 
 #[wasm_bindgen(typescript_custom_section)]
 const SET_EPOCH: &'static str = r#"
-type EpochString = "2.0" | "2.05" | "2.1" | "2.2" | "2.3" | "2.4" | "3.0"
+type EpochString = "2.0" | "2.05" | "2.1" | "2.2" | "2.3" | "2.4" | "2.5" | "3.0"
 "#;
 
 #[wasm_bindgen]


### PR DESCRIPTION
### Description

Fix and release clarinet-sdk-wasm
This fix doesn't require a change on clarinet-sdk
