### PR TITLE
Support workspaces

### DIFF
--- a/components/clarinet-sdk/src/vitest/index.ts
+++ b/components/clarinet-sdk/src/vitest/index.ts
@@ -1,5 +1,6 @@
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
+import { join } from "node:path";
 
 export function getClarinetVitestsArgv() {
   const argv = hideBin(process.argv);
@@ -39,5 +40,5 @@ export function getClarinetVitestsArgv() {
     }).argv;
 }
 
-export const vitestHelpersPath = "node_modules/@hirosystems/clarinet-sdk/vitest-helpers/src/";
+export const vitestHelpersPath = require.resolve("@hirosystems/clarinet-sdk") + "../../vitest-helpers/src/";
 export const vitestSetupFilePath = `${vitestHelpersPath}vitest.setup.ts`;


### PR DESCRIPTION
The location of `node_modules` is not guaranteed to be relative to the current directory (e.g. in yarn workspaces). 

A better solution here is to update package.json `exports` to include the file.

### Description

<!-- Describe the bug this PR fixes or the feature it adds. Link to any related issues and PRs -->

#### Breaking change?

<!-- If applicable, list the APIs/functionality which this PR breaks -->

### Example

<!-- If applicable, add an example on how this improves the application -->

---

### Checklist

- [ ] Tests added in this PR (if applicable)

