### PR TITLE
Fix/better new project name handling

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -85,7 +85,7 @@ jobs:
         run: cargo install cargo-audit
 
       - name: Run audit
-        run: cargo audit --ignore RUSTSEC-2022-0093 --ignore RUSTSEC-2021-0076 --ignore RUSTSEC-2022-0090 --ignore RUSTSEC-2022-002 --ignore RUSTSEC-2022-0028
+        run: cargo audit --ignore RUSTSEC-2022-0093 --ignore RUSTSEC-2021-0076 --ignore RUSTSEC-2022-0090 --ignore RUSTSEC-2022-002 --ignore RUSTSEC-2022-0028 --ignore RUSTSEC-2024-0344
 
       - name: Run rustfmt
         run: cargo fmt --all -- --check

--- a/components/clarinet-cli/src/generate/mod.rs
+++ b/components/clarinet-cli/src/generate/mod.rs
@@ -12,9 +12,15 @@ use self::contract::GetChangesForRmContract;
 pub fn get_changes_for_new_project(
     project_path: String,
     project_name: String,
+    use_current_dir: bool,
     telemetry_enabled: bool,
 ) -> Result<Vec<Changes>, String> {
-    let mut command = GetChangesForNewProject::new(project_path, project_name, telemetry_enabled);
+    let mut command = GetChangesForNewProject::new(
+        project_path,
+        project_name,
+        use_current_dir,
+        telemetry_enabled,
+    );
     command.run()
 }
 

--- a/components/clarinet-cli/src/generate/project.rs
+++ b/components/clarinet-cli/src/generate/project.rs
@@ -150,8 +150,7 @@ node_modules
     }
 
     fn create_gitattributes(&mut self) {
-        let content = r#"
-tests/** linguist-vendored
+        let content = r#"tests/** linguist-vendored
 vitest.config.js linguist-vendored
 * text=lf
 "#
@@ -163,8 +162,7 @@ vitest.config.js linguist-vendored
 
     fn create_clarinet_toml(&mut self) {
         let content = format!(
-            r#"
-[project]
+            r#"[project]
 name = "{}"
 description = ""
 authors = []


### PR DESCRIPTION
### Description

Fix #1480 

- Ask users if they want to continue if the directory already exists or already contains files (when using `.`
- Allow to include path in project name `clarinet new path/to/project`
- Sanitize project name (only allow alphanum, `-`, and `_`