### PR TITLE
fix: improved sdk deployment plan handling and perf improvements

### DIFF
--- a/components/clarinet-deployments/src/lib.rs
+++ b/components/clarinet-deployments/src/lib.rs
@@ -55,6 +55,7 @@ pub fn setup_session_with_deployment(
 ) -> DeploymentGenerationArtifacts {
     let mut session = initiate_session_from_deployment(manifest);
     update_session_with_genesis_accounts(&mut session, deployment);
+    // session.load_boot_contracts();
     let UpdateSessionExecutionResult { contracts, .. } = update_session_with_contracts_executions(
         &mut session,
         deployment,
@@ -120,7 +121,6 @@ pub fn update_session_with_genesis_accounts(
                 session.set_tx_sender(wallet.address.to_address());
             }
         }
-        session.load_boot_contracts();
     }
 }
 

--- a/components/clarinet-deployments/src/lib.rs
+++ b/components/clarinet-deployments/src/lib.rs
@@ -55,7 +55,6 @@ pub fn setup_session_with_deployment(
 ) -> DeploymentGenerationArtifacts {
     let mut session = initiate_session_from_deployment(manifest);
     update_session_with_genesis_accounts(&mut session, deployment);
-    // session.load_boot_contracts();
     let UpdateSessionExecutionResult { contracts, .. } = update_session_with_contracts_executions(
         &mut session,
         deployment,

--- a/components/clarinet-deployments/src/types.rs
+++ b/components/clarinet-deployments/src/types.rs
@@ -1144,7 +1144,7 @@ impl DeploymentSpecification {
         })
     }
 
-    fn to_specification_file(&self) -> DeploymentSpecificationFile {
+    pub fn to_specification_file(&self) -> DeploymentSpecificationFile {
         DeploymentSpecificationFile {
             id: Some(self.id),
             name: self.name.clone(),
@@ -1247,6 +1247,12 @@ impl DeploymentSpecificationFile {
         let spec_file_content = file_accesor.read_file(path.to_string()).await?;
 
         serde_yaml::from_str(&spec_file_content)
+            .map_err(|msg| format!("unable to read file {}", msg))
+    }
+    pub fn from_file_content(
+        spec_file_content: &str,
+    ) -> Result<DeploymentSpecificationFile, String> {
+        serde_yaml::from_str(spec_file_content)
             .map_err(|msg| format!("unable to read file {}", msg))
     }
 }

--- a/components/clarinet-deployments/src/types.rs
+++ b/components/clarinet-deployments/src/types.rs
@@ -98,6 +98,19 @@ pub struct TransactionsBatchSpecificationFile {
     pub epoch: Option<EpochSpec>,
 }
 
+impl TransactionsBatchSpecificationFile {
+    pub fn remove_publish_transactions(&mut self) {
+        self.transactions.retain(|transaction| {
+            !matches!(
+                transaction,
+                TransactionSpecificationFile::RequirementPublish(_)
+                    | TransactionSpecificationFile::ContractPublish(_)
+                    | TransactionSpecificationFile::EmulatedContractPublish(_)
+            )
+        });
+    }
+}
+
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum TransactionSpecificationFile {
@@ -1032,8 +1045,7 @@ impl DeploymentSpecification {
                                             .get(&contract_path)
                                             .cloned()
                                             .unwrap_or_else(|| panic!("missing contract source for {}", spec.path.clone().unwrap_or_default()))
-                                    }
-                                    );
+                                    });
 
                                     let spec = EmulatedContractPublishSpecification::from_specifications(spec, project_root_location, source)?;
                                     let contract_id = QualifiedContractIdentifier::new(spec.emulated_sender.clone(), spec.contract_name.clone());

--- a/components/clarinet-sdk-wasm/src/core.rs
+++ b/components/clarinet-sdk-wasm/src/core.rs
@@ -267,7 +267,6 @@ pub struct SDK {
     current_test_name: String,
 }
 
-#[allow(non_snake_case)]
 #[wasm_bindgen]
 impl SDK {
     #[wasm_bindgen(constructor)]
@@ -343,6 +342,14 @@ impl SDK {
             Some(StacksEpochId::Epoch21),
         )
         .await?;
+
+        if !artifacts.success {
+            let diags_digest = DiagnosticsDigest::new(&artifacts.diags, &deployment);
+            if diags_digest.errors > 0 {
+                return Err(diags_digest.message);
+            }
+        }
+
         if self
             .file_accessor
             .file_exists(deployment_plan_location.to_string())
@@ -368,13 +375,6 @@ impl SDK {
             )?;
 
             deployment.merge_batches(existing_deployment.plan.batches);
-        }
-
-        if artifacts.success {
-            let diags_digest = DiagnosticsDigest::new(&artifacts.diags, &deployment);
-            if diags_digest.errors > 0 {
-                return Err(diags_digest.message);
-            }
         }
 
         self.write_deployment_plan(&deployment, &project_root, &deployment_plan_location)

