### PR TITLE
chore: upgrade clarity vm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -703,7 +703,7 @@ dependencies = [
  "serde-hex",
  "serde_derive",
  "serde_json",
- "stacks-codec 2.5.1",
+ "stacks-codec 2.6.0 (git+https://github.com/hirosystems/clarinet.git)",
  "threadpool",
  "tokio",
 ]
@@ -798,13 +798,28 @@ checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 [[package]]
 name = "clar2wasm"
 version = "0.1.0"
-source = "git+https://github.com/stacks-network/clarity-wasm.git#3cac25c2ccea31be11829b3ab24147445b5dd41d"
+source = "git+https://github.com/stacks-network/clarity-wasm.git?branch=chore/udpate-clarity#41359464b7a72f6ad7f4181b6b7c37dcf8d31b65"
 dependencies = [
  "clap",
- "clarity",
+ "clarity 2.3.0 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
  "lazy_static",
  "regex",
- "stacks-common",
+ "stacks-common 0.0.2 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
+ "walrus",
+ "wasmtime",
+ "wat",
+]
+
+[[package]]
+name = "clar2wasm"
+version = "0.1.0"
+source = "git+https://github.com/stacks-network/clarity-wasm.git?rev=7e6d4be#7e6d4beb64ab19714ae27ec76420aeeab4ed875d"
+dependencies = [
+ "clap",
+ "clarity 2.3.0 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
+ "lazy_static",
+ "regex",
+ "stacks-common 0.0.2 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
  "walrus",
  "wasmtime",
  "wat",
@@ -946,9 +961,32 @@ dependencies = [
 [[package]]
 name = "clarity"
 version = "2.3.0"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-next#35cce11f4a7e49f29dd1cf06680abfbd31099669"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#9d786f5dd445bfef7f396249b215577c98d18c71"
 dependencies = [
  "getrandom 0.2.8",
+ "hashbrown 0.14.3",
+ "integer-sqrt",
+ "lazy_static",
+ "mutants",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "regex",
+ "rusqlite",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_stacker",
+ "sha2-asm 0.5.5",
+ "slog",
+ "stacks-common 0.0.2 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
+ "wasmtime",
+]
+
+[[package]]
+name = "clarity"
+version = "2.3.0"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-next#35cce11f4a7e49f29dd1cf06680abfbd31099669"
+dependencies = [
  "hashbrown 0.14.3",
  "integer-sqrt",
  "lazy_static",
@@ -962,7 +1000,7 @@ dependencies = [
  "serde_stacker",
  "sha2-asm 0.5.5",
  "slog",
- "stacks-common",
+ "stacks-common 0.0.2 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-next)",
  "wasmtime",
 ]
 
@@ -1007,8 +1045,8 @@ dependencies = [
  "atty",
  "bytes",
  "chrono",
- "clar2wasm",
- "clarity",
+ "clar2wasm 0.1.0 (git+https://github.com/stacks-network/clarity-wasm.git?branch=chore/udpate-clarity)",
+ "clarity 2.3.0 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
  "debug_types",
  "futures",
  "getrandom 0.2.8",
@@ -2852,15 +2890,15 @@ dependencies = [
 [[package]]
 name = "libstackerdb"
 version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-next#35cce11f4a7e49f29dd1cf06680abfbd31099669"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#9d786f5dd445bfef7f396249b215577c98d18c71"
 dependencies = [
- "clarity",
+ "clarity 2.3.0 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
  "secp256k1 0.24.3",
  "serde",
  "serde_derive",
  "serde_stacker",
  "sha2 0.10.6",
- "stacks-common",
+ "stacks-common 0.0.2 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
 ]
 
 [[package]]
@@ -3102,6 +3140,12 @@ dependencies = [
  "tokio-util",
  "version_check",
 ]
+
+[[package]]
+name = "mutants"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc0287524726960e07b119cebd01678f852f147742ae0d925e6a520dca956126"
 
 [[package]]
 name = "neon"
@@ -3365,9 +3409,9 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "p256k1"
-version = "7.0.0"
+version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a64d160b891178fb9d43d1a58ddcafb6502daeb54d810e5e92a7c3c9bfacc07"
+checksum = "a40a031a559eb38c35a14096f21c366254501a06d41c4b327d2a7515d713a5b7"
 dependencies = [
  "bitvec",
  "bs58 0.4.0",
@@ -3583,11 +3627,11 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 [[package]]
 name = "pox-locking"
 version = "2.4.0"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-next#35cce11f4a7e49f29dd1cf06680abfbd31099669"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#9d786f5dd445bfef7f396249b215577c98d18c71"
 dependencies = [
- "clarity",
+ "clarity 2.3.0 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
  "slog",
- "stacks-common",
+ "stacks-common 0.0.2 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
 ]
 
 [[package]]
@@ -4823,27 +4867,27 @@ dependencies = [
 
 [[package]]
 name = "stacks-codec"
-version = "2.5.1"
-source = "git+https://github.com/hirosystems/clarinet.git#cc0577e6514065cd3d451d010c0ad8babbc6932e"
+version = "2.6.0"
 dependencies = [
- "clarity",
+ "clarity 2.3.0 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
  "serde",
- "wsts",
+ "wsts 8.1.0",
 ]
 
 [[package]]
 name = "stacks-codec"
 version = "2.6.0"
+source = "git+https://github.com/hirosystems/clarinet.git#3de07ff6c2f379af229dc553f8437f59263bce03"
 dependencies = [
- "clarity",
+ "clarity 2.3.0 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-next)",
  "serde",
- "wsts",
+ "wsts 8.1.0",
 ]
 
 [[package]]
 name = "stacks-common"
 version = "0.0.2"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-next#35cce11f4a7e49f29dd1cf06680abfbd31099669"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#9d786f5dd445bfef7f396249b215577c98d18c71"
 dependencies = [
  "chrono",
  "curve25519-dalek 2.0.0",
@@ -4869,7 +4913,37 @@ dependencies = [
  "slog-term",
  "time",
  "winapi 0.3.9",
- "wsts",
+ "wsts 9.0.0",
+]
+
+[[package]]
+name = "stacks-common"
+version = "0.0.2"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-next#35cce11f4a7e49f29dd1cf06680abfbd31099669"
+dependencies = [
+ "chrono",
+ "curve25519-dalek 2.0.0",
+ "ed25519-dalek",
+ "hashbrown 0.14.3",
+ "lazy_static",
+ "libc",
+ "nix 0.23.2",
+ "percent-encoding",
+ "rand 0.8.5",
+ "ripemd",
+ "rusqlite",
+ "secp256k1 0.24.3",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sha2 0.10.6",
+ "sha3",
+ "slog",
+ "slog-json",
+ "slog-term",
+ "time",
+ "winapi 0.3.9",
+ "wsts 8.1.0",
 ]
 
 [[package]]
@@ -4946,11 +5020,11 @@ dependencies = [
 [[package]]
 name = "stackslib"
 version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-next#35cce11f4a7e49f29dd1cf06680abfbd31099669"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#9d786f5dd445bfef7f396249b215577c98d18c71"
 dependencies = [
  "chrono",
- "clar2wasm",
- "clarity",
+ "clar2wasm 0.1.0 (git+https://github.com/stacks-network/clarity-wasm.git?rev=7e6d4be)",
+ "clarity 2.3.0 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
  "curve25519-dalek 2.0.0",
  "ed25519-dalek",
  "hashbrown 0.14.3",
@@ -4977,12 +5051,12 @@ dependencies = [
  "siphasher",
  "slog",
  "slog-term",
- "stacks-common",
+ "stacks-common 0.0.2 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
  "tikv-jemallocator",
  "time",
  "url",
  "winapi 0.3.9",
- "wsts",
+ "wsts 9.0.0",
 ]
 
 [[package]]
@@ -6515,6 +6589,28 @@ name = "wsts"
 version = "8.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "467aa8e40ed0277d19922fd0e7357c16552cb900e5138f61a48ac23c4b7878e0"
+dependencies = [
+ "aes-gcm",
+ "bs58 0.5.0",
+ "hashbrown 0.14.3",
+ "hex",
+ "num-traits",
+ "p256k1",
+ "polynomial",
+ "primitive-types",
+ "rand_core 0.6.4",
+ "serde",
+ "sha2 0.10.6",
+ "thiserror",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "wsts"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c80d57a61294350ed91e91eb20a6c34da084ec8f15d039bab79ce3efabbd1a4"
 dependencies = [
  "aes-gcm",
  "bs58 0.5.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -798,22 +798,7 @@ checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 [[package]]
 name = "clar2wasm"
 version = "0.1.0"
-source = "git+https://github.com/stacks-network/clarity-wasm.git?branch=chore/udpate-clarity#7c3e6e4baed1b0b4bb2001dc8ba1e9bb99a3eabc"
-dependencies = [
- "clap",
- "clarity 2.3.0 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
- "lazy_static",
- "regex",
- "stacks-common 0.0.2 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
- "walrus",
- "wasmtime",
- "wat",
-]
-
-[[package]]
-name = "clar2wasm"
-version = "0.1.0"
-source = "git+https://github.com/stacks-network/clarity-wasm.git?rev=7e6d4be#7e6d4beb64ab19714ae27ec76420aeeab4ed875d"
+source = "git+https://github.com/stacks-network/clarity-wasm.git#6600e2dcb545210bd018149787698e254702eb80"
 dependencies = [
  "clap",
  "clarity 2.3.0 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
@@ -961,7 +946,7 @@ dependencies = [
 [[package]]
 name = "clarity"
 version = "2.3.0"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#9d786f5dd445bfef7f396249b215577c98d18c71"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#30bc1af6a07aaeedc01a084170f07065802bdff1"
 dependencies = [
  "getrandom 0.2.8",
  "hashbrown 0.14.3",
@@ -1045,7 +1030,7 @@ dependencies = [
  "atty",
  "bytes",
  "chrono",
- "clar2wasm 0.1.0 (git+https://github.com/stacks-network/clarity-wasm.git?branch=chore/udpate-clarity)",
+ "clar2wasm",
  "clarity 2.3.0 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
  "debug_types",
  "futures",
@@ -2890,7 +2875,7 @@ dependencies = [
 [[package]]
 name = "libstackerdb"
 version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#9d786f5dd445bfef7f396249b215577c98d18c71"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#30bc1af6a07aaeedc01a084170f07065802bdff1"
 dependencies = [
  "clarity 2.3.0 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
  "secp256k1 0.24.3",
@@ -3627,7 +3612,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 [[package]]
 name = "pox-locking"
 version = "2.4.0"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#9d786f5dd445bfef7f396249b215577c98d18c71"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#30bc1af6a07aaeedc01a084170f07065802bdff1"
 dependencies = [
  "clarity 2.3.0 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
  "slog",
@@ -4877,7 +4862,7 @@ dependencies = [
 [[package]]
 name = "stacks-codec"
 version = "2.6.0"
-source = "git+https://github.com/hirosystems/clarinet.git#3de07ff6c2f379af229dc553f8437f59263bce03"
+source = "git+https://github.com/hirosystems/clarinet.git#7ac84986e1e87a2400de1b3da579e864ed43dc6f"
 dependencies = [
  "clarity 2.3.0 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-next)",
  "serde",
@@ -4887,7 +4872,7 @@ dependencies = [
 [[package]]
 name = "stacks-common"
 version = "0.0.2"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#9d786f5dd445bfef7f396249b215577c98d18c71"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#30bc1af6a07aaeedc01a084170f07065802bdff1"
 dependencies = [
  "chrono",
  "curve25519-dalek 2.0.0",
@@ -5020,10 +5005,10 @@ dependencies = [
 [[package]]
 name = "stackslib"
 version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#9d786f5dd445bfef7f396249b215577c98d18c71"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#30bc1af6a07aaeedc01a084170f07065802bdff1"
 dependencies = [
  "chrono",
- "clar2wasm 0.1.0 (git+https://github.com/stacks-network/clarity-wasm.git?rev=7e6d4be)",
+ "clar2wasm",
  "clarity 2.3.0 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
  "curve25519-dalek 2.0.0",
  "ed25519-dalek",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -798,7 +798,7 @@ checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 [[package]]
 name = "clar2wasm"
 version = "0.1.0"
-source = "git+https://github.com/stacks-network/clarity-wasm.git?branch=chore/udpate-clarity#41359464b7a72f6ad7f4181b6b7c37dcf8d31b65"
+source = "git+https://github.com/stacks-network/clarity-wasm.git?branch=chore/udpate-clarity#7c3e6e4baed1b0b4bb2001dc8ba1e9bb99a3eabc"
 dependencies = [
  "clap",
  "clarity 2.3.0 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",

--- a/components/clarity-events/src/analysis/mod.rs
+++ b/components/clarity-events/src/analysis/mod.rs
@@ -636,7 +636,7 @@ impl ASTVisitor<'_> for EventCollector<'_, '_> {
         let value_type_shape = self
             .type_checker
             .type_map
-            .get_type(expr)
+            .get_type_expected(expr)
             .expect("unable to infer value's type shape");
 
         let data = SmartContractEventData {
@@ -846,7 +846,7 @@ impl ASTVisitor<'_> for EventCollector<'_, '_> {
         let type_signature = self
             .type_checker
             .type_map
-            .get_type(identifier)
+            .get_type_expected(identifier)
             .expect("unable to infer value's type shape");
 
         let mut data = NFTBurnEventData::default(self.create_asset_identifier(token.clone()));
@@ -887,7 +887,7 @@ impl ASTVisitor<'_> for EventCollector<'_, '_> {
         let type_signature = self
             .type_checker
             .type_map
-            .get_type(identifier)
+            .get_type_expected(identifier)
             .expect("unable to infer value's type shape");
 
         let mut data = NFTTransferEventData::default(self.create_asset_identifier(token.clone()));
@@ -939,7 +939,7 @@ impl ASTVisitor<'_> for EventCollector<'_, '_> {
         let type_signature = self
             .type_checker
             .type_map
-            .get_type(identifier)
+            .get_type_expected(identifier)
             .expect("unable to infer value's type shape");
 
         let mut data = NFTTransferEventData::default(self.create_asset_identifier(token.clone()));

--- a/components/clarity-events/src/bin.rs
+++ b/components/clarity-events/src/bin.rs
@@ -67,7 +67,7 @@ pub fn main() {
             {
                 let mut analysis_db = session.interpreter.datastore.as_analysis_db();
                 let cost_track = LimitedCostTracker::new_free();
-                let type_checker = TypeChecker::new(&mut analysis_db, cost_track);
+                let type_checker = TypeChecker::new(&mut analysis_db, cost_track, true);
                 let settings = Settings::default();
                 let mut event_collector = EventCollector::new(settings, type_checker);
                 let event_map = event_collector.run(&mut contract_analysis);

--- a/components/clarity-repl/Cargo.toml
+++ b/components/clarity-repl/Cargo.toml
@@ -35,9 +35,9 @@ getrandom = { version = "0.2.3", features = ["js"] }
 atty = "0.2.14"
 # clarity-vm = { version = "2.3.0", default-features = false }
 clarity = { git = "https://github.com/stacks-network/stacks-core.git", branch="feat/clarity-wasm-develop", package = "clarity", default-features = false }
-clar2wasm = { git = "https://github.com/stacks-network/clarity-wasm.git", branch="chore/udpate-clarity", optional = true }
+clar2wasm = { git = "https://github.com/stacks-network/clarity-wasm.git", optional = true }
 # clar2wasm = { path="../../../clarity-wasm/clar2wasm", optional = true }
-pox-locking = { git = "https://github.com/stacks-network/stacks-core.git", branch="feat/clarity-wasm-develop",  optional = true, default-features = false }
+pox-locking = { git = "https://github.com/stacks-network/stacks-core.git", branch="feat/clarity-wasm-develop", optional = true, default-features = false }
 
 # DAP Debugger
 tokio = { version = "1.35.1", features = ["full"], optional = true }

--- a/components/clarity-repl/Cargo.toml
+++ b/components/clarity-repl/Cargo.toml
@@ -87,6 +87,7 @@ cli = [
     "clarity/canonical",
     "clarity/developer-mode",
     "clarity/log",
+    "clarity/devtools",
     "hiro_system_kit/tokio_helpers",
     "clar2wasm",
     "pox-locking/default"
@@ -95,6 +96,7 @@ sdk = [
     "clarity/canonical",
     "clarity/developer-mode",
     "clarity/log",
+    "clarity/devtools",
     "hiro_system_kit/tokio_helpers",
     "pox-locking/default"
 ]

--- a/components/clarity-repl/Cargo.toml
+++ b/components/clarity-repl/Cargo.toml
@@ -34,10 +34,10 @@ integer-sqrt = "0.1.3"
 getrandom = { version = "0.2.3", features = ["js"] }
 atty = "0.2.14"
 # clarity-vm = { version = "2.3.0", default-features = false }
-clarity = { git = "https://github.com/stacks-network/stacks-core.git", branch="feat/clarity-wasm-next", package = "clarity", default-features = false }
-clar2wasm = { git = "https://github.com/stacks-network/clarity-wasm.git", optional = true }
+clarity = { git = "https://github.com/stacks-network/stacks-core.git", branch="feat/clarity-wasm-develop", package = "clarity", default-features = false }
+clar2wasm = { git = "https://github.com/stacks-network/clarity-wasm.git", branch="chore/udpate-clarity", optional = true }
 # clar2wasm = { path="../../../clarity-wasm/clar2wasm", optional = true }
-pox-locking = { git = "https://github.com/stacks-network/stacks-core.git", branch="feat/clarity-wasm-next",  optional = true, default-features = false }
+pox-locking = { git = "https://github.com/stacks-network/stacks-core.git", branch="feat/clarity-wasm-develop",  optional = true, default-features = false }
 
 # DAP Debugger
 tokio = { version = "1.35.1", features = ["full"], optional = true }

--- a/components/clarity-repl/src/repl/datastore.rs
+++ b/components/clarity-repl/src/repl/datastore.rs
@@ -181,7 +181,7 @@ impl Datastore {
 }
 
 impl ClarityBackingStore for Datastore {
-    fn put_all(&mut self, items: Vec<(String, String)>) -> Result<()> {
+    fn put_all_data(&mut self, items: Vec<(String, String)>) -> Result<()> {
         for (key, value) in items {
             self.put(&key, &value);
         }
@@ -189,7 +189,7 @@ impl ClarityBackingStore for Datastore {
     }
 
     /// fetch K-V out of the committed datastore
-    fn get(&mut self, key: &str) -> Result<Option<String>> {
+    fn get_data(&mut self, key: &str) -> Result<Option<String>> {
         let lookup_id = self
             .block_id_lookup
             .get(&self.current_chain_tip)
@@ -203,7 +203,7 @@ impl ClarityBackingStore for Datastore {
     }
 
     fn has_entry(&mut self, key: &str) -> Result<bool> {
-        Ok(self.get(key)?.is_some())
+        Ok(self.get_data(key)?.is_some())
     }
 
     /// change the current MARF context to service reads from a different chain_tip
@@ -271,7 +271,7 @@ impl ClarityBackingStore for Datastore {
         }
     }
 
-    fn get_with_proof(&mut self, _key: &str) -> Result<Option<(String, Vec<u8>)>> {
+    fn get_data_with_proof(&mut self, _key: &str) -> Result<Option<(String, Vec<u8>)>> {
         Ok(None)
     }
 

--- a/components/clarity-repl/src/repl/interpreter.rs
+++ b/components/clarity-repl/src/repl/interpreter.rs
@@ -310,6 +310,7 @@ impl ClarityInterpreter {
             LimitedCostTracker::new_free(),
             contract.epoch,
             contract.clarity_version,
+            true,
         )
         .map_err(|(error, _)| error.diagnostic)?;
 
@@ -401,7 +402,7 @@ impl ClarityInterpreter {
         let key = ClarityDatabase::make_key_for_trip(contract_id, StoreType::Variable, var_name);
         let value_hex = self
             .datastore
-            .get(&key)
+            .get_data(&key)
             .expect("failed to get key from datastore")?;
         Some(format!("0x{value_hex}"))
     }
@@ -416,7 +417,7 @@ impl ClarityInterpreter {
             ClarityDatabase::make_key_for_data_map_entry(contract_id, map_name, map_key).unwrap();
         let value_hex = self
             .datastore
-            .get(&key)
+            .get_data(&key)
             .expect("failed to get map entry from datastore")?;
         Some(format!("0x{value_hex}"))
     }

--- a/components/clarity-repl/src/repl/interpreter.rs
+++ b/components/clarity-repl/src/repl/interpreter.rs
@@ -1727,7 +1727,7 @@ mod tests {
     #[test]
     fn can_run_boot_contracts() {
         let repl_settings = Settings {
-            clarity_wasm_mode: true,
+            clarity_wasm_mode: false,
             ..Default::default()
         };
         let mut interpreter =
@@ -1741,7 +1741,8 @@ mod tests {
             }
             let res = interpreter
                 .run(&boot_contract, &mut Some(ast), false, None)
-                .unwrap_or_else(|_| {
+                .unwrap_or_else(|err| {
+                    dbg!(&err);
                     panic!("failed to interpret {} boot contract", &boot_contract.name)
                 });
 
@@ -1819,6 +1820,7 @@ mod tests {
             None,
         );
 
+        println!("{:?}", result);
         assert!(result.is_ok());
         let ExecutionResult { result, .. } = result.unwrap();
 

--- a/components/stacks-codec/Cargo.toml
+++ b/components/stacks-codec/Cargo.toml
@@ -7,7 +7,7 @@ description = "Stack wire format implementation"
 
 [dependencies]
 # clarity-vm = { version = "2.3.0",  default-features = false, features = ["canonical", "developer-mode", "log"] }
-clarity = { git = "https://github.com/stacks-network/stacks-core.git", branch="feat/clarity-wasm-next", package = "clarity", default-features = false, features = ["canonical", "developer-mode", "log"] }
+clarity = { git = "https://github.com/stacks-network/stacks-core.git", branch="feat/clarity-wasm-develop", package = "clarity", default-features = false, features = ["canonical", "developer-mode", "log"] }
 
 serde = { version = "1", features = ["derive"] }
 wsts = { version = "8.1.0", default-features = false }

--- a/components/stacks-network/Cargo.toml
+++ b/components/stacks-network/Cargo.toml
@@ -34,7 +34,7 @@ tokio = { version = "1.35.1", features = ["full"] }
 dirs = { version = "4.0.0" }
 clap = { version = "4.4.8", features = ["derive"] }
 serde_yaml = "0.8.23"
-stackslib = { git = "https://github.com/stacks-network/stacks-core.git", branch="feat/clarity-wasm-next", package = "stackslib" }
+stackslib = { git = "https://github.com/stacks-network/stacks-core.git", branch="feat/clarity-wasm-develop", package = "stackslib" }
 chainhook-sdk = { version = "0.12" }
 stacks-rpc-client = { path = "../stacks-rpc-client" }
 clarinet-files = { path = "../clarinet-files", features = ["cli"] }

--- a/components/stacks-network/src/chains_coordinator.rs
+++ b/components/stacks-network/src/chains_coordinator.rs
@@ -42,12 +42,8 @@ use stackslib::chainstate::stacks::address::PoxAddress;
 use stackslib::core::CHAIN_ID_TESTNET;
 use stackslib::types::chainstate::StacksPrivateKey;
 use stackslib::types::chainstate::StacksPublicKey;
-use stackslib::types::PrivateKey;
-use stackslib::util::hash::Sha256Sum;
-use stackslib::util::secp256k1::MessageSignature;
-use stackslib::util_lib::signed_structured_data::pox4::make_pox_4_signed_data_domain;
+use stackslib::util_lib::signed_structured_data::pox4::make_pox_4_signer_key_signature;
 use stackslib::util_lib::signed_structured_data::pox4::Pox4SignatureTopic;
-use stackslib::util_lib::signed_structured_data::structured_data_message_hash;
 use std::convert::TryFrom;
 use std::str;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -959,15 +955,20 @@ fn get_stacking_tx_method_and_args(
             Pox4SignatureTopic::StackStx
         };
 
-        let signer_sig = make_signer_key_signature(
+        let signature = make_pox_4_signer_key_signature(
             &pox_addr,
             signer_key,
             cycle,
             &topic,
+            CHAIN_ID_TESTNET,
             duration.into(),
             stx_amount.into(),
             auth_id,
-        );
+        )
+        .expect("Unable to make pox 4 signature");
+
+        let signer_sig = signature.to_rsv();
+
         let pub_key = StacksPublicKey::from_private(signer_key);
         arguments.push(ClarityValue::some(ClarityValue::buff_from(signer_sig).unwrap()).unwrap());
         arguments.push(ClarityValue::buff_from(pub_key.to_bytes()).unwrap());
@@ -976,83 +977,4 @@ fn get_stacking_tx_method_and_args(
     };
 
     (method.to_string(), arguments)
-}
-
-// The current version of stackslib we are using (from feat/clarity-wasm-develop) does not have the latest version of make_pox_4_signer_key_signature
-// This is a temporary fix until feat/clarity-wasm-develop catches up with the latest updates
-
-fn make_pox_4_signer_key_message_hash(
-    pox_addr: &PoxAddress,
-    reward_cycle: u128,
-    topic: &Pox4SignatureTopic,
-    chain_id: u32,
-    period: u128,
-    max_amount: u128,
-    auth_id: u128,
-) -> Sha256Sum {
-    let domain_tuple = make_pox_4_signed_data_domain(chain_id);
-    let data_tuple = ClarityValue::Tuple(
-        TupleData::from_data(vec![
-            (
-                "pox-addr".into(),
-                pox_addr.clone().as_clarity_tuple().unwrap().into(),
-            ),
-            ("reward-cycle".into(), ClarityValue::UInt(reward_cycle)),
-            ("period".into(), ClarityValue::UInt(period)),
-            (
-                "topic".into(),
-                ClarityValue::string_ascii_from_bytes(topic.get_name_str().into()).unwrap(),
-            ),
-            ("auth-id".into(), ClarityValue::UInt(auth_id)),
-            ("max-amount".into(), ClarityValue::UInt(max_amount)),
-        ])
-        .unwrap(),
-    );
-    structured_data_message_hash(data_tuple, domain_tuple)
-}
-
-fn make_pox_4_signer_key_signature(
-    pox_addr: &PoxAddress,
-    signer_key: &StacksPrivateKey,
-    reward_cycle: u128,
-    topic: &Pox4SignatureTopic,
-    chain_id: u32,
-    period: u128,
-    max_amount: u128,
-    auth_id: u128,
-) -> Result<MessageSignature, &'static str> {
-    let msg_hash = make_pox_4_signer_key_message_hash(
-        pox_addr,
-        reward_cycle,
-        topic,
-        chain_id,
-        period,
-        max_amount,
-        auth_id,
-    );
-    signer_key.sign(msg_hash.as_bytes())
-}
-
-fn make_signer_key_signature(
-    pox_addr: &PoxAddress,
-    signer_key: &StacksPrivateKey,
-    reward_cycle: u128,
-    topic: &Pox4SignatureTopic,
-    period: u128,
-    max_amount: u128,
-    auth_id: u128,
-) -> Vec<u8> {
-    let signature = make_pox_4_signer_key_signature(
-        pox_addr,
-        signer_key,
-        reward_cycle,
-        topic,
-        CHAIN_ID_TESTNET,
-        period,
-        max_amount,
-        auth_id,
-    )
-    .unwrap();
-
-    signature.to_rsv()
 }

--- a/components/stacks-network/src/chains_coordinator.rs
+++ b/components/stacks-network/src/chains_coordinator.rs
@@ -978,8 +978,8 @@ fn get_stacking_tx_method_and_args(
     (method.to_string(), arguments)
 }
 
-// The current version of stackslib we are using (from feat/clarity-wasm-next) does not have the latest version of make_pox_4_signer_key_signature
-// This is a temporary fix until feat/clarity-wasm-next catches up with the branch next
+// The current version of stackslib we are using (from feat/clarity-wasm-develop) does not have the latest version of make_pox_4_signer_key_signature
+// This is a temporary fix until feat/clarity-wasm-develop catches up with the latest updates
 
 fn make_pox_4_signer_key_message_hash(
     pox_addr: &PoxAddress,


### PR DESCRIPTION
### Description

The branch we use on stacks-core has been updated with the latest changes of `develop`.
A new branch `feat/clarity-wasm-develop` has been pushed https://github.com/stacks-network/stacks-core/pull/4756