### PR TITLE
chore: update 2.5 constants

### DIFF
--- a/components/clarinet-deployments/src/requirements.rs
+++ b/components/clarinet-deployments/src/requirements.rs
@@ -126,8 +126,8 @@ pub const MAINNET_21_START_HEIGHT: u32 = 99_113;
 pub const MAINNET_22_START_HEIGHT: u32 = 103_900;
 pub const MAINNET_23_START_HEIGHT: u32 = 104_359;
 pub const MAINNET_24_START_HEIGHT: u32 = 107_055;
-// @TODO: set right heights once epochs are live on mainnet
-pub const MAINNET_25_START_HEIGHT: u32 = 200_000;
+pub const MAINNET_25_START_HEIGHT: u32 = 147_290;
+// @TODO: set right heights once live on mainnet
 pub const MAINNET_30_START_HEIGHT: u32 = 300_000;
 
 pub const TESTNET_20_START_HEIGHT: u32 = 1;
@@ -137,7 +137,7 @@ pub const TESTNET_22_START_HEIGHT: u32 = 105_923;
 pub const TESTNET_23_START_HEIGHT: u32 = 106_196;
 pub const TESTNET_24_START_HEIGHT: u32 = 106_979;
 pub const TESTNET_25_START_HEIGHT: u32 = 152_256;
-// @TODO: set right heights once epochs are live on testnet
+// @TODO: set right heights once live on testnet
 pub const TESTNET_30_START_HEIGHT: u32 = 300_000;
 
 fn epoch_for_height(is_mainnet: bool, height: u32) -> StacksEpochId {

--- a/components/clarity-repl/src/repl/mod.rs
+++ b/components/clarity-repl/src/repl/mod.rs
@@ -25,7 +25,7 @@ use clarity::types::StacksEpochId;
 use clarity::vm::ClarityVersion;
 
 pub const DEFAULT_CLARITY_VERSION: ClarityVersion = ClarityVersion::Clarity2;
-pub const DEFAULT_EPOCH: StacksEpochId = StacksEpochId::Epoch24;
+pub const DEFAULT_EPOCH: StacksEpochId = StacksEpochId::Epoch25;
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct ClarityContract {


### PR DESCRIPTION
### Description

- Make 2.5 he default epoch 
- Set 2.5 block height: https://explorer.hiro.so/block/0x813e5b09c962905439fb21b5969e826b7a0f744f70ee80b2d7a8a00341d95f8c?chain=mainnet