--- a/components/clarinet-sdk-wasm/src/core.rs
+++ b/components/clarinet-sdk-wasm/src/core.rs
@@ -362,7 +362,7 @@ impl SDK {
 
             let mut spec_file = DeploymentSpecificationFile::from_file_content(&spec_file_content)?;
 
-            // the contract publish txs are management by the manifest
+            // the contract publish txs are managed by the manifest
             // keep the user added txs and merge them with the default deployment plan
             if let Some(ref mut plan) = spec_file.plan {
                 for batch in plan.batches.iter_mut() {

--- a/components/clarinet-sdk/tests/deployment-plan.test.ts
+++ b/components/clarinet-sdk/tests/deployment-plan.test.ts
@@ -1,11 +1,11 @@
 import fs from "node:fs";
 import path from "node:path";
-import { describe, expect, it, beforeEach, afterEach, assert } from "vitest";
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
 
 // test the built package and not the source code
 // makes it simpler to handle wasm build
 import { initSimnet } from "../dist/esm";
-import { Cl, cvToHex, hexToCV } from "@stacks/transactions";
+import { Cl } from "@stacks/transactions";
 
 const nbOfBootContracts = 24;
 
@@ -85,14 +85,11 @@ describe("deployment plans test", async () => {
     );
     const manifestContent = fs.readFileSync("tests/fixtures/Clarinet.toml", "utf-8");
     const newContent = manifestContent.replace("counter.clar", "_counter.clar");
-    console.log(manifestContent);
     fs.writeFileSync("tests/fixtures/Clarinet.toml", newContent);
 
-    try {
-      await initSimnet("tests/fixtures/Clarinet.toml", true);
-    } catch (e) {
-      console.log("e", e);
-    }
+    const simnet = await initSimnet("tests/fixtures/Clarinet.toml", true);
+    const contractInterfaces = simnet.getContractsInterfaces();
+    expect(contractInterfaces.get(`${simnet.deployer}.counter`)).toBeDefined();
 
     // revert the changes
     fs.renameSync(

--- a/components/clarinet-sdk/tests/simnet-usage.test.ts
+++ b/components/clarinet-sdk/tests/simnet-usage.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
-import { Cl, cvToValue } from "@stacks/transactions";
-import { describe, expect, it, beforeEach, afterEach, assert } from "vitest";
+import { Cl } from "@stacks/transactions";
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
 
 // test the built package and not the source code
 // makes it simpler to handle wasm build
@@ -86,7 +86,6 @@ describe("simnet can run arbitrary snippets", () => {
 
   it("show diagnostic in case of error", () => {
     const res = simnet.runSnippet("(+ 1 u2)");
-    console.log("res", res);
     expect(res).toBe("error:\nexpecting expression of type 'int', found 'uint'");
   });
 });

--- a/components/clarinet-sdk/tests/simnet-usage.test.ts
+++ b/components/clarinet-sdk/tests/simnet-usage.test.ts
@@ -63,7 +63,8 @@ describe("basic simnet interactions", () => {
   });
 
   it("can get and set epoch", () => {
-    // should be 2.4 by default
+    // should be 2.4 at the beginning because
+    // the latest contract in the manifest is deployed in 2.4
     expect(simnet.currentEpoch).toBe("2.4");
 
     simnet.setEpoch("2.0");
@@ -71,9 +72,9 @@ describe("basic simnet interactions", () => {
 
     // @ts-ignore
     // "0" is an invalid epoch
-    // it logs that 0 is invalid and defaults to 2.4
+    // it logs that 0 is invalid and defaults to 2.5
     simnet.setEpoch("0");
-    expect(simnet.currentEpoch).toBe("2.4");
+    expect(simnet.currentEpoch).toBe("2.5");
   });
 });
 

--- a/components/clarity-repl/src/analysis/coverage_tests.rs
+++ b/components/clarity-repl/src/analysis/coverage_tests.rs
@@ -11,7 +11,8 @@ fn get_coverage_report(contract: &str, snippets: Vec<String>) -> (TestCoverageRe
         let _ = session.eval(snippet, Some(vec![&mut report]), false);
     }
 
-    let (contract_id, ast) = session.asts.pop_first().unwrap();
+    let (contract_id, contract) = session.contracts.pop_first().unwrap();
+    let ast = contract.ast;
 
     let mut coverage_reporter = CoverageReporter::new();
     coverage_reporter

--- a/components/clarity-repl/src/repl/session.rs
+++ b/components/clarity-repl/src/repl/session.rs
@@ -645,7 +645,7 @@ impl Session {
             args,
             self.current_epoch,
             clarity_version,
-            true,
+            false,
             allow_private,
             Some(hooks),
         ) {

--- a/components/clarity-repl/src/repl/session.rs
+++ b/components/clarity-repl/src/repl/session.rs
@@ -641,7 +641,7 @@ impl Session {
             args,
             self.current_epoch,
             clarity_version,
-            false,
+            true,
             allow_private,
             Some(hooks),
         ) {


### PR DESCRIPTION
### Description

Fix #1435

This PR started as a bug fix, but as I worked on it, I found that I could get massive perf improvements.

In the SDK `init_session`, some data is cached. Before this PR, just de deployment was cached.
But the **whole session** can actually be cached. It reduces file system access by a lot (in a Vitest context, we now only need to read the manifest and contract once) and reduce the time spent parsing contracts.

On my machine (M1), the cached `init_session` go from more than 100ms to a few ms (the time taken for `cache.clone()`). And knowing that `init_session` is called before each test, it takes the time to run tests in a project like pox-4 testing down from 32sec to 6secs

It also reworks a bit the session and the SDK structs