### PR TITLE
chore: remove jupyter kernel from workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -557,7 +557,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "hex 0.4.3",
+ "hex",
  "http 1.1.0",
  "http-body-util",
  "hyper 1.2.0",
@@ -682,7 +682,7 @@ dependencies = [
  "dashmap",
  "futures",
  "fxhash",
- "hex 0.4.3",
+ "hex",
  "hiro-system-kit 0.3.4",
  "hyper 0.14.27",
  "lazy_static",
@@ -707,7 +707,7 @@ name = "chainhook-types"
 version = "1.3.7"
 source = "git+https://github.com/hirosystems/chainhook.git?branch=feat/update-pox-default-settings#5490923ea2a208e98b6bda20b5c913dd0c6194a6"
 dependencies = [
- "hex 0.4.3",
+ "hex",
  "schemars",
  "serde",
  "serde_derive",
@@ -827,7 +827,7 @@ dependencies = [
  "encoding_rs",
  "futures",
  "fwdansi",
- "hex 0.4.3",
+ "hex",
  "hiro-system-kit 0.1.0",
  "hmac 0.12.1",
  "lazy_static",
@@ -875,7 +875,7 @@ dependencies = [
  "clarinet-files",
  "clarinet-utils",
  "clarity-repl",
- "colored 2.1.0",
+ "colored",
  "libsecp256k1 0.7.1",
  "reqwest",
  "serde",
@@ -916,7 +916,7 @@ dependencies = [
  "clarinet-deployments",
  "clarinet-files",
  "clarity-repl",
- "colored 2.1.0",
+ "colored",
  "console_error_panic_hook",
  "gloo-utils",
  "js-sys",
@@ -971,27 +971,6 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "toml 0.5.11",
-]
-
-[[package]]
-name = "clarity-jupyter-kernel"
-version = "1.0.0"
-dependencies = [
- "chrono",
- "clarity-repl",
- "colored 1.9.3",
- "dirs",
- "failure",
- "hex 0.3.2",
- "hmac 0.7.1",
- "json",
- "lazy_static",
- "regex",
- "ripemd160",
- "sha2 0.8.2",
- "sha3 0.8.2",
- "uuid",
- "zmq",
 ]
 
 [[package]]
@@ -1098,17 +1077,6 @@ name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
-
-[[package]]
-name = "colored"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ffc801dacf156c5854b9df4f425a626539c3a6ef7893cc0c5084a23f0b6c59"
-dependencies = [
- "atty",
- "lazy_static",
- "winapi 0.3.9",
-]
 
 [[package]]
 name = "colored"
@@ -1775,12 +1743,6 @@ dependencies = [
 
 [[package]]
 name = "error-chain"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9435d864e017c3c6afeac1654189b06cdb491cf2ff73dbf0d73b0f292f42ff8"
-
-[[package]]
-name = "error-chain"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
@@ -1797,15 +1759,6 @@ checksum = "64f18991e7bf11e7ffee451b5318b5c1a73c52d0d0ada6e5a3017c8c1ced6a21"
 dependencies = [
  "libc",
  "str-buf",
-]
-
-[[package]]
-name = "failure"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
-dependencies = [
- "backtrace",
 ]
 
 [[package]]
@@ -2238,12 +2191,6 @@ checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hex"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
-
-[[package]]
-name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
@@ -2473,7 +2420,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
 dependencies = [
- "hex 0.4.3",
+ "hex",
  "hyper 1.2.0",
  "hyper-util",
  "pin-project-lite",
@@ -2522,7 +2469,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acf569d43fa9848e510358c07b80f4adf34084ddc28c6a4a651ee8474c070dcc"
 dependencies = [
- "hex 0.4.3",
+ "hex",
  "http-body-util",
  "hyper 1.2.0",
  "hyper-util",
@@ -2740,12 +2687,6 @@ checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "json"
-version = "0.11.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92c245af8786f6ac35f95ca14feca9119e71339aaab41e878e7cdd655c97e9e5"
 
 [[package]]
 name = "jsonrpc"
@@ -3112,17 +3053,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93c0d11ac30a033511ae414355d80f70d9f29a44a49140face477117a1ee90db"
 
 [[package]]
-name = "metadeps"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73b122901b3a675fac8cecf68dcb2f0d3036193bc861d1ac0e1c337f7d5254c2"
-dependencies = [
- "error-chain 0.10.0",
- "pkg-config",
- "toml 0.2.1",
-]
-
-[[package]]
 name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3468,7 +3398,7 @@ dependencies = [
  "bitvec",
  "bs58 0.4.0",
  "cc",
- "hex 0.4.3",
+ "hex",
  "itertools 0.10.5",
  "num-traits",
  "primitive-types",
@@ -4128,17 +4058,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ripemd160"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad5112e0dbbb87577bfbc56c42450235e3012ce336e29c5befd7807bd626da4a"
-dependencies = [
- "block-buffer 0.7.3",
- "digest 0.8.1",
- "opaque-debug 0.2.3",
-]
-
-[[package]]
 name = "rocket"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4619,7 +4538,7 @@ checksum = "f58c3a1b3e418f61c25b2aeb43fc6c95eaa252b8cecdda67f401943e9e08d33f"
 dependencies = [
  "base64 0.21.7",
  "chrono",
- "hex 0.4.3",
+ "hex",
  "indexmap 1.9.2",
  "indexmap 2.2.3",
  "serde",
@@ -4692,19 +4611,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27ba7066011e3fb30d808b51affff34f0a66d3a03a58edd787c6e420e40e44e"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "sha3"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd26bc0e7a2e3a7c959bc494caf58b72ee0c71d67704e9520f736ca7e4853ecf"
-dependencies = [
- "block-buffer 0.7.3",
- "byte-tools",
- "digest 0.8.1",
- "keccak",
- "opaque-debug 0.2.3",
 ]
 
 [[package]]
@@ -5000,7 +4906,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha2 0.10.6",
- "sha3 0.10.6",
+ "sha3",
  "slog",
  "slog-json",
  "slog-term",
@@ -5031,7 +4937,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha2 0.10.6",
- "sha3 0.10.6",
+ "sha3",
  "slog",
  "slog-json",
  "slog-term",
@@ -5048,7 +4954,7 @@ dependencies = [
  "clarinet-files",
  "clarinet-utils",
  "crossbeam-channel",
- "error-chain 0.12.4",
+ "error-chain",
  "hiro-system-kit 0.1.0",
  "neon",
  "num",
@@ -5141,7 +5047,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha2 0.10.6",
- "sha3 0.10.6",
+ "sha3",
  "siphasher",
  "slog",
  "slog-term",
@@ -5517,12 +5423,6 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "736b60249cb25337bc196faa43ee12c705e426f3d55c214d73a4e7be06f92cb4"
-
-[[package]]
-name = "toml"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
@@ -5754,7 +5654,7 @@ checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
 dependencies = [
  "byteorder",
  "crunchy",
- "hex 0.4.3",
+ "hex",
  "static_assertions",
 ]
 
@@ -5852,9 +5752,6 @@ name = "uuid"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cfcd319456c4d6ea10087ed423473267e1a071f3bc0aa89f80d60997843c6f0"
-dependencies = [
- "getrandom 0.2.8",
-]
 
 [[package]]
 name = "valuable"
@@ -6669,7 +6566,7 @@ dependencies = [
  "aes-gcm",
  "bs58 0.5.0",
  "hashbrown 0.14.3",
- "hex 0.4.3",
+ "hex",
  "num-traits",
  "p256k1",
  "polynomial",
@@ -6734,28 +6631,6 @@ name = "zeroize"
 version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
-
-[[package]]
-name = "zmq"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aad98a7a617d608cd9e1127147f630d24af07c7cd95ba1533246d96cbdd76c66"
-dependencies = [
- "bitflags 1.3.2",
- "libc",
- "log",
- "zmq-sys",
-]
-
-[[package]]
-name = "zmq-sys"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d33a2c51dde24d5b451a2ed4b488266df221a5eaee2ee519933dc46b9a9b3648"
-dependencies = [
- "libc",
- "metadeps",
-]
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ members = [
     "components/clarinet-files",
     "components/clarinet-utils",
     "components/clarinet-sdk-wasm",
-    "components/clarity-jupyter-kernel",
     "components/clarity-lsp",
     "components/clarity-repl",
     "components/clarity-events",


### PR DESCRIPTION
### Description

The `clarity-jupyter-kernel` component is unmaintained.
Maybe we could fully remove it, or keep it maintain it some day. In the meantime, it can safely be removed from the workspace.

It simplifies the cargo.lock file and remove some very old dependencies. Especially `failure` which trigger `Critical` [dependabot alerts on this repo](https://github.com/hirosystems/clarinet/security/dependabot).

Other than that, this PR has no impact.
