### PR TITLE
fix: print error if deployment start fails

### DIFF
--- a/components/stacks-network/src/chains_coordinator.rs
+++ b/components/stacks-network/src/chains_coordinator.rs
@@ -355,7 +355,8 @@ pub async fn start_chains_coordinator(
                             if let Some(deployment_commands_tx) = deployment_commands_tx.take() {
                                 deployment_commands_tx
                                     .send(DeploymentCommand::Start)
-                                    .expect("unable to trigger deployment");
+                                    .map_err(|e| format!("unable to start deployment: {}", e))
+                                    .unwrap();
                             }
                         }
                     }


### PR DESCRIPTION
### Description

Slightly improve log following #1478


