### PR TITLE
fix: add a safety check in lsp check_if_should_wrap

### DIFF
--- a/components/clarity-lsp/src/common/requests/completion.rs
+++ b/components/clarity-lsp/src/common/requests/completion.rs
@@ -469,11 +469,7 @@ pub fn build_completion_item_list(
 }
 
 pub fn check_if_should_wrap(source: &str, position: &Position) -> bool {
-    if let Some(line) = source
-        .lines()
-        .collect::<Vec<&str>>()
-        .get(position.line as usize)
-    {
+    if let Some(line) = source.lines().nth(position.line as usize) {
         if position.character as usize > line.len() {
             return false;
         }
@@ -482,11 +478,8 @@ pub fn check_if_should_wrap(source: &str, position: &Position) -> bool {
         while let Some(char) = chars.next_back() {
             match char {
                 '(' => return false,
-                char => {
-                    if char.is_whitespace() {
-                        return true;
-                    }
-                }
+                char if char.is_whitespace() => return true,
+                _ => {}
             }
         }
     }

--- a/components/clarity-lsp/src/common/requests/completion.rs
+++ b/components/clarity-lsp/src/common/requests/completion.rs
@@ -474,6 +474,10 @@ pub fn check_if_should_wrap(source: &str, position: &Position) -> bool {
         .collect::<Vec<&str>>()
         .get(position.line as usize)
     {
+        if position.character as usize > line.len() {
+            return false;
+        }
+
         let mut chars = line[..position.character as usize].chars();
         while let Some(char) = chars.next_back() {
             match char {


### PR DESCRIPTION
### Description

In some rare cases, eg: if the LSP state isn't up to date, it's possible that the cursor position is past the end of the line (as the LSP sees it).

This PR adds a safety check before getting the beginning of the line with `line[..position.character as usize]`.
This PR also slightly refactor this method

