### PR TITLE
fix: revert preventing epoch being set to lower epoch in simnet

### DIFF
--- a/components/clarinet-sdk-wasm/src/core.rs
+++ b/components/clarinet-sdk-wasm/src/core.rs
@@ -573,7 +573,7 @@ impl SDK {
         };
 
         let session = self.get_session_mut();
-        session.update_epoch(epoch)
+        session.update_epoch(epoch);
     }
 
     #[wasm_bindgen(js_name=getContractsInterfaces)]

--- a/components/clarity-repl/src/repl/session.rs
+++ b/components/clarity-repl/src/repl/session.rs
@@ -951,22 +951,14 @@ impl Session {
                 ))
             }
         };
-        if self.update_epoch(epoch) {
-            output.push(green!(format!("Epoch updated to: {epoch}")))
-        } else {
-            output.push(red!(format!("Epoch can not be set to a lower value")))
-        }
+        output.push(green!(format!("Epoch updated to: {epoch}")));
     }
 
-    pub fn update_epoch(&mut self, epoch: StacksEpochId) -> bool {
-        if epoch < self.current_epoch {
-            return false;
-        }
+    pub fn update_epoch(&mut self, epoch: StacksEpochId) {
         self.current_epoch = epoch;
         if epoch >= StacksEpochId::Epoch30 {
             self.interpreter.set_tenure_height();
         }
-        true
     }
 
     pub fn encode(&mut self, output: &mut Vec<String>, cmd: &str) {


### PR DESCRIPTION
### Description

This change was probably a good idea, in an effort to get simnet closet to real network. But it's also a breaking change with little to no benefit

