### PR TITLE
fix: block height increment in sdk mine_block

### DIFF
--- a/components/clarinet-sdk-wasm/src/core.rs
+++ b/components/clarinet-sdk-wasm/src/core.rs
@@ -725,8 +725,9 @@ impl SDK {
         if interface.access != ContractInterfaceFunctionAccess::public {
             return Err(format!("{} is not a public function", &args.method));
         }
-        let session = self.get_session_mut();
+
         if advance_chain_tip {
+            let session = self.get_session_mut();
             session.advance_chain_tip(1);
         }
         self.call_contract_fn(args, false)
@@ -741,8 +742,8 @@ impl SDK {
         if interface.access != ContractInterfaceFunctionAccess::private {
             return Err(format!("{} is not a private function", &args.method));
         }
-        let session = self.get_session_mut();
         if advance_chain_tip {
+            let session = self.get_session_mut();
             session.advance_chain_tip(1);
         }
         self.call_contract_fn(args, true)
@@ -854,6 +855,11 @@ impl SDK {
             .into_serde()
             .map_err(|e| format!("Failed to parse js txs: {:}", e))?;
 
+        {
+            let session = self.get_session_mut();
+            session.advance_chain_tip(1);
+        }
+
         for tx in txs {
             let result = if let Some(call_public) = tx.call_public_fn {
                 self.inner_call_public_fn(&CallFnArgs::from_json_args(call_public), false)
@@ -868,9 +874,6 @@ impl SDK {
             }?;
             results.push(result);
         }
-
-        let session = self.get_session_mut();
-        session.advance_chain_tip(1);
 
         encode_to_js(&results).map_err(|e| format!("error: {}", e))
     }

--- a/components/clarinet-sdk/tests/deployment-plan.test.ts
+++ b/components/clarinet-sdk/tests/deployment-plan.test.ts
@@ -53,7 +53,7 @@ describe("deployment plans test", async () => {
 
     // test that all 3 contracts are deployed
     const contracts = simnet.getContractsInterfaces();
-    expect(contracts.size).toBe(nbOfBootContracts + 3);
+    expect(contracts.size).toBe(nbOfBootContracts + 4);
 
     // the additional custom tx should have been applied
     const count = simnet.getDataVar("counter", "count");

--- a/components/clarinet-sdk/tests/fixtures/Clarinet.toml
+++ b/components/clarinet-sdk/tests/fixtures/Clarinet.toml
@@ -19,3 +19,8 @@ epoch = 2.4
 path = 'contracts/counter.clar'
 clarity_version = 2
 epoch = 2.4
+
+[contracts.block-height-tests]
+path = 'contracts/block-height-tests.clar'
+clarity_version = 2
+epoch = 2.4

--- a/components/clarinet-sdk/tests/fixtures/contracts/block-height-tests.clar
+++ b/components/clarinet-sdk/tests/fixtures/contracts/block-height-tests.clar
@@ -1,0 +1,3 @@
+(define-public (get-block-height)
+  (ok block-height)
+)

--- a/components/clarinet-sdk/tests/reports.test.ts
+++ b/components/clarinet-sdk/tests/reports.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it, beforeEach, afterEach } from "vitest";
 
 // test the built package and not the source code
 // makes it simpler to handle wasm build
-import { Simnet, initSimnet } from "../dist/esm";
+import { initSimnet } from "../dist/esm";
 
 const address1 = "ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5";
 

--- a/components/clarinet-sdk/tests/simnet-usage.test.ts
+++ b/components/clarinet-sdk/tests/simnet-usage.test.ts
@@ -217,6 +217,22 @@ describe("simnet can call contracts function", () => {
   });
 });
 
+describe("mineBlock and callPublicFunction properly handle block height incrementation", () => {
+  const expectedReturnedBH = 2;
+
+  it("increases the block height after the call in callPublicFn", () => {
+    const { result } = simnet.callPublicFn("block-height-tests", "get-block-height", [], address1);
+    expect(result).toStrictEqual(Cl.ok(Cl.uint(expectedReturnedBH)));
+  });
+
+  it("increases the block height after the call in mineBlock", () => {
+    const [{ result }] = simnet.mineBlock([
+      tx.callPublicFn("block-height-tests", "get-block-height", [], address1),
+    ]);
+    expect(result).toStrictEqual(Cl.ok(Cl.uint(expectedReturnedBH)));
+  });
+});
+
 describe("simnet can read contracts data vars and maps", () => {
   it("can get data-vars", () => {
     const counter = simnet.getDataVar("counter", "count");
@@ -239,7 +255,7 @@ describe("simnet can read contracts data vars and maps", () => {
 describe("simnet can get contracts info and deploy contracts", () => {
   it("can get contract interfaces", () => {
     const contractInterfaces = simnet.getContractsInterfaces();
-    expect(contractInterfaces).toHaveLength(nbOfBootContracts + 3);
+    expect(contractInterfaces).toHaveLength(nbOfBootContracts + 4);
 
     const counterInterface = contractInterfaces.get(`${deployerAddr}.counter`);
     expect(counterInterface).not.toBeNull();
@@ -273,7 +289,7 @@ describe("simnet can get contracts info and deploy contracts", () => {
     expect(res.result).toStrictEqual(Cl.int(42));
 
     const contractInterfaces = simnet.getContractsInterfaces();
-    expect(contractInterfaces).toHaveLength(nbOfBootContracts + 3);
+    expect(contractInterfaces).toHaveLength(nbOfBootContracts + 4);
   });
 
   it("can deploy contracts", () => {
@@ -282,7 +298,7 @@ describe("simnet can get contracts info and deploy contracts", () => {
     expect(deployRes.result).toStrictEqual(Cl.bool(true));
 
     const contractInterfaces = simnet.getContractsInterfaces();
-    expect(contractInterfaces).toHaveLength(nbOfBootContracts + 4);
+    expect(contractInterfaces).toHaveLength(nbOfBootContracts + 5);
 
     const addRes = simnet.callPublicFn("op", "add", [Cl.uint(13), Cl.uint(29)], address1);
     expect(addRes.result).toStrictEqual(Cl.ok(Cl.uint(42)));

--- a/components/clarity-lsp/src/common/requests/signature_help.rs
+++ b/components/clarity-lsp/src/common/requests/signature_help.rs
@@ -23,7 +23,7 @@ pub fn get_signatures(
     ]
     .contains(&function_name.as_str())
     {
-        // showing signature help for define-<function>, define-trait, let and bug adds to much noise
+        // showing signature help for define-<function>, define-trait, let, and begin adds to much noise
         // it doesn't make sense for the tuple {} notation
         return None;
     }

--- a/components/clarity-repl/Cargo.toml
+++ b/components/clarity-repl/Cargo.toml
@@ -86,8 +86,8 @@ cli = [
     "prettytable-rs",
     "clarity/canonical",
     "clarity/developer-mode",
-    "clarity/log",
     "clarity/devtools",
+    "clarity/log",
     "hiro_system_kit/tokio_helpers",
     "clar2wasm",
     "pox-locking/default"
@@ -95,8 +95,8 @@ cli = [
 sdk = [
     "clarity/canonical",
     "clarity/developer-mode",
-    "clarity/log",
     "clarity/devtools",
+    "clarity/log",
     "hiro_system_kit/tokio_helpers",
     "pox-locking/default"
 ]
@@ -115,6 +115,7 @@ wasm = [
     "wasm-bindgen-futures",
     "clarity/wasm",
     "clarity/developer-mode",
+    "clarity/devtools",
     "pox-locking/wasm"
 ]
 


### PR DESCRIPTION
### Description

In `sdk.mine_block`, `session.advance_chain_tip(1);` must be called before executing the contract calls.

This PR includes other minor fix