### PR TITLE
fix: add options to enable or disable costs and coverage reports in sdk

### DIFF
--- a/components/clarinet-sdk/src/index.ts
+++ b/components/clarinet-sdk/src/index.ts
@@ -1,6 +1,7 @@
 import { Cl, ClarityValue } from "@stacks/transactions";
 import {
   SDK,
+  SDKOptions,
   TransactionRes,
   CallFnArgs,
   DeployContractArgs,
@@ -279,10 +280,15 @@ const getSessionProxy = () => ({
 function memoizedInit() {
   let simnet: Simnet | null = null;
 
-  return async (manifestPath = "./Clarinet.toml", noCache = false) => {
+  return async (
+    manifestPath = "./Clarinet.toml",
+    noCache = false,
+    options?: { trackCosts: boolean; trackCoverage: boolean },
+  ) => {
     if (noCache || !simnet) {
       const module = await wasmModule;
-      simnet = new Proxy(new module.SDK(vfs), getSessionProxy()) as unknown as Simnet;
+      let sdkOptions = new SDKOptions(!!options?.trackCosts, !!options?.trackCoverage);
+      simnet = new Proxy(new module.SDK(vfs, sdkOptions), getSessionProxy()) as unknown as Simnet;
     }
 
     // start a new simnet session

--- a/components/clarinet-sdk/tests/pox-locking.test.ts
+++ b/components/clarinet-sdk/tests/pox-locking.test.ts
@@ -122,7 +122,13 @@ describe("test pox-3", () => {
     );
   });
 
-  it("can get pox boot contract code coverage", () => {
+  it("can get pox boot contract code coverage", async () => {
+    const simnet = await initSimnet("tests/fixtures/Clarinet.toml", true, {
+      trackCoverage: true,
+      trackCosts: false,
+    });
+    simnet.setEpoch("2.4");
+
     const stackStxArgs = [
       Cl.uint(ustxAmount),
       Cl.tuple({

--- a/components/clarinet-sdk/tests/reports.test.ts
+++ b/components/clarinet-sdk/tests/reports.test.ts
@@ -1,0 +1,109 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+
+// test the built package and not the source code
+// makes it simpler to handle wasm build
+import { Simnet, initSimnet } from "../dist/esm";
+
+const address1 = "ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5";
+
+const deploymentPlanPath = path.join(
+  process.cwd(),
+  "tests/fixtures/deployments/default.simnet-plan.yaml",
+);
+
+function deleteExistingDeploymentPlan() {
+  if (fs.existsSync(deploymentPlanPath)) {
+    fs.unlinkSync(deploymentPlanPath);
+  }
+}
+
+beforeEach(async () => {
+  deleteExistingDeploymentPlan();
+});
+
+afterEach(() => {
+  deleteExistingDeploymentPlan();
+});
+
+describe("simnet can get code coverage", () => {
+  it("does not report coverage by default", async () => {
+    const simnet = await initSimnet("tests/fixtures/Clarinet.toml", true);
+
+    simnet.callPublicFn("counter", "increment", [], address1);
+
+    const reports = simnet.collectReport(false, "");
+    expect(reports.coverage.length).toBe(0);
+  });
+
+  it("reports coverage if enabled", async () => {
+    const simnet = await initSimnet("tests/fixtures/Clarinet.toml", true, {
+      trackCoverage: true,
+      trackCosts: false,
+    });
+
+    simnet.callPublicFn("counter", "increment", [], address1);
+    simnet.callPublicFn("counter", "increment", [], address1);
+    simnet.callPrivateFn("counter", "inner-increment", [], address1);
+
+    const reports = simnet.collectReport(false, "");
+
+    // increment is called twice
+    expect(reports.coverage.includes("FNDA:2,increment")).toBe(true);
+    // inner-increment is called one time directly and twice by `increment`
+    expect(reports.coverage.includes("FNDA:3,inner-increment")).toBe(true);
+
+    expect(reports.coverage.startsWith("TN:")).toBe(true);
+    expect(reports.coverage.endsWith("end_of_record\n")).toBe(true);
+  });
+});
+
+describe("simnet can get costs reports", () => {
+  it("does not report costs by default", async () => {
+    const simnet = await initSimnet("tests/fixtures/Clarinet.toml", true);
+    simnet.callPublicFn("counter", "increment", [], address1);
+
+    const reports = simnet.collectReport(false, "");
+    expect(() => JSON.parse(reports.costs)).not.toThrow();
+
+    const parsedReports = JSON.parse(reports.costs);
+    expect(parsedReports).toHaveLength(0);
+  });
+
+  it("report costs if enabled", async () => {
+    const simnet = await initSimnet("tests/fixtures/Clarinet.toml", true, {
+      trackCoverage: false,
+      trackCosts: true,
+    });
+    simnet.callPublicFn("counter", "increment", [], address1);
+
+    const reports = simnet.collectReport(false, "");
+    expect(() => JSON.parse(reports.costs)).not.toThrow();
+
+    const parsedReports = JSON.parse(reports.costs);
+    expect(parsedReports).toHaveLength(1);
+
+    const report = parsedReports[0];
+    expect(report.contract_id).toBe(`${simnet.deployer}.counter`);
+    expect(report.method).toBe("increment");
+    expect(report.cost_result.total.write_count).toBe(3);
+  });
+});
+
+describe("simnet can report both costs and coverage", () => {
+  it("can report both costs and coverage", async () => {
+    const simnet = await initSimnet("tests/fixtures/Clarinet.toml", true, {
+      trackCoverage: true,
+      trackCosts: true,
+    });
+    simnet.callPublicFn("counter", "increment", [], address1);
+
+    const reports = simnet.collectReport(false, "");
+
+    const parsedReports = JSON.parse(reports.costs);
+    expect(parsedReports).toHaveLength(1);
+
+    expect(reports.coverage.length).greaterThan(0);
+  });
+});

--- a/components/clarinet-sdk/tests/simnet-usage.test.ts
+++ b/components/clarinet-sdk/tests/simnet-usage.test.ts
@@ -327,39 +327,6 @@ describe("simnet can transfer stx", () => {
   });
 });
 
-describe("simnet can get session reports", () => {
-  it("can get line coverage", () => {
-    simnet.callPublicFn("counter", "increment", [], address1);
-    simnet.callPublicFn("counter", "increment", [], address1);
-    simnet.callPrivateFn("counter", "inner-increment", [], address1);
-
-    const reports = simnet.collectReport(false, "");
-
-    // increment is called twice
-    expect(reports.coverage.includes("FNDA:2,increment")).toBe(true);
-    // inner-increment is called one time directly and twice by `increment`
-    expect(reports.coverage.includes("FNDA:3,inner-increment")).toBe(true);
-
-    expect(reports.coverage.startsWith("TN:")).toBe(true);
-    expect(reports.coverage.endsWith("end_of_record\n")).toBe(true);
-  });
-
-  it("can get costs", () => {
-    simnet.callPublicFn("counter", "increment", [], address1);
-
-    const reports = simnet.collectReport(false, "");
-    expect(() => JSON.parse(reports.costs)).not.toThrow();
-
-    const parsedReports = JSON.parse(reports.costs);
-    expect(parsedReports).toHaveLength(1);
-
-    const report = parsedReports[0];
-    expect(report.contract_id).toBe(`${simnet.deployer}.counter`);
-    expect(report.method).toBe("increment");
-    expect(report.cost_result.total.write_count).toBe(3);
-  });
-});
-
 describe("the sdk handles multiple manifests project", () => {
   it("handle invalid project", () => {
     const manifestPath = path.join(process.cwd(), "tests/fixtures/contracts/invalid.clar");

--- a/components/clarity-repl/src/repl/interpreter.rs
+++ b/components/clarity-repl/src/repl/interpreter.rs
@@ -941,7 +941,7 @@ impl ClarityInterpreter {
         raw_args: &[Vec<u8>],
         epoch: StacksEpochId,
         clarity_version: ClarityVersion,
-        cost_track: bool,
+        track_costs: bool,
         allow_private: bool,
         eval_hooks: Option<Vec<&mut dyn EvalHook>>,
     ) -> Result<ExecutionResult, String> {
@@ -955,7 +955,7 @@ impl ClarityInterpreter {
         conn.set_clarity_epoch_version(epoch)
             .map_err(|e| e.to_string())?;
         conn.commit().map_err(|e| e.to_string())?;
-        let cost_tracker = if cost_track {
+        let cost_tracker = if track_costs {
             LimitedCostTracker::new(
                 false,
                 CHAIN_ID_TESTNET,
@@ -1020,7 +1020,7 @@ impl ClarityInterpreter {
         })?;
 
         let mut cost = None;
-        if cost_track {
+        if track_costs {
             cost = Some(CostSynthesis::from_cost_tracker(&global_context.cost_track));
         }
 

--- a/components/clarity-repl/src/repl/session.rs
+++ b/components/clarity-repl/src/repl/session.rs
@@ -617,6 +617,8 @@ impl Session {
         args: &[Vec<u8>],
         sender: &str,
         allow_private: bool,
+        track_costs: bool,
+        track_coverage: bool,
         test_name: String,
     ) -> Result<ExecutionResult, Vec<Diagnostic>> {
         let initial_tx_sender = self.get_tx_sender();
@@ -630,7 +632,9 @@ impl Session {
 
         let mut hooks: Vec<&mut dyn EvalHook> = vec![];
         let mut coverage = TestCoverageReport::new(test_name.clone());
-        hooks.push(&mut coverage);
+        if track_coverage {
+            hooks.push(&mut coverage);
+        }
 
         let clarity_version = ClarityVersion::default_for_epoch(self.current_epoch);
 
@@ -641,7 +645,7 @@ impl Session {
             args,
             self.current_epoch,
             clarity_version,
-            true,
+            track_costs,
             allow_private,
             Some(hooks),
         ) {
@@ -657,7 +661,10 @@ impl Session {
             }
         };
         self.set_tx_sender(initial_tx_sender);
-        self.coverage_reports.push(coverage);
+
+        if track_coverage {
+            self.coverage_reports.push(coverage);
+        }
 
         if let Some(ref cost) = execution.cost {
             self.costs_reports.push(CostsReport {


### PR DESCRIPTION
### Description

To be rebased on main and merged after #1437 

The sdk was always tracking costs and coverage reports even when it wasn't enabled.
By only enabling it when needed, we get better performance

