### PR TITLE
Feat/handle clarity 3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -798,7 +798,7 @@ checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 [[package]]
 name = "clar2wasm"
 version = "0.1.0"
-source = "git+https://github.com/stacks-network/clarity-wasm.git?branch=chore/update-clarity#a7c711e011b12c1780987df51f028b500978f992"
+source = "git+https://github.com/stacks-network/clarity-wasm.git?branch=chore/update-clarity#683470d54b39ede7ae83d03e3270c2897a1e11b2"
 dependencies = [
  "chrono",
  "clap",
@@ -949,13 +949,12 @@ dependencies = [
 [[package]]
 name = "clarity"
 version = "2.3.0"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#03728f1f2e55e91ad5bf8cd3708994b6a1d73113"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#b0fe27e025e38202c613f99438929c2cc2272aa0"
 dependencies = [
  "getrandom 0.2.8",
  "hashbrown 0.14.3",
  "integer-sqrt",
  "lazy_static",
- "mutants",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "regex",
@@ -2864,7 +2863,7 @@ dependencies = [
 [[package]]
 name = "libstackerdb"
 version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#03728f1f2e55e91ad5bf8cd3708994b6a1d73113"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#b0fe27e025e38202c613f99438929c2cc2272aa0"
 dependencies = [
  "clarity",
  "secp256k1 0.24.3",
@@ -3114,12 +3113,6 @@ dependencies = [
  "tokio-util",
  "version_check",
 ]
-
-[[package]]
-name = "mutants"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc0287524726960e07b119cebd01678f852f147742ae0d925e6a520dca956126"
 
 [[package]]
 name = "neon"
@@ -3601,7 +3594,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 [[package]]
 name = "pox-locking"
 version = "2.4.0"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#03728f1f2e55e91ad5bf8cd3708994b6a1d73113"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#b0fe27e025e38202c613f99438929c2cc2272aa0"
 dependencies = [
  "clarity",
  "slog",
@@ -4889,7 +4882,7 @@ dependencies = [
 [[package]]
 name = "stacks-common"
 version = "0.0.2"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#03728f1f2e55e91ad5bf8cd3708994b6a1d73113"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#b0fe27e025e38202c613f99438929c2cc2272aa0"
 dependencies = [
  "chrono",
  "curve25519-dalek 2.0.0",
@@ -4992,7 +4985,7 @@ dependencies = [
 [[package]]
 name = "stackslib"
 version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#03728f1f2e55e91ad5bf8cd3708994b6a1d73113"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#b0fe27e025e38202c613f99438929c2cc2272aa0"
 dependencies = [
  "chrono",
  "clar2wasm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -798,7 +798,7 @@ checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 [[package]]
 name = "clar2wasm"
 version = "0.1.0"
-source = "git+https://github.com/stacks-network/clarity-wasm.git?branch=chore/update-clarity#2af2f01879ff2a6fb4ad9985d14c0fefca2dd8d6"
+source = "git+https://github.com/stacks-network/clarity-wasm.git?branch=chore/update-clarity#a7c711e011b12c1780987df51f028b500978f992"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -798,12 +798,15 @@ checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 [[package]]
 name = "clar2wasm"
 version = "0.1.0"
-source = "git+https://github.com/stacks-network/clarity-wasm.git#6600e2dcb545210bd018149787698e254702eb80"
+source = "git+https://github.com/stacks-network/clarity-wasm.git?branch=chore/update-clarity#3233f99030b33a8909d41e6f2ec1ba5afd5863df"
 dependencies = [
+ "chrono",
  "clap",
  "clarity",
  "lazy_static",
  "regex",
+ "rusqlite",
+ "sha2 0.10.8",
  "stacks-common",
  "walrus",
  "wasmtime",
@@ -854,7 +857,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "sha2 0.10.6",
+ "sha2 0.10.8",
  "signal-hook-registry",
  "similar",
  "stacks-network",
@@ -940,13 +943,13 @@ version = "1.0.0"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
- "sha2 0.10.6",
+ "sha2 0.10.8",
 ]
 
 [[package]]
 name = "clarity"
 version = "2.3.0"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#30bc1af6a07aaeedc01a084170f07065802bdff1"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#cf19e624a1ee687ae0b2646e7626de9327a416b9"
 dependencies = [
  "getrandom 0.2.8",
  "hashbrown 0.14.3",
@@ -956,6 +959,8 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "regex",
+ "rstest",
+ "rstest_reuse",
  "rusqlite",
  "serde",
  "serde_derive",
@@ -1028,7 +1033,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "sha2 0.10.6",
+ "sha2 0.10.8",
  "test-case",
  "tokio",
  "tokio-util",
@@ -1676,7 +1681,7 @@ dependencies = [
  "ed25519",
  "rand_core 0.6.4",
  "serde",
- "sha2 0.10.6",
+ "sha2 0.10.8",
  "subtle 2.4.1",
  "zeroize",
 ]
@@ -1920,6 +1925,12 @@ name = "futures-task"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
@@ -2853,14 +2864,14 @@ dependencies = [
 [[package]]
 name = "libstackerdb"
 version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#30bc1af6a07aaeedc01a084170f07065802bdff1"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#cf19e624a1ee687ae0b2646e7626de9327a416b9"
 dependencies = [
  "clarity",
  "secp256k1 0.24.3",
  "serde",
  "serde_derive",
  "serde_stacker",
- "sha2 0.10.6",
+ "sha2 0.10.8",
  "stacks-common",
 ]
 
@@ -3388,7 +3399,7 @@ dependencies = [
  "rand_core 0.6.4",
  "rustfmt-wrapper",
  "serde",
- "sha2 0.10.6",
+ "sha2 0.10.8",
  "syn 2.0.50",
 ]
 
@@ -3467,7 +3478,7 @@ dependencies = [
  "digest 0.10.7",
  "hmac 0.12.1",
  "password-hash",
- "sha2 0.10.6",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -3590,7 +3601,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 [[package]]
 name = "pox-locking"
 version = "2.4.0"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#30bc1af6a07aaeedc01a084170f07065802bdff1"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#cf19e624a1ee687ae0b2646e7626de9327a416b9"
 dependencies = [
  "clarity",
  "slog",
@@ -4121,6 +4132,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "rstest"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de1bb486a691878cd320c2f0d319ba91eeaa2e894066d8b5f8f117c000e9d962"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290ca1a1c8ca7edb7c3283bd44dc35dd54fdec6253a3912e201ba1072018fca8"
+dependencies = [
+ "cfg-if 1.0.0",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 1.0.107",
+ "unicode-ident",
+]
+
+[[package]]
+name = "rstest_reuse"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45f80dcc84beab3a327bbe161f77db25f336a1452428176787c8c79ac79d7073"
+dependencies = [
+ "quote",
+ "rand 0.8.5",
+ "rustc_version",
+ "syn 1.0.107",
+]
+
+[[package]]
 name = "rusqlite"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4550,9 +4599,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.6"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
@@ -4840,7 +4889,7 @@ dependencies = [
 [[package]]
 name = "stacks-common"
 version = "0.0.2"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#30bc1af6a07aaeedc01a084170f07065802bdff1"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#cf19e624a1ee687ae0b2646e7626de9327a416b9"
 dependencies = [
  "chrono",
  "curve25519-dalek 2.0.0",
@@ -4859,7 +4908,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "sha2 0.10.6",
+ "sha2 0.10.8",
  "sha3",
  "slog",
  "slog-json",
@@ -4935,7 +4984,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "sha2 0.10.6",
+ "sha2 0.10.8",
  "stacks-codec",
  "tiny-hderive",
 ]
@@ -4943,7 +4992,7 @@ dependencies = [
 [[package]]
 name = "stackslib"
 version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#30bc1af6a07aaeedc01a084170f07065802bdff1"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#cf19e624a1ee687ae0b2646e7626de9327a416b9"
 dependencies = [
  "chrono",
  "clar2wasm",
@@ -4969,7 +5018,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "sha2 0.10.6",
+ "sha2 0.10.8",
  "sha3",
  "siphasher",
  "slog",
@@ -5950,7 +5999,7 @@ dependencies = [
  "rustix",
  "serde",
  "serde_derive",
- "sha2 0.10.6",
+ "sha2 0.10.8",
  "toml 0.5.11",
  "windows-sys 0.48.0",
  "zstd",
@@ -6523,7 +6572,7 @@ dependencies = [
  "primitive-types",
  "rand_core 0.6.4",
  "serde",
- "sha2 0.10.6",
+ "sha2 0.10.8",
  "thiserror",
  "tracing",
  "tracing-subscriber",
@@ -6545,7 +6594,7 @@ dependencies = [
  "primitive-types",
  "rand_core 0.6.4",
  "serde",
- "sha2 0.10.6",
+ "sha2 0.10.8",
  "thiserror",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -798,7 +798,7 @@ checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 [[package]]
 name = "clar2wasm"
 version = "0.1.0"
-source = "git+https://github.com/stacks-network/clarity-wasm.git?branch=chore/update-clarity#3233f99030b33a8909d41e6f2ec1ba5afd5863df"
+source = "git+https://github.com/stacks-network/clarity-wasm.git?branch=chore/update-clarity#2af2f01879ff2a6fb4ad9985d14c0fefca2dd8d6"
 dependencies = [
  "chrono",
  "clap",
@@ -949,7 +949,7 @@ dependencies = [
 [[package]]
 name = "clarity"
 version = "2.3.0"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#cf19e624a1ee687ae0b2646e7626de9327a416b9"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#03728f1f2e55e91ad5bf8cd3708994b6a1d73113"
 dependencies = [
  "getrandom 0.2.8",
  "hashbrown 0.14.3",
@@ -2864,7 +2864,7 @@ dependencies = [
 [[package]]
 name = "libstackerdb"
 version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#cf19e624a1ee687ae0b2646e7626de9327a416b9"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#03728f1f2e55e91ad5bf8cd3708994b6a1d73113"
 dependencies = [
  "clarity",
  "secp256k1 0.24.3",
@@ -3601,7 +3601,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 [[package]]
 name = "pox-locking"
 version = "2.4.0"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#cf19e624a1ee687ae0b2646e7626de9327a416b9"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#03728f1f2e55e91ad5bf8cd3708994b6a1d73113"
 dependencies = [
  "clarity",
  "slog",
@@ -4889,7 +4889,7 @@ dependencies = [
 [[package]]
 name = "stacks-common"
 version = "0.0.2"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#cf19e624a1ee687ae0b2646e7626de9327a416b9"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#03728f1f2e55e91ad5bf8cd3708994b6a1d73113"
 dependencies = [
  "chrono",
  "curve25519-dalek 2.0.0",
@@ -4992,7 +4992,7 @@ dependencies = [
 [[package]]
 name = "stackslib"
 version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#cf19e624a1ee687ae0b2646e7626de9327a416b9"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#03728f1f2e55e91ad5bf8cd3708994b6a1d73113"
 dependencies = [
  "chrono",
  "clar2wasm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -949,7 +949,7 @@ dependencies = [
 [[package]]
 name = "clarity"
 version = "2.3.0"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#b0fe27e025e38202c613f99438929c2cc2272aa0"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#379d8cebddf4c073a37346690978bca28d130cb9"
 dependencies = [
  "getrandom 0.2.8",
  "hashbrown 0.14.3",
@@ -2863,7 +2863,7 @@ dependencies = [
 [[package]]
 name = "libstackerdb"
 version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#b0fe27e025e38202c613f99438929c2cc2272aa0"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#379d8cebddf4c073a37346690978bca28d130cb9"
 dependencies = [
  "clarity",
  "secp256k1 0.24.3",
@@ -3594,7 +3594,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 [[package]]
 name = "pox-locking"
 version = "2.4.0"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#b0fe27e025e38202c613f99438929c2cc2272aa0"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#379d8cebddf4c073a37346690978bca28d130cb9"
 dependencies = [
  "clarity",
  "slog",
@@ -4882,7 +4882,7 @@ dependencies = [
 [[package]]
 name = "stacks-common"
 version = "0.0.2"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#b0fe27e025e38202c613f99438929c2cc2272aa0"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#379d8cebddf4c073a37346690978bca28d130cb9"
 dependencies = [
  "chrono",
  "curve25519-dalek 2.0.0",
@@ -4985,7 +4985,7 @@ dependencies = [
 [[package]]
 name = "stackslib"
 version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#b0fe27e025e38202c613f99438929c2cc2272aa0"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#379d8cebddf4c073a37346690978bca28d130cb9"
 dependencies = [
  "chrono",
  "clar2wasm",

--- a/components/clarinet-deployments/src/requirements.rs
+++ b/components/clarinet-deployments/src/requirements.rs
@@ -81,6 +81,7 @@ pub async fn retrieve_contract(
     let clarity_version = match contract.clarity_version {
         Some(1) => ClarityVersion::Clarity1,
         Some(2) => ClarityVersion::Clarity2,
+        Some(3) => ClarityVersion::Clarity3,
         Some(_) => {
             return Err("unable to parse clarity_version (can either be '1' or '2'".to_string())
         }

--- a/components/clarinet-deployments/src/types.rs
+++ b/components/clarinet-deployments/src/types.rs
@@ -501,8 +501,13 @@ impl ContractPublishSpecification {
                     Ok(ClarityVersion::Clarity1)
                 } else if clarity_version.eq(&2) {
                     Ok(ClarityVersion::Clarity2)
+                } else if clarity_version.eq(&3) {
+                    Ok(ClarityVersion::Clarity3)
                 } else {
-                    Err("unable to parse clarity_version (can either be '1' or '2'".to_string())
+                    Err(
+                        "unable to parse clarity_version, it can either be '1', '2', or '3'"
+                            .to_string(),
+                    )
                 }
             }
             _ => Ok(DEFAULT_CLARITY_VERSION),
@@ -661,6 +666,7 @@ pub mod clarity_version_serde {
         match clarity_version {
             ClarityVersion::Clarity1 => s.serialize_i64(1),
             ClarityVersion::Clarity2 => s.serialize_i64(2),
+            ClarityVersion::Clarity3 => s.serialize_i64(3),
         }
     }
 
@@ -672,6 +678,7 @@ pub mod clarity_version_serde {
         match cv {
             1 => Ok(ClarityVersion::Clarity1),
             2 => Ok(ClarityVersion::Clarity2),
+            3 => Ok(ClarityVersion::Clarity3),
             _ => Err(serde::de::Error::custom(INVALID_CLARITY_VERSION)),
         }
     }
@@ -743,8 +750,13 @@ impl RequirementPublishSpecification {
                     Ok(ClarityVersion::Clarity1)
                 } else if clarity_version.eq(&2) {
                     Ok(ClarityVersion::Clarity2)
+                } else if clarity_version.eq(&3) {
+                    Ok(ClarityVersion::Clarity3)
                 } else {
-                    Err("unable to parse clarity_version (can either be '1' or '2'".to_string())
+                    Err(
+                        "unable to parse clarity_version, it can either be '1', '2', or '3'"
+                            .to_string(),
+                    )
                 }
             }
             _ => Ok(DEFAULT_CLARITY_VERSION),
@@ -867,8 +879,13 @@ impl EmulatedContractPublishSpecification {
                     Ok(ClarityVersion::Clarity1)
                 } else if clarity_version.eq(&2) {
                     Ok(ClarityVersion::Clarity2)
+                } else if clarity_version.eq(&3) {
+                    Ok(ClarityVersion::Clarity3)
                 } else {
-                    Err("unable to parse clarity_version (can either be '1' or '2'".to_string())
+                    Err(
+                        "unable to parse clarity_version, it can either be '1', '2', or '3'"
+                            .to_string(),
+                    )
                 }
             }
             _ => Ok(DEFAULT_CLARITY_VERSION),
@@ -1380,6 +1397,7 @@ impl TransactionPlanSpecification {
                                 clarity_version: match tx.clarity_version {
                                     ClarityVersion::Clarity1 => Some(1),
                                     ClarityVersion::Clarity2 => Some(2),
+                                    ClarityVersion::Clarity3 => Some(3),
                                 },
                             },
                         )
@@ -1405,6 +1423,7 @@ impl TransactionPlanSpecification {
                                 clarity_version: match tx.clarity_version {
                                     ClarityVersion::Clarity1 => Some(1),
                                     ClarityVersion::Clarity2 => Some(2),
+                                    ClarityVersion::Clarity3 => Some(3),
                                 },
                             },
                         )
@@ -1426,6 +1445,7 @@ impl TransactionPlanSpecification {
                                 clarity_version: match tx.clarity_version {
                                     ClarityVersion::Clarity1 => Some(1),
                                     ClarityVersion::Clarity2 => Some(2),
+                                    ClarityVersion::Clarity3 => Some(3),
                                 },
                             },
                         )

--- a/components/clarinet-files/src/project_manifest.rs
+++ b/components/clarinet-files/src/project_manifest.rs
@@ -158,6 +158,8 @@ where
                     ClarityVersion::Clarity1
                 } else if version.eq(&2) {
                     ClarityVersion::Clarity2
+                } else if version.eq(&3) {
+                    ClarityVersion::Clarity3
                 } else {
                     return Err(serde::de::Error::custom(INVALID_CLARITY_VERSION));
                 }
@@ -463,6 +465,8 @@ fn get_epoch_and_clarity_version(
                 ClarityVersion::Clarity1
             } else if version.eq(&2) {
                 ClarityVersion::Clarity2
+            } else if version.eq(&3) {
+                ClarityVersion::Clarity3
             } else {
                 return Err(INVALID_CLARITY_VERSION.into());
             }

--- a/components/clarinet-files/src/project_manifest.rs
+++ b/components/clarinet-files/src/project_manifest.rs
@@ -10,10 +10,12 @@ use serde_json::Value as JsonValue;
 use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
 use std::str::FromStr;
-use toml::value::Value;
+use toml::Value as TomlValue;
 
-pub const INVALID_CLARITY_VERSION: &str = "clarity_version field invalid (value supported: 1, 2)";
-const INVALID_EPOCH: &str = "epoch field invalid (value supported: 2.0, 2.05, 2.1, 2.2, 2.3, 2.4)";
+pub const INVALID_CLARITY_VERSION: &str =
+    "clarity_version field invalid (value supported: 1, 2, 3)";
+const INVALID_EPOCH: &str =
+    "epoch field invalid (value supported: 2.0, 2.05, 2.1, 2.2, 2.3, 2.4, 3.0)";
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct ClarityContractMetadata {
@@ -26,7 +28,7 @@ pub struct ClarityContractMetadata {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ProjectManifestFile {
     project: ProjectConfigFile,
-    contracts: Option<Value>,
+    contracts: Option<TomlValue>,
     repl: Option<repl::SettingsFile>,
 }
 
@@ -36,7 +38,7 @@ pub struct ProjectConfigFile {
     authors: Option<Vec<String>>,
     description: Option<String>,
     telemetry: Option<bool>,
-    requirements: Option<Value>,
+    requirements: Option<TomlValue>,
     boot_contracts: Option<Vec<String>>,
 
     // The fields below have been moved into repl above, but are kept here for
@@ -95,85 +97,22 @@ where
             _ => ContractDeployer::DefaultDeployer,
         };
 
-        let settings_epoch = contract_settings.get("epoch");
-
-        let epoch = match settings_epoch {
-            None => StacksEpochId::Epoch2_05,
-            Some(JsonValue::String(epoch)) => {
-                if epoch.eq("2.0") {
-                    StacksEpochId::Epoch20
-                } else if epoch.eq("2.05") {
-                    StacksEpochId::Epoch2_05
-                } else if epoch.eq("2.1") {
-                    StacksEpochId::Epoch21
-                } else if epoch.eq("2.2") {
-                    StacksEpochId::Epoch22
-                } else if epoch.eq("2.3") {
-                    StacksEpochId::Epoch23
-                } else if epoch.eq("2.4") {
-                    StacksEpochId::Epoch24
-                } else if epoch.eq("2.5") {
-                    StacksEpochId::Epoch25
-                } else if epoch.eq("3.0") {
-                    StacksEpochId::Epoch30
-                } else {
-                    return Err(serde::de::Error::custom(INVALID_EPOCH));
-                }
-            }
-            Some(JsonValue::Number(epoch)) => {
-                let epoch = epoch.as_f64().unwrap();
-                if epoch.eq(&2.0) {
-                    StacksEpochId::Epoch20
-                } else if epoch.eq(&2.05) {
-                    StacksEpochId::Epoch2_05
-                } else if epoch.eq(&2.1) {
-                    StacksEpochId::Epoch21
-                } else if epoch.eq(&2.2) {
-                    StacksEpochId::Epoch22
-                } else if epoch.eq(&2.3) {
-                    StacksEpochId::Epoch23
-                } else if epoch.eq(&2.4) {
-                    StacksEpochId::Epoch24
-                } else if epoch.eq(&2.5) {
-                    StacksEpochId::Epoch25
-                } else if epoch.eq(&3.0) {
-                    StacksEpochId::Epoch30
-                } else {
-                    return Err(serde::de::Error::custom(INVALID_EPOCH));
-                }
-            }
-            _ => {
-                return Err(serde::de::Error::custom(INVALID_EPOCH));
-            }
+        let parsed_settings_epoch = match contract_settings.get("epoch") {
+            None => None,
+            Some(JsonValue::String(epoch)) => Some(epoch.as_str()),
+            Some(JsonValue::Number(epoch)) => Some(epoch.as_str()),
+            _ => return Err(serde::de::Error::custom(INVALID_EPOCH)),
         };
 
-        let clarity_version = match contract_settings.get("clarity_version") {
-            None => match settings_epoch {
-                None => ClarityVersion::Clarity1,
-                Some(_) => ClarityVersion::default_for_epoch(epoch),
-            },
-            Some(JsonValue::Number(version)) => {
-                let version = version.as_i64().unwrap();
-                if version.eq(&1) {
-                    ClarityVersion::Clarity1
-                } else if version.eq(&2) {
-                    ClarityVersion::Clarity2
-                } else if version.eq(&3) {
-                    ClarityVersion::Clarity3
-                } else {
-                    return Err(serde::de::Error::custom(INVALID_CLARITY_VERSION));
-                }
-            }
-            _ => {
-                return Err(serde::de::Error::custom(INVALID_CLARITY_VERSION));
-            }
+        let parsed_clarity_version = match contract_settings.get("clarity_version") {
+            None => None,
+            Some(JsonValue::Number(version)) => Some(version.as_str()),
+            _ => return Err(serde::de::Error::custom(INVALID_CLARITY_VERSION)),
         };
 
-        if clarity_version > ClarityVersion::default_for_epoch(epoch) {
-            return Err(serde::de::Error::custom(format!(
-                "{clarity_version} can not be used with {epoch}"
-            )));
-        }
+        let (epoch, clarity_version) =
+            get_epoch_and_clarity_version(parsed_settings_epoch, parsed_clarity_version)
+                .map_err(serde::de::Error::custom)?;
 
         let cc = ClarityContract {
             code_source,
@@ -331,22 +270,22 @@ impl ProjectManifest {
         let mut contracts_settings = HashMap::new();
         let mut config_requirements: Vec<RequirementConfig> = Vec::new();
 
-        if let Some(Value::Array(requirements)) = project_manifest_file.project.requirements {
+        if let Some(TomlValue::Array(requirements)) = project_manifest_file.project.requirements {
             for link_settings in requirements.iter() {
-                if let Value::Table(link_settings) = link_settings {
+                if let TomlValue::Table(link_settings) = link_settings {
                     let contract_id = match link_settings.get("contract_id") {
-                        Some(Value::String(contract_id)) => contract_id.to_string(),
+                        Some(TomlValue::String(contract_id)) => contract_id.to_string(),
                         _ => continue,
                     };
                     config_requirements.push(RequirementConfig { contract_id });
                 }
             }
         };
-        if let Some(Value::Table(contracts)) = project_manifest_file.contracts {
+        if let Some(TomlValue::Table(contracts)) = project_manifest_file.contracts {
             for (contract_name, contract_settings) in contracts.iter() {
-                if let Value::Table(contract_settings) = contract_settings {
+                if let TomlValue::Table(contract_settings) = contract_settings {
                     let contract_path = match contract_settings.get("path") {
-                        Some(Value::String(path)) => path,
+                        Some(TomlValue::String(path)) => path,
                         _ => continue,
                     };
                     let code_source = match PathBuf::from_str(contract_path) {
@@ -356,15 +295,30 @@ impl ProjectManifest {
                         }
                     };
                     let deployer = match contract_settings.get("deployer") {
-                        Some(Value::String(path)) => {
+                        Some(TomlValue::String(path)) => {
                             ContractDeployer::LabeledDeployer(path.clone())
                         }
                         _ => ContractDeployer::DefaultDeployer,
                     };
 
+                    let parsed_epoch = match contract_settings.get("epoch") {
+                        Some(TomlValue::String(epoch)) => Some(epoch.clone()),
+                        Some(TomlValue::Float(epoch)) => Some(epoch.to_string()),
+                        None => None,
+                        _ => return Err(INVALID_EPOCH.into()),
+                    };
+
+                    let parsed_clarity_version = match contract_settings.get("clarity_version") {
+                        Some(TomlValue::Integer(clarity_version)) => {
+                            Some(clarity_version.to_string())
+                        }
+                        None => None,
+                        _ => return Err(INVALID_CLARITY_VERSION.into()),
+                    };
+
                     let (epoch, clarity_version) = get_epoch_and_clarity_version(
-                        contract_settings.get("epoch"),
-                        contract_settings.get("clarity_version"),
+                        parsed_epoch.as_deref(),
+                        parsed_clarity_version.as_deref(),
                     )?;
 
                     config_contracts.insert(
@@ -400,59 +354,25 @@ impl ProjectManifest {
 }
 
 fn get_epoch_and_clarity_version(
-    settings_epoch: Option<&Value>,
-    settings_clarity_version: Option<&Value>,
+    settings_epoch: Option<&str>,
+    settings_clarity_version: Option<&str>,
 ) -> Result<(StacksEpochId, ClarityVersion), String> {
     // if neither epoch or version are specified in clarinet.toml use: epoch 2.05 and clarity 1
     // if epoch is specified but not version: use the default version for that epoch
 
     let epoch = match settings_epoch {
         None => StacksEpochId::Epoch2_05,
-        Some(Value::String(epoch)) => {
-            if epoch.eq("2.0") {
-                StacksEpochId::Epoch20
-            } else if epoch.eq("2.05") {
-                StacksEpochId::Epoch2_05
-            } else if epoch.eq("2.1") {
-                StacksEpochId::Epoch21
-            } else if epoch.eq("2.2") {
-                StacksEpochId::Epoch22
-            } else if epoch.eq("2.3") {
-                StacksEpochId::Epoch23
-            } else if epoch.eq("2.4") {
-                StacksEpochId::Epoch24
-            } else if epoch.eq("2.5") {
-                StacksEpochId::Epoch25
-            } else if epoch.eq("3.0") {
-                StacksEpochId::Epoch30
-            } else {
-                return Err(INVALID_EPOCH.into());
-            }
-        }
-        Some(Value::Float(epoch)) => {
-            if epoch.eq(&2.0) {
-                StacksEpochId::Epoch20
-            } else if epoch.eq(&2.05) {
-                StacksEpochId::Epoch2_05
-            } else if epoch.eq(&2.1) {
-                StacksEpochId::Epoch21
-            } else if epoch.eq(&2.2) {
-                StacksEpochId::Epoch22
-            } else if epoch.eq(&2.3) {
-                StacksEpochId::Epoch23
-            } else if epoch.eq(&2.4) {
-                StacksEpochId::Epoch24
-            } else if epoch.eq(&2.5) {
-                StacksEpochId::Epoch25
-            } else if epoch.eq(&3.0) {
-                StacksEpochId::Epoch30
-            } else {
-                return Err(INVALID_EPOCH.into());
-            }
-        }
-        _ => {
-            return Err(INVALID_EPOCH.into());
-        }
+        Some(epoch) => match epoch {
+            "2" | "2.0" => StacksEpochId::Epoch20,
+            "2.05" => StacksEpochId::Epoch2_05,
+            "2.1" => StacksEpochId::Epoch21,
+            "2.2" => StacksEpochId::Epoch22,
+            "2.3" => StacksEpochId::Epoch23,
+            "2.4" => StacksEpochId::Epoch24,
+            "2.5" => StacksEpochId::Epoch25,
+            "3" | "3.0" => StacksEpochId::Epoch30,
+            _ => return Err(INVALID_EPOCH.into()),
+        },
     };
 
     let clarity_version = match settings_clarity_version {
@@ -460,20 +380,8 @@ fn get_epoch_and_clarity_version(
             None => ClarityVersion::Clarity1,
             Some(_) => ClarityVersion::default_for_epoch(epoch),
         },
-        Some(Value::Integer(version)) => {
-            if version.eq(&1) {
-                ClarityVersion::Clarity1
-            } else if version.eq(&2) {
-                ClarityVersion::Clarity2
-            } else if version.eq(&3) {
-                ClarityVersion::Clarity3
-            } else {
-                return Err(INVALID_CLARITY_VERSION.into());
-            }
-        }
-        _ => {
-            return Err(INVALID_CLARITY_VERSION.into());
-        }
+        Some(version) => ClarityVersion::from_str(&format!("clarity{version}"))
+            .map_err(|_| INVALID_CLARITY_VERSION)?,
     };
 
     if clarity_version > ClarityVersion::default_for_epoch(epoch) {
@@ -492,54 +400,45 @@ fn test_get_epoch_and_clarity_version() {
     let result = get_epoch_and_clarity_version(None, None);
     assert_eq!(result, Ok((Epoch2_05, Clarity1)));
 
-    // no version
-    // epoch 2.0
-    let result = get_epoch_and_clarity_version(Some(&Value::String(String::from("2.0"))), None);
+    // epoch 2.0, no version
+    let result = get_epoch_and_clarity_version(Some("2.0"), None);
     assert_eq!(result, Ok((Epoch20, Clarity1)));
 
     // epoch 2.05, no version
-    let result = get_epoch_and_clarity_version(Some(&Value::String(String::from("2.05"))), None);
+    let result = get_epoch_and_clarity_version(Some("2.05"), None);
     assert_eq!(result, Ok((Epoch2_05, Clarity1)));
 
     // epoch 2.1, no version
-    let result = get_epoch_and_clarity_version(Some(&Value::String(String::from("2.1"))), None);
+    let result = get_epoch_and_clarity_version(Some("2.1"), None);
     assert_eq!(result, Ok((Epoch21, Clarity2)));
+
+    // epoch 3.0, no version
+    let result = get_epoch_and_clarity_version(Some("3.0"), None);
+    assert_eq!(result, Ok((Epoch30, Clarity3)));
 
     // no epoch
     // no epoch, version 1
-    let result = get_epoch_and_clarity_version(None, Some(&Value::Integer(1)));
+    let result = get_epoch_and_clarity_version(None, Some("1"));
     assert_eq!(result, Ok((Epoch2_05, Clarity1)));
 
     // no epoch, version 2 -> error, must specify epoch
-    let result = get_epoch_and_clarity_version(None, Some(&Value::Integer(2)));
+    let result = get_epoch_and_clarity_version(None, Some("2"));
     assert_eq!(result, Err("Clarity 2 can not be used with 2.05".into()));
 
     // epoch and clarity version
     // no epoch 2.05, version 1
-    let result = get_epoch_and_clarity_version(
-        Some(&Value::String(String::from("2.05"))),
-        Some(&Value::Integer(1)),
-    );
+    let result = get_epoch_and_clarity_version(Some("2.05"), Some("1"));
     assert_eq!(result, Ok((Epoch2_05, Clarity1)));
 
     // no epoch 2.05, version 2 -> error
-    let result = get_epoch_and_clarity_version(
-        Some(&Value::String(String::from("2.05"))),
-        Some(&Value::Integer(2)),
-    );
+    let result = get_epoch_and_clarity_version(Some("2.05"), Some("2"));
     assert_eq!(result, Err("Clarity 2 can not be used with 2.05".into()));
 
     // no epoch 2.05, version 1
-    let result = get_epoch_and_clarity_version(
-        Some(&Value::String(String::from("2.1"))),
-        Some(&Value::Integer(1)),
-    );
+    let result = get_epoch_and_clarity_version(Some("2.1"), Some("1"));
     assert_eq!(result, Ok((Epoch21, Clarity1)));
 
     // no epoch 2.05, version 2 -> error
-    let result = get_epoch_and_clarity_version(
-        Some(&Value::String(String::from("2.1"))),
-        Some(&Value::Integer(2)),
-    );
+    let result = get_epoch_and_clarity_version(Some("2.1"), Some("2"));
     assert_eq!(result, Ok((Epoch21, Clarity2)));
 }

--- a/components/clarinet-sdk-wasm/src/core.rs
+++ b/components/clarinet-sdk-wasm/src/core.rs
@@ -140,6 +140,7 @@ impl ContractOptions {
             Some(v) => match v {
                 1 => ClarityVersion::Clarity1,
                 2 => ClarityVersion::Clarity2,
+                3 => ClarityVersion::Clarity3,
                 _ => {
                     log!("Invalid clarity version {v}. Using default version.");
                     DEFAULT_CLARITY_VERSION

--- a/components/clarity-lsp/src/common/requests/api_ref.rs
+++ b/components/clarity-lsp/src/common/requests/api_ref.rs
@@ -21,7 +21,7 @@ lazy_static! {
             let reference = make_define_reference(define_function);
             api_references.insert(
                 define_function.to_string(),
-                (reference.version, Vec::from([
+                (reference.min_version, Vec::from([
                     &code(&reference.signature),
                     separator,
                     "**Description**",
@@ -38,7 +38,7 @@ lazy_static! {
             let reference = make_api_reference(native_function);
             api_references.insert(
                 native_function.to_string(),
-                (reference.version, Vec::from([
+                (reference.min_version, Vec::from([
                     &code(format!("{} -> {}", &reference.signature, &reference.output_type).as_str()),
                     separator,
                     "**Description**",
@@ -47,7 +47,7 @@ lazy_static! {
                     "**Example**",
                     &code(&reference.example),
                     separator,
-                    &format!("**Introduced in:** {}", &reference.version),
+                    &format!("**Introduced in:** {}", &reference.min_version),
                 ])
                 .join("\n"), Some(reference)),
             );
@@ -57,14 +57,14 @@ lazy_static! {
             let reference = make_keyword_reference(native_keyword).unwrap();
             api_references.insert(
                 native_keyword.to_string(),
-                (reference.version, Vec::from([
+                (reference.min_version, Vec::from([
                     "**Description**",
                     reference.description,
                     separator,
                     "**Example**",
                     &code(reference.example),
                     separator,
-                    &format!("**Introduced in:** {}", &reference.version),
+                    &format!("**Introduced in:** {}", &reference.min_version),
                 ])
                 .join("\n"), None),
             );

--- a/components/clarity-lsp/src/common/requests/api_ref.rs
+++ b/components/clarity-lsp/src/common/requests/api_ref.rs
@@ -11,26 +11,42 @@ fn code(code: &str) -> String {
     ["```clarity", code.trim(), "```"].join("\n")
 }
 
+fn format_removed_in(max_version: Option<ClarityVersion>) -> String {
+    max_version
+        .map(|max_version| {
+            format!(
+                "Removed in **{}**",
+                match max_version {
+                    ClarityVersion::Clarity1 => ClarityVersion::Clarity2,
+                    ClarityVersion::Clarity2 => ClarityVersion::Clarity3,
+                    ClarityVersion::Clarity3 => ClarityVersion::latest(),
+                }
+            )
+        })
+        .unwrap_or_default()
+}
+
 lazy_static! {
-    pub static ref API_REF: HashMap<String, (ClarityVersion, String, Option<FunctionAPI>)> = {
-        let mut api_references: HashMap<String, (ClarityVersion, String, Option<FunctionAPI>)> = HashMap::new();
-         // "---" can produce h2 if placed under text
+    pub static ref API_REF: HashMap<String, (String, Option<FunctionAPI>)> = {
+        let mut api_references: HashMap<String, (String, Option<FunctionAPI>)> = HashMap::new();
         let separator = "- - -";
 
         for define_function in DefineFunctions::ALL {
             let reference = make_define_reference(define_function);
             api_references.insert(
                 define_function.to_string(),
-                (reference.min_version, Vec::from([
-                    &code(&reference.signature),
-                    separator,
-                    "**Description**",
-                    &reference.description,
-                    separator,
-                    "**Example**",
-                    &code(&reference.example),
-                ])
-                .join("\n"), Some(reference)),
+                (
+                    Vec::from([
+                        &code(&reference.signature),
+                        separator,
+                        &reference.description,
+                        separator,
+                        "**Example**",
+                        &code(&reference.example),
+                    ])
+                    .join("\n"),
+                    Some(reference),
+                ),
             );
         }
 
@@ -38,18 +54,24 @@ lazy_static! {
             let reference = make_api_reference(native_function);
             api_references.insert(
                 native_function.to_string(),
-                (reference.min_version, Vec::from([
-                    &code(format!("{} -> {}", &reference.signature, &reference.output_type).as_str()),
-                    separator,
-                    "**Description**",
-                    &reference.description,
-                    separator,
-                    "**Example**",
-                    &code(&reference.example),
-                    separator,
-                    &format!("**Introduced in:** {}", &reference.min_version),
-                ])
-                .join("\n"), Some(reference)),
+                (
+                    Vec::from([
+                        &code(
+                            format!("{} -> {}", &reference.signature, &reference.output_type)
+                                .as_str(),
+                        ),
+                        separator,
+                        &reference.description,
+                        separator,
+                        &format!("Introduced in **{}**  ", &reference.min_version),
+                        &format_removed_in(reference.max_version),
+                        separator,
+                        "**Example**",
+                        &code(&reference.example),
+                    ])
+                    .join("\n"),
+                    Some(reference),
+                ),
             );
         }
 
@@ -57,16 +79,19 @@ lazy_static! {
             let reference = make_keyword_reference(native_keyword).unwrap();
             api_references.insert(
                 native_keyword.to_string(),
-                (reference.min_version, Vec::from([
-                    "**Description**",
-                    reference.description,
-                    separator,
-                    "**Example**",
-                    &code(reference.example),
-                    separator,
-                    &format!("**Introduced in:** {}", &reference.min_version),
-                ])
-                .join("\n"), None),
+                (
+                    Vec::from([
+                        reference.description,
+                        separator,
+                        &format!("Introduced in **{}**  ", &reference.min_version),
+                        &format_removed_in(reference.max_version),
+                        separator,
+                        "**Example**",
+                        &code(reference.example),
+                    ])
+                    .join("\n"),
+                    None,
+                ),
             );
         }
 

--- a/components/clarity-lsp/src/common/requests/completion.rs
+++ b/components/clarity-lsp/src/common/requests/completion.rs
@@ -26,6 +26,8 @@ lazy_static! {
         build_default_native_keywords_list(ClarityVersion::Clarity1);
     static ref COMPLETION_ITEMS_CLARITY_2: Vec<CompletionItem> =
         build_default_native_keywords_list(ClarityVersion::Clarity2);
+    static ref COMPLETION_ITEMS_CLARITY_3: Vec<CompletionItem> =
+        build_default_native_keywords_list(ClarityVersion::Clarity3);
     static ref VAR_FUNCTIONS: Vec<String> = vec![
         NativeFunctions::SetVar.to_string(),
         NativeFunctions::FetchVar.to_string(),
@@ -58,14 +60,20 @@ lazy_static! {
         build_map_valid_cb_completion_items(ClarityVersion::Clarity1);
     static ref VALID_MAP_FUNCTIONS_CLARITY_2: Vec<CompletionItem> =
         build_map_valid_cb_completion_items(ClarityVersion::Clarity2);
+    static ref VALID_MAP_FUNCTIONS_CLARITY_3: Vec<CompletionItem> =
+        build_map_valid_cb_completion_items(ClarityVersion::Clarity3);
     static ref VALID_FILTER_FUNCTIONS_CLARITY_1: Vec<CompletionItem> =
         build_filter_valid_cb_completion_items(ClarityVersion::Clarity1);
     static ref VALID_FILTER_FUNCTIONS_CLARITY_2: Vec<CompletionItem> =
         build_filter_valid_cb_completion_items(ClarityVersion::Clarity2);
+    static ref VALID_FILTER_FUNCTIONS_CLARITY_3: Vec<CompletionItem> =
+        build_filter_valid_cb_completion_items(ClarityVersion::Clarity3);
     static ref VALID_FOLD_FUNCTIONS_CLARITY_1: Vec<CompletionItem> =
         build_fold_valid_cb_completion_items(ClarityVersion::Clarity1);
     static ref VALID_FOLD_FUNCTIONS_CLARITY_2: Vec<CompletionItem> =
         build_fold_valid_cb_completion_items(ClarityVersion::Clarity2);
+    static ref VALID_FOLD_FUNCTIONS_CLARITY_3: Vec<CompletionItem> =
+        build_fold_valid_cb_completion_items(ClarityVersion::Clarity3);
 }
 
 #[derive(Clone, Debug, Default)]
@@ -381,6 +389,7 @@ pub fn build_completion_item_list(
     let native_keywords = match clarity_version {
         ClarityVersion::Clarity1 => COMPLETION_ITEMS_CLARITY_1.to_vec(),
         ClarityVersion::Clarity2 => COMPLETION_ITEMS_CLARITY_2.to_vec(),
+        ClarityVersion::Clarity3 => COMPLETION_ITEMS_CLARITY_3.to_vec(),
     };
     let placeholder_pattern = Regex::new(r" \$\{\d+:[\w-]+\}").unwrap();
 
@@ -503,13 +512,13 @@ pub fn build_default_native_keywords_list(version: ClarityVersion) -> Vec<Comple
         .iter()
         .filter_map(|func| {
             let mut api = make_api_reference(func);
-            if api.version > version {
+            if api.min_version > version {
                 return None;
             }
             if clarity2_aliased_functions.contains(func) {
                 if version >= ClarityVersion::Clarity2 {
                     return None;
-                } else if api.version == ClarityVersion::Clarity1 {
+                } else if api.min_version == ClarityVersion::Clarity1 {
                     // only for element-at? and index-of?
                     api.snippet = api.snippet.replace('?', "");
                 }
@@ -535,7 +544,7 @@ pub fn build_default_native_keywords_list(version: ClarityVersion) -> Vec<Comple
         .iter()
         .filter_map(|func| {
             let api = make_define_reference(func);
-            if api.version > version {
+            if api.min_version > version {
                 return None;
             }
             Some(CompletionItem {
@@ -558,7 +567,7 @@ pub fn build_default_native_keywords_list(version: ClarityVersion) -> Vec<Comple
         .iter()
         .filter_map(|var| {
             if let Some(api) = make_keyword_reference(var) {
-                if api.version > version {
+                if api.min_version > version {
                     return None;
                 }
                 Some(CompletionItem {
@@ -582,7 +591,7 @@ pub fn build_default_native_keywords_list(version: ClarityVersion) -> Vec<Comple
     let block_properties: Vec<CompletionItem> = BlockInfoProperty::ALL
         .iter()
         .filter_map(|var| {
-            if var.get_version() > version {
+            if var.get_min_version() > version {
                 return None;
             }
             Some(CompletionItem {
@@ -727,7 +736,7 @@ fn build_iterator_cb_completion_item(
     version: ClarityVersion,
 ) -> Option<CompletionItem> {
     let api = make_api_reference(func);
-    if api.version > version {
+    if api.min_version > version {
         return None;
     }
 
@@ -751,18 +760,21 @@ fn get_iterator_cb_completion_item(version: &ClarityVersion, func: &str) -> Vec<
     if func.to_string().eq(&NativeFunctions::Map.to_string()) {
         return match version {
             ClarityVersion::Clarity1 => VALID_MAP_FUNCTIONS_CLARITY_1.to_vec(),
-            ClarityVersion::Clarity2 => VALID_MAP_FUNCTIONS_CLARITY_1.to_vec(),
+            ClarityVersion::Clarity2 => VALID_MAP_FUNCTIONS_CLARITY_2.to_vec(),
+            ClarityVersion::Clarity3 => VALID_MAP_FUNCTIONS_CLARITY_3.to_vec(),
         };
     }
     if func.to_string().eq(&NativeFunctions::Filter.to_string()) {
         return match version {
             ClarityVersion::Clarity1 => VALID_FILTER_FUNCTIONS_CLARITY_1.to_vec(),
-            ClarityVersion::Clarity2 => VALID_FILTER_FUNCTIONS_CLARITY_1.to_vec(),
+            ClarityVersion::Clarity2 => VALID_FILTER_FUNCTIONS_CLARITY_2.to_vec(),
+            ClarityVersion::Clarity3 => VALID_FILTER_FUNCTIONS_CLARITY_3.to_vec(),
         };
     }
     match version {
         ClarityVersion::Clarity1 => VALID_FOLD_FUNCTIONS_CLARITY_1.to_vec(),
-        ClarityVersion::Clarity2 => VALID_FOLD_FUNCTIONS_CLARITY_1.to_vec(),
+        ClarityVersion::Clarity2 => VALID_FOLD_FUNCTIONS_CLARITY_2.to_vec(),
+        ClarityVersion::Clarity3 => VALID_FOLD_FUNCTIONS_CLARITY_3.to_vec(),
     }
 }
 

--- a/components/clarity-lsp/src/common/requests/completion.rs
+++ b/components/clarity-lsp/src/common/requests/completion.rs
@@ -512,7 +512,9 @@ pub fn build_default_native_keywords_list(version: ClarityVersion) -> Vec<Comple
         .iter()
         .filter_map(|func| {
             let mut api = make_api_reference(func);
-            if api.min_version > version {
+            if version < api.min_version
+                || version > api.max_version.unwrap_or(ClarityVersion::latest())
+            {
                 return None;
             }
             if clarity2_aliased_functions.contains(func) {
@@ -544,7 +546,9 @@ pub fn build_default_native_keywords_list(version: ClarityVersion) -> Vec<Comple
         .iter()
         .filter_map(|func| {
             let api = make_define_reference(func);
-            if api.min_version > version {
+            if version < api.min_version
+                || version > api.max_version.unwrap_or(ClarityVersion::latest())
+            {
                 return None;
             }
             Some(CompletionItem {
@@ -567,7 +571,9 @@ pub fn build_default_native_keywords_list(version: ClarityVersion) -> Vec<Comple
         .iter()
         .filter_map(|var| {
             if let Some(api) = make_keyword_reference(var) {
-                if api.min_version > version {
+                if version < api.min_version
+                    || version > api.max_version.unwrap_or(ClarityVersion::latest())
+                {
                     return None;
                 }
                 Some(CompletionItem {

--- a/components/clarity-lsp/src/common/requests/hover.rs
+++ b/components/clarity-lsp/src/common/requests/hover.rs
@@ -1,22 +1,15 @@
-use clarity_repl::clarity::{ClarityVersion, SymbolicExpression};
+use clarity_repl::clarity::SymbolicExpression;
 use lsp_types::Position;
 
 use super::{api_ref::API_REF, helpers::get_expression_name_at_position};
 
 pub fn get_expression_documentation(
     position: &Position,
-    clarity_version: ClarityVersion,
     expressions: &Vec<SymbolicExpression>,
 ) -> Option<String> {
     let expression_name = get_expression_name_at_position(position, expressions)?;
 
-    match API_REF.get(&expression_name.to_string()) {
-        Some((version, documentation, _)) => {
-            if version <= &clarity_version {
-                return Some(documentation.to_owned());
-            }
-            None
-        }
-        None => None,
-    }
+    API_REF
+        .get(&expression_name.to_string())
+        .map(|(documentation, _)| documentation.to_owned())
 }

--- a/components/clarity-lsp/src/common/requests/signature_help.rs
+++ b/components/clarity-lsp/src/common/requests/signature_help.rs
@@ -28,16 +28,12 @@ pub fn get_signatures(
         return None;
     }
 
-    let (version, _, reference) = API_REF.get(&function_name.to_string())?;
+    let (_, reference) = API_REF.get(&function_name.to_string())?;
     let FunctionAPI {
         signature,
         output_type,
         ..
     } = (*reference).as_ref()?;
-
-    if version > &contract.clarity_version {
-        return None;
-    }
 
     let signatures = signature
         .split(" |")

--- a/components/clarity-lsp/src/common/state.rs
+++ b/components/clarity-lsp/src/common/state.rs
@@ -413,11 +413,8 @@ impl EditorState {
             line: position.line + 1,
             character: position.character + 1,
         };
-        let documentation = get_expression_documentation(
-            &position,
-            contract.clarity_version,
-            contract.expressions.as_ref()?,
-        )?;
+        let documentation =
+            get_expression_documentation(&position, contract.expressions.as_ref()?)?;
 
         Some(Hover {
             contents: lsp_types::HoverContents::Markup(lsp_types::MarkupContent {

--- a/components/clarity-repl/Cargo.toml
+++ b/components/clarity-repl/Cargo.toml
@@ -35,7 +35,7 @@ getrandom = { version = "0.2.3", features = ["js"] }
 atty = "0.2.14"
 # clarity-vm = { version = "2.3.0", default-features = false }
 clarity = { git = "https://github.com/stacks-network/stacks-core.git", branch="feat/clarity-wasm-develop", package = "clarity", default-features = false }
-clar2wasm = { git = "https://github.com/stacks-network/clarity-wasm.git", optional = true }
+clar2wasm = { git = "https://github.com/stacks-network/clarity-wasm.git", branch = "chore/update-clarity", optional = true }
 # clar2wasm = { path="../../../clarity-wasm/clar2wasm", optional = true }
 pox-locking = { git = "https://github.com/stacks-network/stacks-core.git", branch="feat/clarity-wasm-develop", optional = true, default-features = false }
 

--- a/components/clarity-repl/src/repl/datastore.rs
+++ b/components/clarity-repl/src/repl/datastore.rs
@@ -461,6 +461,14 @@ impl BurnStateDB for BurnDatastore {
         0
     }
 
+    fn get_tip_burn_block_height(&self) -> Option<u32> {
+        Some(0)
+    }
+
+    fn get_tip_sortition_id(&self) -> Option<SortitionId> {
+        Some(SortitionId([0; 32]))
+    }
+
     /// Returns the *burnchain block height* for the `sortition_id` is associated with.
     fn get_burn_block_height(&self, sortition_id: &SortitionId) -> Option<u32> {
         self.sortition_lookup

--- a/components/clarity-repl/src/repl/mod.rs
+++ b/components/clarity-repl/src/repl/mod.rs
@@ -62,6 +62,9 @@ impl Serialize for ClarityContract {
             ClarityVersion::Clarity2 => {
                 map.serialize_entry("clarity_version", &2)?;
             }
+            ClarityVersion::Clarity3 => {
+                map.serialize_entry("clarity_version", &3)?;
+            }
         }
         match self.epoch {
             StacksEpochId::Epoch10 => {

--- a/components/clarity-vscode/syntaxes/clarity.tmLanguage.json
+++ b/components/clarity-vscode/syntaxes/clarity.tmLanguage.json
@@ -31,7 +31,7 @@
     },
     "keyword": {
       "name": "constant.language.clarity",
-      "match": "(?<!\\S)(?!-)\\b(?:block-height|burn-block-height|chain-id|contract-caller|is-in-regtest|stx-liquid-supply|tx-sender|tx-sponsor?)\\b(?!\\s*-)"
+      "match": "(?<!\\S)(?!-)\\b(?:block-height|burn-block-height|chain-id|contract-caller|is-in-regtest|stacks-block-height|stx-liquid-supply|tenure-height|tx-sender|tx-sponsor?)\\b(?!\\s*-)"
     },
     "define-function": {
       "begin": "(?x) (\\() \\s* (define-(?:public|private|read-only)) \\s+",

--- a/components/stacks-codec/src/codec.rs
+++ b/components/stacks-codec/src/codec.rs
@@ -2485,6 +2485,7 @@ fn clarity_version_consensus_serialize<W: Write>(
     match *version {
         ClarityVersion::Clarity1 => write_next(fd, &1u8)?,
         ClarityVersion::Clarity2 => write_next(fd, &2u8)?,
+        ClarityVersion::Clarity3 => write_next(fd, &3u8)?,
     }
     Ok(())
 }
@@ -2496,6 +2497,7 @@ fn clarity_version_consensus_deserialize<R: Read>(
     match version_byte {
         1u8 => Ok(ClarityVersion::Clarity1),
         2u8 => Ok(ClarityVersion::Clarity2),
+        3u8 => Ok(ClarityVersion::Clarity3),
         _ => Err(CodecError::DeserializeError(format!(
             "Unrecognized ClarityVersion byte {}",
             &version_byte


### PR DESCRIPTION
### Description

Update clarity-vm and clar2wasm.

Handle clarity 3 keywords as well as the new `max_version` property in the clarity reference.
Tried to make it clearer when a keyword/function was introduced and removed

---

**Before:**
<img width="749" alt="Screenshot 2024-06-03 at 17 53 46" src="https://github.com/hirosystems/clarinet/assets/911307/5e99fbf5-9d37-442c-b7e7-6dfc0b1b8eaf">

**After:**
<img width="726" alt="Screenshot 2024-06-03 at 17 50 47" src="https://github.com/hirosystems/clarinet/assets/911307/4ecaf77b-98f2-4aed-9f4f-3892ebaaf006">

With error (previously, it wouldn't even show the documentation)
<img width="696" alt="Screenshot 2024-06-03 at 17 55 13" src="https://github.com/hirosystems/clarinet/assets/911307/0b84939a-ef83-49b2-8042-2ae3a868a700">
