### PR TITLE
fix: testnet.toml path in project creation template

### DIFF
--- a/components/clarinet-cli/src/generate/project.rs
+++ b/components/clarinet-cli/src/generate/project.rs
@@ -200,7 +200,7 @@ deployment_fee_rate = 10
 mnemonic = "<YOUR PRIVATE TESTNET MNEMONIC HERE>"
 "#
         .into();
-        let name = "Testnet.toml".into();
+        let name = "settings/Testnet.toml".into();
         self.changes
             .push(self.get_changes_for_new_file(name, content));
     }


### PR DESCRIPTION
The testnet.toml file was created in the wrong directory