### PR TITLE
Upgrade rustyline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1028,6 +1028,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha2 0.10.6",
+ "test-case",
  "tokio",
  "tokio-util",
  "wasm-bindgen",
@@ -5153,6 +5154,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "test-case"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2550dd13afcd286853192af8601920d959b14c401fcece38071d53bf0768a8"
+dependencies = [
+ "test-case-macros",
+]
+
+[[package]]
+name = "test-case-core"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adcb7fd841cd518e279be3d5a3eb0636409487998a4aff22f3de87b81e88384f"
+dependencies = [
+ "cfg-if 1.0.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.50",
+]
+
+[[package]]
+name = "test-case-macros"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.50",
+ "test-case-core",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,6 +669,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
 name = "chainhook-sdk"
 version = "0.12.8"
 source = "git+https://github.com/hirosystems/chainhook.git?branch=feat/update-pox-default-settings#ec6fa6ec1ed020fc24be56be1671f3aed3bdd54c"
@@ -1030,13 +1036,11 @@ dependencies = [
 
 [[package]]
 name = "clipboard-win"
-version = "4.5.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7191c27c2357d9b7ef96baac1773290d4ca63b24205b82a3fd8a0637afcf0362"
+checksum = "d517d4b86184dbb111d3556a10f1c8a04da7428d2987bf1081602bf11c3aa9ee"
 dependencies = [
  "error-code",
- "str-buf",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1730,13 +1734,9 @@ dependencies = [
 
 [[package]]
 name = "error-code"
-version = "2.3.1"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64f18991e7bf11e7ffee451b5318b5c1a73c52d0d0ada6e5a3017c8c1ced6a21"
-dependencies = [
- "libc",
- "str-buf",
-]
+checksum = "a0474425d51df81997e2f90a21591180b38eccf27292d755f3e30750225c175b"
 
 [[package]]
 name = "fake-simd"
@@ -1770,13 +1770,13 @@ checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "fd-lock"
-version = "3.0.10"
+version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ef1a30ae415c3a691a4f41afddc2dbcd6d70baf338368d85ebc1e8ed92cedb9"
+checksum = "7e5768da2206272c81ef0b5e951a41862938a6070da63bcea197899942d3b947"
 dependencies = [
  "cfg-if 1.0.0",
- "rustix 0.36.16",
- "windows-sys 0.45.0",
+ "rustix",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2568,16 +2568,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-lifetimes"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1abeb7a0dd0f8181267ff8adc397075586500b81b28a73e8a0208b00fc170fb3"
-dependencies = [
- "libc",
- "windows-sys 0.45.0",
-]
-
-[[package]]
 name = "iovec"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2721,9 +2711,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.150"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libloading"
@@ -2889,12 +2879,6 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
-
-[[package]]
-name = "linux-raw-sys"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "969488b55f8ac402214f3f5fd243ebb7206cf82de60d3172994707a4bcc2b829"
@@ -3002,7 +2986,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2cffa4ad52c6f791f4f8b15f0c05f9824b2ced1160e88cc393d64fff9a8ac64"
 dependencies = [
- "rustix 0.38.25",
+ "rustix",
 ]
 
 [[package]]
@@ -3214,6 +3198,18 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "static_assertions",
+]
+
+[[package]]
+name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.4.0",
+ "cfg-if 1.0.0",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -4173,20 +4169,6 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6da3636faa25820d8648e0e31c5d519bbb01f72fdf57131f0f5f7da5fed36eab"
-dependencies = [
- "bitflags 1.3.2",
- "errno",
- "io-lifetimes",
- "libc",
- "linux-raw-sys 0.1.4",
- "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "rustix"
 version = "0.38.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc99bc2d4f1fed22595588a013687477aedf3cdcfb26558c559edb67b4d9b22e"
@@ -4194,7 +4176,7 @@ dependencies = [
  "bitflags 2.4.0",
  "errno",
  "libc",
- "linux-raw-sys 0.4.11",
+ "linux-raw-sys",
  "windows-sys 0.48.0",
 ]
 
@@ -4237,26 +4219,24 @@ checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
 
 [[package]]
 name = "rustyline"
-version = "9.1.2"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db7826789c0e25614b03e5a54a0717a86f9ff6e6e5247f92b369472869320039"
+checksum = "7803e8936da37efd9b6d4478277f4b2b9bb5cdb37a113e8d63222e58da647e63"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.0",
  "cfg-if 1.0.0",
  "clipboard-win",
- "dirs-next",
  "fd-lock",
+ "home",
  "libc",
  "log",
  "memchr",
- "nix 0.23.2",
+ "nix 0.28.0",
  "radix_trie",
- "scopeguard",
- "smallvec 1.13.1",
  "unicode-segmentation",
  "unicode-width",
  "utf8parse",
- "winapi 0.3.9",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5020,12 +5000,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
-name = "str-buf"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
-
-[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5157,7 +5131,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "fastrand",
  "redox_syscall 0.3.5",
- "rustix 0.38.25",
+ "rustix",
  "windows-sys 0.48.0",
 ]
 
@@ -5942,7 +5916,7 @@ dependencies = [
  "bincode",
  "directories-next",
  "log",
- "rustix 0.38.25",
+ "rustix",
  "serde",
  "serde_derive",
  "sha2 0.10.6",
@@ -6042,7 +6016,7 @@ dependencies = [
  "anyhow",
  "cc",
  "cfg-if 1.0.0",
- "rustix 0.38.25",
+ "rustix",
  "wasmtime-asm-macros",
  "wasmtime-versioned-export-macros",
  "windows-sys 0.48.0",
@@ -6064,7 +6038,7 @@ dependencies = [
  "log",
  "object 0.32.1",
  "rustc-demangle",
- "rustix 0.38.25",
+ "rustix",
  "serde",
  "serde_derive",
  "target-lexicon",
@@ -6083,7 +6057,7 @@ checksum = "4e0c4b74e606d1462d648631d5bc328e3d5b14e7f9d3ff93bc6db062fb8c5cd8"
 dependencies = [
  "object 0.32.1",
  "once_cell",
- "rustix 0.38.25",
+ "rustix",
  "wasmtime-versioned-export-macros",
 ]
 
@@ -6115,7 +6089,7 @@ dependencies = [
  "memoffset 0.9.0",
  "paste",
  "rand 0.8.5",
- "rustix 0.38.25",
+ "rustix",
  "sptr",
  "wasm-encoder 0.36.2",
  "wasmtime-asm-macros",

--- a/components/clarity-repl/Cargo.toml
+++ b/components/clarity-repl/Cargo.toml
@@ -63,6 +63,9 @@ reqwest = { version = "0.11", default-features = false, features = [
 wasm-bindgen = { version = "0.2.91", optional = true }
 wasm-bindgen-futures = { version = "0.4.41", optional = true }
 
+[dev-dependencies]
+test-case = "*"
+
 [lib]
 name = "clarity_repl"
 path = "src/lib.rs"

--- a/components/clarity-repl/Cargo.toml
+++ b/components/clarity-repl/Cargo.toml
@@ -51,7 +51,7 @@ memchr = { version = "2.4.1", optional = true }
 
 # CLI
 pico-args = { version = "0.5.0", optional = true }
-rustyline = { version = "9.1.1", optional = true }
+rustyline = { version = "14.0.0", optional = true }
 prettytable-rs = { version = "0.10.0", optional = true }
 hiro_system_kit = { version = "0.1.0", package = "hiro-system-kit", path = "../hiro-system-kit", default-features = false }
 reqwest = { version = "0.11", default-features = false, features = [

--- a/components/clarity-repl/src/frontend/terminal.rs
+++ b/components/clarity-repl/src/frontend/terminal.rs
@@ -22,22 +22,19 @@ fn complete_input(str: &str) -> Result<Input, (char, char)> {
     let mut in_string = false;
 
     for (pos, character) in str.char_indices() {
-        let skip_current = skip_next;
+        // if the previous character was a backslash, skip this character (only in strings)
         if skip_next {
             skip_next = false;
+            continue;
         }
 
         match character {
             '\\' => {
-                if !skip_current {
-                    skip_next = true
+                if in_string {
+                    skip_next = true;
                 }
             }
-            '"' => {
-                if !skip_current {
-                    in_string = !in_string
-                }
-            }
+            '"' => in_string = !in_string,
             '(' | '{' => {
                 if !in_string {
                     brackets.push(character);

--- a/components/clarity-repl/src/frontend/terminal.rs
+++ b/components/clarity-repl/src/frontend/terminal.rs
@@ -2,7 +2,7 @@ use crate::repl::{settings::SessionSettings, Session};
 
 use clarity::vm::EvaluationResult;
 use rustyline::error::ReadlineError;
-use rustyline::Editor;
+use rustyline::DefaultEditor;
 
 const VERSION: Option<&'static str> = option_env!("CARGO_PKG_VERSION");
 const HISTORY_FILE: Option<&'static str> = option_env!("CLARITY_REPL_HISTORY_FILE");
@@ -110,7 +110,7 @@ impl Terminal {
             }
         };
         println!("{}", output);
-        let mut editor = Editor::<()>::new();
+        let mut editor = DefaultEditor::new().unwrap();
         let mut ctrl_c_acc = 0;
         let mut input_buffer = vec![];
         let mut prompt = String::from(">> ");
@@ -183,7 +183,7 @@ impl Terminal {
                             }
                             prompt = String::from(">> ");
                             self.session.executed.push(input.to_string());
-                            editor.add_history_entry(input);
+                            let _ = editor.add_history_entry(input);
                             input_buffer.clear();
                             if reload {
                                 break true;

--- a/components/clarity-repl/src/frontend/terminal.rs
+++ b/components/clarity-repl/src/frontend/terminal.rs
@@ -114,7 +114,7 @@ impl Terminal {
             }
         };
         println!("{}", output);
-        let mut editor = DefaultEditor::new().unwrap();
+        let mut editor = DefaultEditor::new().expect("Failed to initialize cli");
         let mut ctrl_c_acc = 0;
         let mut input_buffer = vec![];
         let mut prompt = String::from(">> ");

--- a/components/clarity-repl/src/frontend/terminal.rs
+++ b/components/clarity-repl/src/frontend/terminal.rs
@@ -62,7 +62,11 @@ fn complete_input(str: &str) -> Result<Input, (char, char)> {
                     }
                 }
             }
-            _ => {}
+            _ => {
+                if skip_next {
+                    skip_next = false
+                }
+            }
         }
     }
 
@@ -125,6 +129,7 @@ impl Terminal {
                     ctrl_c_acc = 0;
                     input_buffer.push(command);
                     let input = input_buffer.join(" ");
+                    dbg!(&input);
                     match complete_input(&input) {
                         Ok(Input::Complete(_)) => {
                             let (reload, output, result) = self.session.handle_command(&input);

--- a/components/clarity-repl/src/frontend/terminal.rs
+++ b/components/clarity-repl/src/frontend/terminal.rs
@@ -129,7 +129,6 @@ impl Terminal {
                     ctrl_c_acc = 0;
                     input_buffer.push(command);
                     let input = input_buffer.join(" ");
-                    dbg!(&input);
                     match complete_input(&input) {
                         Ok(Input::Complete(_)) => {
                             let (reload, output, result) = self.session.handle_command(&input);

--- a/components/clarity-repl/src/repl/debug/cli.rs
+++ b/components/clarity-repl/src/repl/debug/cli.rs
@@ -22,7 +22,7 @@ pub struct CLIDebugger {
 
 impl CLIDebugger {
     pub fn new(contract_id: &QualifiedContractIdentifier, snippet: &str) -> Self {
-        let mut editor = DefaultEditor::new().unwrap();
+        let mut editor = DefaultEditor::new().expect("Failed to initialize cli");
         editor
             .load_history(HISTORY_FILE.unwrap_or(".debug_history"))
             .ok();
@@ -36,7 +36,7 @@ impl CLIDebugger {
     fn prompt(&mut self, env: &mut Environment, context: &LocalContext, expr: &SymbolicExpression) {
         let prompt = black!("(debug) ");
         loop {
-            let readline = self.editor.readline(&prompt.escape_default().to_string());
+            let readline = self.editor.readline(&prompt);
             let resume = match readline {
                 Ok(mut command) => {
                     if command.is_empty() {


### PR DESCRIPTION
### Description

- upgrade rustyline dependency
- fix `skip_next` behavior when parsing user input in clarinet console

Fix #1323
Fix #1271
Fix #616 
