### PR TITLE
refactor: fix clippy warnings in tests

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,10 +1,8 @@
 {
-  "rust-analyzer.check.overrideCommand": [
-    "cargo",
-    "clippy",
-    "--workspace",
+  "rust-analyzer.check.command": "clippy",
+  "rust-analyzer.check.workspace": true,
+  "rust-analyzer.check.extraArgs": [
     "--exclude=clarinet-sdk-wasm",
-    "--exclude=clarity-jupyter-kernel",
-    "--message-format=json"
+    "--exclude=clarity-jupyter-kernel"
   ]
 }

--- a/components/clarinet-cli/src/frontend/cli.rs
+++ b/components/clarinet-cli/src/frontend/cli.rs
@@ -1858,16 +1858,11 @@ mod tests {
                 let mut cmd = Opts::command();
                 generate(shell, &mut cmd, "clarinet", &mut output_buffer);
                 assert!(
-                    output_buffer.len() > 0,
-                    "failed to generate completion for {}",
-                    shell.to_string()
+                    !output_buffer.is_empty(),
+                    "failed to generate completion for {shell}",
                 );
             });
-            assert!(
-                result.is_ok(),
-                "failed to generate completion for {}",
-                shell.to_string()
-            );
+            assert!(result.is_ok(), "failed to generate completion for {shell}",);
         }
     }
 }

--- a/components/clarinet-deployments/src/deployment_plan_test.rs
+++ b/components/clarinet-deployments/src/deployment_plan_test.rs
@@ -2,8 +2,7 @@ use std::collections::BTreeMap;
 
 use clarinet_files::{chainhook_types::StacksNetwork, FileLocation};
 use clarity_repl::clarity::{
-    vm::types::{QualifiedContractIdentifier, StandardPrincipalData},
-    ClarityName, ClarityVersion, ContractName,
+    vm::types::QualifiedContractIdentifier, ClarityName, ClarityVersion, ContractName,
 };
 
 use crate::types::*;
