### PR TITLE
ci: fix homebrew release

### DIFF
--- a/.github/workflows/pkg-version-bump.yaml
+++ b/.github/workflows/pkg-version-bump.yaml
@@ -27,6 +27,10 @@ jobs:
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GH_TOKEN }}
           TAG: ${{ github.event.client_payload.tag || github.event.inputs.tag }}
         run: |
+          # Get version info
+          $VERSION=${env:TAG}.substring(1)
+
+          # Configure git configs
           git config --global user.name "${GIT_USER_NAME}"
           git config --global user.email "${GIT_USER_EMAIL}"
 
@@ -36,6 +40,7 @@ jobs:
             --no-audit \
             --force \
             --tag "${TAG}" \
+            --version ${VERSION} \
             ${{ github.event.repository.name }}
 
   winget:
@@ -46,7 +51,7 @@ jobs:
         env:
           TAG: ${{ github.event.client_payload.tag || github.event.inputs.tag }}
         run: |
-          # Get version infoq
+          # Get version info
           $VERSION=${env:TAG}.substring(1)
 
           # Configure git configs

--- a/.github/workflows/pkg-version-bump.yaml
+++ b/.github/workflows/pkg-version-bump.yaml
@@ -28,7 +28,7 @@ jobs:
           TAG: ${{ github.event.client_payload.tag || github.event.inputs.tag }}
         run: |
           # Get version info
-          $VERSION=${env:TAG}.substring(1)
+          VERSION=$(echo "${ENV#v}")
 
           # Configure git configs
           git config --global user.name "${GIT_USER_NAME}"

--- a/.github/workflows/pkg-version-bump.yaml
+++ b/.github/workflows/pkg-version-bump.yaml
@@ -40,7 +40,7 @@ jobs:
             --no-audit \
             --force \
             --tag "${TAG}" \
-            --version ${VERSION} \
+            --version "${VERSION}" \
             ${{ github.event.repository.name }}
 
   winget:


### PR DESCRIPTION
### Description

The release actions failed on the homebrew step for clarinet 2.5.0:
https://github.com/hirosystems/clarinet/actions/runs/8690598712
With the error:
```
Invalid usage: clarinet: no `--url` or `--version` argument specified!
```

I was able [to open the homebrew PR](https://github.com/Homebrew/homebrew-core/pull/169081) by running this command locally:
```console
brew bump-formula-pr \
  --no-browse \
  --no-audit \
  --force \
  --tag 22e10c2f004ebdc3d07cd475844eaa4d11ebbb75 \
  --version 2.5.0 \
  clarinet
```

Looks like there was a breaking change in the bump-formula-pr command