### PR TITLE
fix: better compiling condition on datastore get_side_store method

### DIFF
--- a/components/clarity-repl/src/repl/datastore.rs
+++ b/components/clarity-repl/src/repl/datastore.rs
@@ -299,7 +299,7 @@ impl ClarityBackingStore for Datastore {
         Some(&handle_contract_call_special_cases)
     }
 
-    #[cfg(not(feature = "wasm"))]
+    #[cfg(any(feature = "cli", feature = "cli"))]
     fn get_side_store(&mut self) -> &::clarity::rusqlite::Connection {
         panic!("Datastore cannot get_side_store")
     }


### PR DESCRIPTION
### Description

This condition was causing issue in the rust analyzer, that wouldn't correctly know if the trait was fully implemented or not

