### PR TITLE
fix: prevent panic in trace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -703,7 +703,7 @@ dependencies = [
  "serde-hex",
  "serde_derive",
  "serde_json",
- "stacks-codec 2.6.0 (git+https://github.com/hirosystems/clarinet.git)",
+ "stacks-codec",
  "threadpool",
  "tokio",
 ]
@@ -888,7 +888,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_yaml",
- "stacks-codec 2.6.0",
+ "stacks-codec",
  "stacks-rpc-client",
  "tiny-hderive",
 ]
@@ -4838,16 +4838,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "stacks-codec"
-version = "2.6.0"
-source = "git+https://github.com/hirosystems/clarinet.git#f880ebb86e03546e2a0d12d81ae7b3fa11db6379"
-dependencies = [
- "clarity",
- "serde",
- "wsts 8.1.0",
-]
-
-[[package]]
 name = "stacks-common"
 version = "0.0.2"
 source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#30bc1af6a07aaeedc01a084170f07065802bdff1"
@@ -4925,7 +4915,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_yaml",
- "stacks-codec 2.6.0",
+ "stacks-codec",
  "stacks-rpc-client",
  "stackslib",
  "tokio",
@@ -4946,7 +4936,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha2 0.10.6",
- "stacks-codec 2.6.0",
+ "stacks-codec",
  "tiny-hderive",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,6 @@ version = "2.6.0"
 [patch.crates-io]
 chainhook-sdk = { git = "https://github.com/hirosystems/chainhook.git", branch = "feat/update-pox-default-settings" }
 chainhook-types = { git = "https://github.com/hirosystems/chainhook.git", branch = "feat/update-pox-default-settings" }
+
+[patch.'https://github.com/hirosystems/clarinet.git']
+stacks-codec = { path = "./components/stacks-codec" }

--- a/components/clarity-repl/src/repl/tracer.rs
+++ b/components/clarity-repl/src/repl/tracer.rs
@@ -52,8 +52,10 @@ impl EvalHook for Tracer {
                         NativeFunctions::ContractCall => {
                             let mut call = format!(
                                 "{}├── {}  {}\n",
-                                "│   "
-                                    .repeat(self.stack.len() - self.pending_call_string.len() - 1),
+                                "│   ".repeat(
+                                    (self.stack.len() - self.pending_call_string.len())
+                                        .saturating_sub(1)
+                                ),
                                 expr,
                                 black!(format!(
                                     "{}:{}:{}",
@@ -104,7 +106,9 @@ impl EvalHook for Tracer {
                     // Call user-defined function
                     let mut call = format!(
                         "{}├── {}  {}\n",
-                        "│   ".repeat(self.stack.len() - self.pending_call_string.len() - 1),
+                        "│   ".repeat(
+                            (self.stack.len() - self.pending_call_string.len()).saturating_sub(1)
+                        ),
                         expr,
                         black!(format!(
                             "{}:{}:{}",
@@ -156,7 +160,9 @@ impl EvalHook for Tracer {
             for event in emitted_events.iter().skip(self.nb_of_emitted_events) {
                 println!(
                     "{}│ {}",
-                    "│   ".repeat(self.stack.len() - self.pending_call_string.len() - 1),
+                    "│   ".repeat(
+                        (self.stack.len() - self.pending_call_string.len()).saturating_sub(1)
+                    ),
                     black!(format!(
                         "✸ {}",
                         event
@@ -173,7 +179,9 @@ impl EvalHook for Tracer {
                 if let Ok(value) = res {
                     println!(
                         "{}└── {}",
-                        "│   ".repeat(self.stack.len() - self.pending_call_string.len() - 1),
+                        "│   ".repeat(
+                            (self.stack.len() - self.pending_call_string.len()).saturating_sub(1)
+                        ),
                         blue!(value.to_string())
                     );
                 }


### PR DESCRIPTION
### Description

Fix #1453 

This PR patches a potential panic when display the trace.*

The indentation is still wrong when showing the traces involving `contract-call?`
This implementation should be revisited in future work of the the traces (eg: when implemented traces in unit tests)