### PR TITLE
fix: improve error message in sdk custom matchers

### DIFF
--- a/components/clarinet-sdk/vitest-helpers/src/clarityValuesMatchers.ts
+++ b/components/clarinet-sdk/vitest-helpers/src/clarityValuesMatchers.ts
@@ -120,7 +120,7 @@ function checkCVType<T extends ClarityType>(
     // for readability, the error diff is kept short if the developers uses the wrong `expect<ClarityType>`
     // ideally, we should have a way to display short message diffs even if the actual and/or expected data are big lists/tuples/buffers
 
-    // for now, we make and exception and display the full error message if the actual value is a ResponseErr
+    // for now, we make an exception and display the full error message if the actual value is a ResponseErr
     const errorCode = actual.type === ClarityType.ResponseErr ? ` ${Cl.prettyPrint(actual)}` : "";
 
     throw new ClarityTypeError({

--- a/components/clarinet-sdk/vitest-helpers/src/clarityValuesMatchers.ts
+++ b/components/clarinet-sdk/vitest-helpers/src/clarityValuesMatchers.ts
@@ -117,10 +117,17 @@ function checkCVType<T extends ClarityType>(
   const isCVWithType = isClarityValueWithType(actual, expectedType);
 
   if (!isCVWithType) {
+    // for readability, the error diff is kept short if the developers uses the wrong `expect<ClarityType>`
+    // ideally, we should have a way to display short message diffs even if the actual and/or expected data are big lists/tuples/buffers
+
+    // for now, we make and exception and display the full error message if the actual value is a ResponseErr
+    const errorCode = actual.type === ClarityType.ResponseErr ? ` ${Cl.prettyPrint(actual)}` : "";
+
     throw new ClarityTypeError({
+      // generic and short message
       message: `actual value must ${notStr(isNot)}be a Clarity "${
         ClarityType[expectedType]
-      }", received "${ClarityType[actual.type]}"`,
+      }", received "${ClarityType[actual.type]}"${errorCode}`,
       actual: ClarityType[actual.type],
       expected: ClarityType[expectedType],
     });

--- a/components/clarinet-sdk/vitest-helpers/tests/clarityValueMatchers.test.ts
+++ b/components/clarinet-sdk/vitest-helpers/tests/clarityValueMatchers.test.ts
@@ -424,7 +424,7 @@ describe("test nested types", () => {
     });
   });
 
-  it("display values on one line in message", () => {
+  it("displays values on one line in message", () => {
     const failingTest = () =>
       expect(Cl.ok(Cl.tuple({ counter: Cl.uint(1) }))).toBeOk(Cl.tuple({ counter: Cl.uint(2) }));
 
@@ -435,5 +435,21 @@ describe("test nested types", () => {
       expect(e.actual).toBe("(ok {\n  counter: u1\n})");
       expect(e.expected).toBe("(ok {\n  counter: u2\n})");
     }
+  });
+
+  it("displays short message of the matchers does not match the actual clarity type", () => {
+    const value = Cl.ok(Cl.uint(1));
+    const failingTest = () => expect(value).toBeList([]);
+
+    expect(failingTest).toThrow('actual value must be a Clarity "List", received "ResponseOk"');
+  });
+
+  it("displays error code even if `err` is not the expected type", () => {
+    const value = Cl.error(Cl.uint(1));
+    const failingTest = () => expect(value).toBeOk(Cl.tuple({ counter: Cl.uint(2) }));
+
+    expect(failingTest).toThrow(
+      'actual value must be a Clarity "ResponseOk", received "ResponseErr" (err u1)',
+    );
   });
 });


### PR DESCRIPTION
### Description

When using the sdk with vitest, if the custom matcher expects the wrong types, we keep error messages short
(eg: `expect(Cl.uint(1)).toBeOk(Cl.uint(1))` will throw `actual value must be a Clarity "UInt", received "ResponseOk"`)

This should be improved to display a more detailed error diff, but it requires some more work so that the error message remain readable, even when the test is handling big set of data (such as big lists or buffers).

This PR simply handle a quick fix for the common case were `expectOk` actually receive a ResponseError. We should display the received error