@@ -12,7 +11,7 @@ fn get_test_txs() -> (TransactionSpecification, TransactionSpecification) {
     let contract_id =
         QualifiedContractIdentifier::parse("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.test")
             .unwrap();
-    let tx_sender = StandardPrincipalData::from(contract_id.issuer.clone());
+    let tx_sender = contract_id.issuer.clone();
 
     let contract_publish_tx =
         TransactionSpecification::EmulatedContractPublish(EmulatedContractPublishSpecification {

--- a/components/clarity-lsp/src/common/requests/completion.rs
+++ b/components/clarity-lsp/src/common/requests/completion.rs
@@ -903,7 +903,7 @@ mod populate_snippet_with_options_tests {
         let snippet = data.populate_snippet_with_options(
             &ClarityVersion::Clarity2,
             &"var-get".to_string(),
-            &"var-get ${1:var}".to_string(),
+            "var-get ${1:var}",
         );
         assert_eq!(snippet, Some("var-get ${1|counter,is-active|}".to_string()));
     }
@@ -914,7 +914,7 @@ mod populate_snippet_with_options_tests {
         let snippet = data.populate_snippet_with_options(
             &ClarityVersion::Clarity2,
             &"map-get?".to_string(),
-            &"map-get? ${1:map-name} ${2:key-tuple}".to_string(),
+            "map-get? ${1:map-name} ${2:key-tuple}",
         );
         assert_eq!(
             snippet,
@@ -928,7 +928,7 @@ mod populate_snippet_with_options_tests {
         let snippet = data.populate_snippet_with_options(
             &ClarityVersion::Clarity2,
             &"ft-mint?".to_string(),
-            &"ft-mint? ${1:token-name} ${2:amount} ${3:recipient}".to_string(),
+            "ft-mint? ${1:token-name} ${2:amount} ${3:recipient}",
         );
         assert_eq!(
             snippet,
@@ -942,7 +942,7 @@ mod populate_snippet_with_options_tests {
         let snippet = data.populate_snippet_with_options(
             &ClarityVersion::Clarity2,
             &"nft-mint?".to_string(),
-            &"nft-mint? ${1:asset-name} ${2:asset-identifier} ${3:recipient}".to_string(),
+            "nft-mint? ${1:asset-name} ${2:asset-identifier} ${3:recipient}",
         );
         assert_eq!(
             snippet,

--- a/components/clarity-lsp/src/common/requests/definitions.rs
+++ b/components/clarity-lsp/src/common/requests/definitions.rs
@@ -605,7 +605,7 @@ mod definitions_visitor_tests {
             clarity_repl::clarity::ast::ASTRules::Typical,
         )
         .unwrap();
-        return contract_ast.expressions;
+        contract_ast.expressions
     }
 
     fn get_tokens(sources: &str) -> HashMap<(u32, u32), DefinitionLocation> {
@@ -669,7 +669,7 @@ mod definitions_visitor_tests {
     #[test]
     fn find_data_var_definition() {
         let tokens = get_tokens(
-            vec![
+            [
                 "(define-data-var var1 int 1)",
                 "(var-get var1)",
                 "(var-set var1 2)",
@@ -693,7 +693,7 @@ mod definitions_visitor_tests {
     #[test]
     fn find_map_definition() {
         let tokens = get_tokens(
-            vec![
+            [
                 "(define-map owners int principal)",
                 "(map-insert owners 1 tx-sender)",
                 "(map-get? owners 1)",
@@ -727,7 +727,7 @@ mod definitions_visitor_tests {
     #[test]
     fn find_ft_definition() {
         let tokens = get_tokens(
-            vec![
+            [
                 "(define-fungible-token ft u1)",
                 "(ft-mint? ft u1 tx-sender)",
                 "(ft-burn? ft u1 tx-sender)",

--- a/components/clarity-lsp/src/common/requests/document_symbols.rs
+++ b/components/clarity-lsp/src/common/requests/document_symbols.rs
@@ -530,10 +530,10 @@ mod tests {
     // ranges are painful to test and just reflects the `span`s
     // of the ast, it can be safe to not test it
     fn to_partial(symbol: &DocumentSymbol) -> PartialDocumentSymbol {
-        let children = match &symbol.children {
-            Some(children) => Some(children.iter().map(|child| to_partial(child)).collect()),
-            None => None,
-        };
+        let children = symbol
+            .children
+            .as_ref()
+            .map(|children| children.iter().map(to_partial).collect());
         PartialDocumentSymbol {
             name: symbol.name.to_string(),
             detail: symbol.detail.clone(),
@@ -553,7 +553,7 @@ mod tests {
         )
         .unwrap();
 
-        return contract_ast.expressions;
+        contract_ast.expressions
     }
 
     fn get_symbols(source: &str) -> Vec<DocumentSymbol> {
@@ -568,7 +568,7 @@ mod tests {
         assert_eq!(
             symbols,
             vec![build_symbol(
-                &"impl-trait".to_owned(),
+                "impl-trait",
                 Some("sip-010-trait".to_owned()),
                 ClaritySymbolKind::IMPL_TRAIT,
                 &new_span(1, 1, 1, 95),
@@ -583,7 +583,7 @@ mod tests {
         assert_eq!(
             symbols,
             vec![build_symbol(
-                &"next-id".to_owned(),
+                "next-id",
                 Some("uint".to_owned()),
                 ClaritySymbolKind::VARIABLE,
                 &new_span(1, 1, 1, 33),
@@ -598,7 +598,7 @@ mod tests {
         assert_eq!(
             symbols,
             vec![build_symbol(
-                &"data".to_owned(),
+                "data",
                 Some("list".to_owned()),
                 ClaritySymbolKind::VARIABLE,
                 &new_span(1, 1, 1, 46),
@@ -610,7 +610,7 @@ mod tests {
     #[test]
     fn test_data_var_tuple() {
         let symbols = get_symbols(
-            vec![
+            [
                 "(define-data-var owners",
                 "  { addr: principal, p: int }",
                 "  { addr: contract-caller, p: 1 }",
@@ -628,7 +628,7 @@ mod tests {
     #[test]
     fn test_data_var_nested_tuple() {
         let symbols = get_symbols(
-            vec![
+            [
                 "(define-data-var names",
                 "  { id: { addr: principal, name: (string-ascii 10) }, qt: int }",
                 "  {",
@@ -652,7 +652,7 @@ mod tests {
         assert_eq!(
             symbols,
             vec![build_symbol(
-                &"ERR_PANIC".to_owned(),
+                "ERR_PANIC",
                 None,
                 ClaritySymbolKind::CONSTANT,
                 &new_span(1, 1, 1, 29),
@@ -664,7 +664,7 @@ mod tests {
         assert_eq!(
             symbols,
             vec![build_symbol(
-                &"ERR_PANIC".to_owned(),
+                "ERR_PANIC",
                 None,
                 ClaritySymbolKind::CONSTANT,
                 &new_span(1, 1, 1, 35),
@@ -680,18 +680,18 @@ mod tests {
         assert_eq!(
             to_partial(&symbols[0]),
             build_partial_symbol(
-                &"owners".to_owned(),
+                "owners",
                 None,
                 ClaritySymbolKind::MAP,
                 Some(vec![
                     build_partial_symbol(
-                        &"key".to_owned(),
+                        "key",
                         Some("principal".to_owned()),
                         ClaritySymbolKind::KEY,
                         None
                     ),
                     build_partial_symbol(
-                        &"value".to_owned(),
+                        "value",
                         Some("tuple".to_owned()),
                         ClaritySymbolKind::VALUE,
                         None
@@ -703,7 +703,7 @@ mod tests {
 
     #[test]
     fn test_define_functions() {
-        let source = vec![
+        let source = [
             "(define-read-only (get-id) (ok u1))",
             "(define-public (get-id-again) (ok u1))",
             "(define-private (set-id (new-id uint)) (ok u1))",
@@ -716,7 +716,7 @@ mod tests {
         assert_eq!(
             symbols[0],
             build_symbol(
-                &"get-id".to_owned(),
+                "get-id",
                 Some("read-only".to_owned()),
                 ClaritySymbolKind::FUNCTION,
                 &new_span(1, 1, 1, 35),
@@ -733,7 +733,7 @@ mod tests {
         assert_eq!(
             symbols[1],
             build_symbol(
-                &"get-id-again".to_owned(),
+                "get-id-again",
                 Some("public".to_owned()),
                 ClaritySymbolKind::FUNCTION,
                 &new_span(2, 1, 2, 38),
@@ -750,7 +750,7 @@ mod tests {
         assert_eq!(
             symbols[2],
             build_symbol(
-                &"set-id".to_owned(),
+                "set-id",
                 Some("private".to_owned()),
                 ClaritySymbolKind::FUNCTION,
                 &new_span(3, 1, 3, 47),
@@ -791,7 +791,7 @@ mod tests {
     #[test]
     fn test_let() {
         let symbols = get_symbols(
-            vec![
+            [
                 "(define-public (with-let)",
                 "  (let ((id u1))",
                 "    (ok id)))",
@@ -841,7 +841,7 @@ mod tests {
     #[test]
     fn test_define_trait() {
         let symbols = get_symbols(
-            vec![
+            [
                 "(define-trait my-trait (",
                 "  (get-id () (response uint uint))",
                 "  (set-id () (response bool uint))",
@@ -853,18 +853,18 @@ mod tests {
         assert_eq!(
             to_partial(&symbols[0]),
             build_partial_symbol(
-                &"my-trait".to_owned(),
+                "my-trait",
                 None,
                 ClaritySymbolKind::TRAIT,
                 Some(vec![
                     build_partial_symbol(
-                        &"get-id".to_owned(),
+                        "get-id",
                         Some("trait method".to_owned()),
                         ClaritySymbolKind::FUNCTION,
                         None
                     ),
                     build_partial_symbol(
-                        &"set-id".to_owned(),
+                        "set-id",
                         Some("trait method".to_owned()),
                         ClaritySymbolKind::FUNCTION,
                         None

--- a/components/clarity-lsp/src/common/requests/signature_help.rs
+++ b/components/clarity-lsp/src/common/requests/signature_help.rs
@@ -98,7 +98,7 @@ mod definitions_visitor_tests {
         position: &Position,
     ) -> Option<Vec<lsp_types::SignatureInformation>> {
         let contract = &ActiveContractData::new(Clarity2, Epoch21, None, source);
-        get_signatures(&contract, position)
+        get_signatures(contract, position)
     }
 
     #[test]
@@ -115,7 +115,7 @@ mod definitions_visitor_tests {
         let signatures = signatures.unwrap();
         assert_eq!(signatures.len(), 1);
         assert_eq!(
-            signatures.get(0).unwrap(),
+            signatures.first().unwrap(),
             &SignatureInformation {
                 label: "(var-set var-name expr1) -> bool".to_string(),
                 documentation: None,
@@ -149,7 +149,7 @@ mod definitions_visitor_tests {
                 "begin",
                 "tuple",
             ]
-            .contains(&method)
+            .contains(method)
             {
                 continue;
             }

--- a/components/clarity-repl/src/repl/interpreter.rs
+++ b/components/clarity-repl/src/repl/interpreter.rs
@@ -1456,7 +1456,7 @@ mod tests {
         let diagnostics = result.unwrap_err();
         assert_eq!(diagnostics.len(), 1);
 
-        let message = format!("Runtime Error: Runtime error while interpreting {}.{}: Runtime(DivisionByZero, Some([FunctionIdentifier {{ identifier: \"_native_:native_div\" }}]))", StandardPrincipalData::transient().to_string(), contract.name);
+        let message = format!("Runtime Error: Runtime error while interpreting {}.{}: Runtime(DivisionByZero, Some([FunctionIdentifier {{ identifier: \"_native_:native_div\" }}]))", StandardPrincipalData::transient(), contract.name);
         assert_eq!(
             diagnostics[0],
             Diagnostic {
@@ -1562,7 +1562,7 @@ mod tests {
             issuer: StandardPrincipalData::transient(),
             name: "contract".into(),
         };
-        let count = interpreter.get_data_var(&contract_id, &"count");
+        let count = interpreter.get_data_var(&contract_id, "count");
 
         assert_eq!(
             count,
@@ -1596,9 +1596,9 @@ mod tests {
             issuer: StandardPrincipalData::transient(),
             name: "contract".into(),
         };
-        let name = interpreter.get_map_entry(&contract_id, &"people", &Value::UInt(0));
+        let name = interpreter.get_map_entry(&contract_id, "people", &Value::UInt(0));
         assert_eq!(name, Some("0x0a0d000000077361746f736869".to_owned()));
-        let no_name = interpreter.get_map_entry(&contract_id, &"people", &Value::UInt(404));
+        let no_name = interpreter.get_map_entry(&contract_id, "people", &Value::UInt(404));
         assert_eq!(no_name, None);
     }
 
@@ -1771,8 +1771,10 @@ mod tests {
 
     #[test]
     fn can_run_boot_contracts() {
-        let mut repl_settings = Settings::default();
-        repl_settings.clarity_wasm_mode = true;
+        let repl_settings = Settings {
+            clarity_wasm_mode: true,
+            ..Default::default()
+        };
         let mut interpreter =
             ClarityInterpreter::new(StandardPrincipalData::transient(), repl_settings);
 
@@ -1784,10 +1786,9 @@ mod tests {
             }
             let res = interpreter
                 .run(&boot_contract, &mut Some(ast), false, None)
-                .expect(&format!(
-                    "failed to interpret {} boot contract",
-                    &boot_contract.name
-                ));
+                .unwrap_or_else(|_| {
+                    panic!("failed to interpret {} boot contract", &boot_contract.name)
+                });
 
             assert!(res.diagnostics.is_empty());
         }
@@ -1816,7 +1817,7 @@ mod tests {
             &contract
                 .expect_resolved_contract_identifier(Some(&StandardPrincipalData::transient())),
             "public-func",
-            &vec![],
+            &[],
             StacksEpochId::Epoch24,
             ClarityVersion::Clarity2,
             false,
@@ -1855,7 +1856,7 @@ mod tests {
             &contract
                 .expect_resolved_contract_identifier(Some(&StandardPrincipalData::transient())),
             "private-func",
-            &vec![],
+            &[],
             StacksEpochId::Epoch24,
             ClarityVersion::Clarity2,
             false,
@@ -1894,7 +1895,7 @@ mod tests {
             &contract
                 .expect_resolved_contract_identifier(Some(&StandardPrincipalData::transient())),
             "private-func",
-            &vec![],
+            &[],
             StacksEpochId::Epoch24,
             ClarityVersion::Clarity2,
             false,

--- a/components/clarity-repl/src/repl/session.rs
+++ b/components/clarity-repl/src/repl/session.rs
@@ -1307,6 +1307,7 @@ fn clarity_keywords() -> HashMap<String, String> {
     keywords
 }
 
+#[allow(clippy::items_after_test_module)]
 #[cfg(test)]
 mod tests {
     use crate::repl::{self, settings::Account};

--- a/components/stacks-network/src/chains_coordinator.rs
+++ b/components/stacks-network/src/chains_coordinator.rs
@@ -571,6 +571,7 @@ fn should_publish_stacking_orders(
     true
 }
 
+#[allow(clippy::items_after_test_module)]
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -591,72 +592,39 @@ mod tests {
         let pox_stacking_order = build_pox_stacking_order(12, 6);
 
         // cycle just before start_at_cycle
-        assert_eq!(
-            should_publish_stacking_orders(&5, &pox_stacking_order),
-            true
-        );
+        assert!(should_publish_stacking_orders(&5, &pox_stacking_order));
 
         // cycle before start_at_cycle + duration
-        assert_eq!(
-            should_publish_stacking_orders(&17, &pox_stacking_order),
-            true
-        );
+        assert!(should_publish_stacking_orders(&17, &pox_stacking_order),);
 
         // cycle before start_at_cycle + duration * 42
-        assert_eq!(
-            should_publish_stacking_orders(&509, &pox_stacking_order),
-            true
-        );
+        assert!(should_publish_stacking_orders(&509, &pox_stacking_order));
 
         // cycle equal to start_at_cycle
-        assert_eq!(
-            should_publish_stacking_orders(&6, &pox_stacking_order),
-            false
-        );
+        assert!(!should_publish_stacking_orders(&6, &pox_stacking_order));
 
         // cycle after to start_at_cycle
-        assert_eq!(
-            should_publish_stacking_orders(&8, &pox_stacking_order),
-            false
-        );
+        assert!(!should_publish_stacking_orders(&8, &pox_stacking_order));
     }
 
     #[test]
     fn test_should_publish_stacking_orders_edge_cases() {
         // duration is one cycle
         let pox_stacking_order = build_pox_stacking_order(1, 4);
-        assert_eq!(
-            should_publish_stacking_orders(&2, &pox_stacking_order),
-            false
-        );
+        assert!(!should_publish_stacking_orders(&2, &pox_stacking_order));
 
         for i in 3..=20 {
-            assert_eq!(
-                should_publish_stacking_orders(&i, &pox_stacking_order),
-                true
-            );
+            assert!(should_publish_stacking_orders(&i, &pox_stacking_order));
         }
 
         // duration is low and start_at_cycle is high
         let pox_stacking_order = build_pox_stacking_order(2, 100);
         for i in 0..=98 {
-            assert_eq!(
-                should_publish_stacking_orders(&i, &pox_stacking_order),
-                false
-            );
+            assert!(!should_publish_stacking_orders(&i, &pox_stacking_order));
         }
-        assert_eq!(
-            should_publish_stacking_orders(&99, &pox_stacking_order),
-            true
-        );
-        assert_eq!(
-            should_publish_stacking_orders(&100, &pox_stacking_order),
-            false
-        );
-        assert_eq!(
-            should_publish_stacking_orders(&101, &pox_stacking_order),
-            true
-        );
+        assert!(should_publish_stacking_orders(&99, &pox_stacking_order));
+        assert!(!should_publish_stacking_orders(&100, &pox_stacking_order));
+        assert!(should_publish_stacking_orders(&101, &pox_stacking_order));
     }
 }
 


### PR DESCRIPTION
### Description

Because of the way rust-analyzer was setup in .vscode/settings.json, clippy wasn't running on tests.
In the future, let's setup clippy in the CI as well, it shouldn't rely on the editor config
