### PR TITLE
chore: upgrade clarity-vm and clar2wasm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,12 +292,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "base-x"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
-
-[[package]]
 name = "base58"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -804,7 +798,7 @@ checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 [[package]]
 name = "clar2wasm"
 version = "0.1.0"
-source = "git+https://github.com/stacks-network/clarity-wasm.git?branch=main#bc969187771b937ebfa29178f8c0fedeb07307f1"
+source = "git+https://github.com/stacks-network/clarity-wasm.git?branch=main#f1573a4c6f9698a49f5f17ad4a2f0f78c5fe92f1"
 dependencies = [
  "chrono",
  "clap",
@@ -955,7 +949,7 @@ dependencies = [
 [[package]]
 name = "clarity"
 version = "2.3.0"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#1a5cb8861f7b9d0cef5ad0293da151728e97d5dc"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#455653214ea64d062c3b6fb6e72ac137d1a86343"
 dependencies = [
  "getrandom 0.2.8",
  "hashbrown 0.14.3",
@@ -974,7 +968,6 @@ dependencies = [
  "sha2-asm 0.5.5",
  "slog",
  "stacks-common",
- "time 0.2.27",
  "wasmtime",
 ]
 
@@ -1098,19 +1091,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
-name = "const_fn"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373e9fafaa20882876db20562275ff58d50e0caa2590077fe7ce7bef90211d0d"
-
-[[package]]
 name = "cookie"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
 dependencies = [
  "percent-encoding",
- "time 0.3.34",
+ "time",
  "version_check",
 ]
 
@@ -1439,7 +1426,7 @@ dependencies = [
  "digest 0.10.7",
  "fiat-crypto",
  "platforms",
- "rustc_version 0.4.0",
+ "rustc_version",
  "subtle 2.4.1",
  "zeroize",
 ]
@@ -1664,12 +1651,6 @@ dependencies = [
  "redox_users",
  "winapi 0.3.9",
 ]
-
-[[package]]
-name = "discard"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
 name = "dyn-clone"
@@ -2227,7 +2208,7 @@ dependencies = [
  "slog-json",
  "slog-scope",
  "slog-term",
- "time 0.3.34",
+ "time",
  "tokio",
 ]
 
@@ -2246,7 +2227,7 @@ dependencies = [
  "slog-json",
  "slog-scope",
  "slog-term",
- "time 0.3.34",
+ "time",
  "tokio",
 ]
 
@@ -2881,7 +2862,7 @@ dependencies = [
 [[package]]
 name = "libstackerdb"
 version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#1a5cb8861f7b9d0cef5ad0293da151728e97d5dc"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#455653214ea64d062c3b6fb6e72ac137d1a86343"
 dependencies = [
  "clarity",
  "secp256k1 0.24.3",
@@ -3612,7 +3593,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 [[package]]
 name = "pox-locking"
 version = "2.4.0"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#1a5cb8861f7b9d0cef5ad0293da151728e97d5dc"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#455653214ea64d062c3b6fb6e72ac137d1a86343"
 dependencies = [
  "clarity",
  "slog",
@@ -3682,12 +3663,6 @@ dependencies = [
  "quote",
  "version_check",
 ]
-
-[[package]]
-name = "proc-macro-hack"
-version = "0.5.20+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
@@ -4095,7 +4070,7 @@ dependencies = [
  "serde_json",
  "state",
  "tempfile",
- "time 0.3.34",
+ "time",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -4143,7 +4118,7 @@ dependencies = [
  "smallvec 1.13.1",
  "stable-pattern",
  "state",
- "time 0.3.34",
+ "time",
  "tokio",
  "uncased",
 ]
@@ -4157,7 +4132,7 @@ dependencies = [
  "futures",
  "futures-timer",
  "rstest_macros",
- "rustc_version 0.4.0",
+ "rustc_version",
 ]
 
 [[package]]
@@ -4169,7 +4144,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "proc-macro2",
  "quote",
- "rustc_version 0.4.0",
+ "rustc_version",
  "syn 1.0.107",
  "unicode-ident",
 ]
@@ -4182,7 +4157,7 @@ checksum = "45f80dcc84beab3a327bbe161f77db25f336a1452428176787c8c79ac79d7073"
 dependencies = [
  "quote",
  "rand 0.8.5",
- "rustc_version 0.4.0",
+ "rustc_version",
  "syn 1.0.107",
 ]
 
@@ -4218,15 +4193,6 @@ name = "rustc-hex"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
-
-[[package]]
-name = "rustc_version"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-dependencies = [
- "semver 0.9.0",
-]
 
 [[package]]
 name = "rustc_version"
@@ -4583,7 +4549,7 @@ dependencies = [
  "indexmap 2.2.3",
  "serde",
  "serde_json",
- "time 0.3.34",
+ "time",
 ]
 
 [[package]]
@@ -4597,21 +4563,6 @@ dependencies = [
  "serde",
  "yaml-rust",
 ]
-
-[[package]]
-name = "sha1"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1da05c97445caa12d05e848c4a4fcbbea29e748ac28f7e80e9b010392063770"
-dependencies = [
- "sha1_smol",
-]
-
-[[package]]
-name = "sha1_smol"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
 
 [[package]]
 name = "sha2"
@@ -4790,7 +4741,7 @@ dependencies = [
  "serde",
  "serde_json",
  "slog",
- "time 0.3.34",
+ "time",
 ]
 
 [[package]]
@@ -4814,7 +4765,7 @@ dependencies = [
  "slog",
  "term",
  "thread_local",
- "time 0.3.34",
+ "time",
 ]
 
 [[package]]
@@ -4930,7 +4881,7 @@ dependencies = [
 [[package]]
 name = "stacks-common"
 version = "0.0.2"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#1a5cb8861f7b9d0cef5ad0293da151728e97d5dc"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#455653214ea64d062c3b6fb6e72ac137d1a86343"
 dependencies = [
  "chrono",
  "curve25519-dalek 2.0.0",
@@ -4954,7 +4905,7 @@ dependencies = [
  "slog",
  "slog-json",
  "slog-term",
- "time 0.3.34",
+ "time",
  "winapi 0.3.9",
  "wsts 9.0.0",
 ]
@@ -5033,7 +4984,7 @@ dependencies = [
 [[package]]
 name = "stackslib"
 version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#1a5cb8861f7b9d0cef5ad0293da151728e97d5dc"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#455653214ea64d062c3b6fb6e72ac137d1a86343"
 dependencies = [
  "chrono",
  "clar2wasm",
@@ -5066,19 +5017,10 @@ dependencies = [
  "slog-term",
  "stacks-common",
  "tikv-jemallocator",
- "time 0.3.34",
+ "time",
  "url",
  "winapi 0.3.9",
  "wsts 9.0.0",
-]
-
-[[package]]
-name = "standback"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e113fb6f3de07a243d434a56ec6f186dfd51cb08448239fe7bcae73f87ff28ff"
-dependencies = [
- "version_check",
 ]
 
 [[package]]
@@ -5095,55 +5037,6 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "stdweb"
-version = "0.4.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
-dependencies = [
- "discard",
- "rustc_version 0.2.3",
- "stdweb-derive",
- "stdweb-internal-macros",
- "stdweb-internal-runtime",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "stdweb-derive"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde",
- "serde_derive",
- "syn 1.0.107",
-]
-
-[[package]]
-name = "stdweb-internal-macros"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
-dependencies = [
- "base-x",
- "proc-macro2",
- "quote",
- "serde",
- "serde_derive",
- "serde_json",
- "sha1",
- "syn 1.0.107",
-]
-
-[[package]]
-name = "stdweb-internal-runtime"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
 name = "strsim"
@@ -5395,21 +5288,6 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.2.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4752a97f8eebd6854ff91f1c1824cd6160626ac4bd44287f7f4ea2035a02a242"
-dependencies = [
- "const_fn",
- "libc",
- "standback",
- "stdweb",
- "time-macros 0.1.1",
- "version_check",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "time"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
@@ -5422,7 +5300,7 @@ dependencies = [
  "powerfmt",
  "serde",
  "time-core",
- "time-macros 0.2.17",
+ "time-macros",
 ]
 
 [[package]]
@@ -5433,35 +5311,12 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957e9c6e26f12cb6d0dd7fc776bb67a706312e7299aed74c8dd5b17ebb27e2f1"
-dependencies = [
- "proc-macro-hack",
- "time-macros-impl",
-]
-
-[[package]]
-name = "time-macros"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
 dependencies = [
  "num-conv",
  "time-core",
-]
-
-[[package]]
-name = "time-macros-impl"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3c141a1b43194f3f56a1411225df8646c55781d5f26db825b3d98507eb482f"
-dependencies = [
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "standback",
- "syn 1.0.107",
 ]
 
 [[package]]
@@ -5707,7 +5562,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09d48f71a791638519505cefafe162606f706c25592e4bde4d97600c0195312e"
 dependencies = [
  "crossbeam-channel",
- "time 0.3.34",
+ "time",
  "tracing-subscriber",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,6 +292,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-x"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
+
+[[package]]
 name = "base58"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -798,7 +804,7 @@ checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 [[package]]
 name = "clar2wasm"
 version = "0.1.0"
-source = "git+https://github.com/stacks-network/clarity-wasm.git?branch=chore/update-clarity#ffbf49befc00d6eb3230a8e44ebf91b621f074e4"
+source = "git+https://github.com/stacks-network/clarity-wasm.git?branch=main#bc969187771b937ebfa29178f8c0fedeb07307f1"
 dependencies = [
  "chrono",
  "clap",
@@ -949,7 +955,7 @@ dependencies = [
 [[package]]
 name = "clarity"
 version = "2.3.0"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#860d7da5af0a46b07d24cb29aa425247cf2b6820"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#1a5cb8861f7b9d0cef5ad0293da151728e97d5dc"
 dependencies = [
  "getrandom 0.2.8",
  "hashbrown 0.14.3",
@@ -968,6 +974,7 @@ dependencies = [
  "sha2-asm 0.5.5",
  "slog",
  "stacks-common",
+ "time 0.2.27",
  "wasmtime",
 ]
 
@@ -1091,13 +1098,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const_fn"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373e9fafaa20882876db20562275ff58d50e0caa2590077fe7ce7bef90211d0d"
+
+[[package]]
 name = "cookie"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
 dependencies = [
  "percent-encoding",
- "time",
+ "time 0.3.34",
  "version_check",
 ]
 
@@ -1426,7 +1439,7 @@ dependencies = [
  "digest 0.10.7",
  "fiat-crypto",
  "platforms",
- "rustc_version",
+ "rustc_version 0.4.0",
  "subtle 2.4.1",
  "zeroize",
 ]
@@ -1651,6 +1664,12 @@ dependencies = [
  "redox_users",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "discard"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
 name = "dyn-clone"
@@ -2140,9 +2159,9 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.8.4"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
  "hashbrown 0.14.3",
 ]
@@ -2208,7 +2227,7 @@ dependencies = [
  "slog-json",
  "slog-scope",
  "slog-term",
- "time",
+ "time 0.3.34",
  "tokio",
 ]
 
@@ -2227,7 +2246,7 @@ dependencies = [
  "slog-json",
  "slog-scope",
  "slog-term",
- "time",
+ "time 0.3.34",
  "tokio",
 ]
 
@@ -2850,9 +2869,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.25.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29f835d03d717946d28b1d1ed632eb6f0e24a299388ee623d0c23118d3e8a7fa"
+checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
 dependencies = [
  "cc",
  "pkg-config",
@@ -2862,7 +2881,7 @@ dependencies = [
 [[package]]
 name = "libstackerdb"
 version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#860d7da5af0a46b07d24cb29aa425247cf2b6820"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#1a5cb8861f7b9d0cef5ad0293da151728e97d5dc"
 dependencies = [
  "clarity",
  "secp256k1 0.24.3",
@@ -3593,7 +3612,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 [[package]]
 name = "pox-locking"
 version = "2.4.0"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#860d7da5af0a46b07d24cb29aa425247cf2b6820"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#1a5cb8861f7b9d0cef5ad0293da151728e97d5dc"
 dependencies = [
  "clarity",
  "slog",
@@ -3663,6 +3682,12 @@ dependencies = [
  "quote",
  "version_check",
 ]
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.20+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
@@ -4070,7 +4095,7 @@ dependencies = [
  "serde_json",
  "state",
  "tempfile",
- "time",
+ "time 0.3.34",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -4118,7 +4143,7 @@ dependencies = [
  "smallvec 1.13.1",
  "stable-pattern",
  "state",
- "time",
+ "time 0.3.34",
  "tokio",
  "uncased",
 ]
@@ -4132,7 +4157,7 @@ dependencies = [
  "futures",
  "futures-timer",
  "rstest_macros",
- "rustc_version",
+ "rustc_version 0.4.0",
 ]
 
 [[package]]
@@ -4144,7 +4169,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "proc-macro2",
  "quote",
- "rustc_version",
+ "rustc_version 0.4.0",
  "syn 1.0.107",
  "unicode-ident",
 ]
@@ -4157,18 +4182,18 @@ checksum = "45f80dcc84beab3a327bbe161f77db25f336a1452428176787c8c79ac79d7073"
 dependencies = [
  "quote",
  "rand 0.8.5",
- "rustc_version",
+ "rustc_version 0.4.0",
  "syn 1.0.107",
 ]
 
 [[package]]
 name = "rusqlite"
-version = "0.28.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01e213bc3ecb39ac32e81e51ebe31fd888a940515173e3a18a35f8c6e896422a"
+checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
 dependencies = [
- "bitflags 1.3.2",
- "fallible-iterator 0.2.0",
+ "bitflags 2.4.0",
+ "fallible-iterator 0.3.0",
  "fallible-streaming-iterator",
  "hashlink",
  "libsqlite3-sys",
@@ -4193,6 +4218,15 @@ name = "rustc-hex"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
+
+[[package]]
+name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+dependencies = [
+ "semver 0.9.0",
+]
 
 [[package]]
 name = "rustc_version"
@@ -4549,7 +4583,7 @@ dependencies = [
  "indexmap 2.2.3",
  "serde",
  "serde_json",
- "time",
+ "time 0.3.34",
 ]
 
 [[package]]
@@ -4563,6 +4597,21 @@ dependencies = [
  "serde",
  "yaml-rust",
 ]
+
+[[package]]
+name = "sha1"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1da05c97445caa12d05e848c4a4fcbbea29e748ac28f7e80e9b010392063770"
+dependencies = [
+ "sha1_smol",
+]
+
+[[package]]
+name = "sha1_smol"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
 
 [[package]]
 name = "sha2"
@@ -4741,7 +4790,7 @@ dependencies = [
  "serde",
  "serde_json",
  "slog",
- "time",
+ "time 0.3.34",
 ]
 
 [[package]]
@@ -4765,7 +4814,7 @@ dependencies = [
  "slog",
  "term",
  "thread_local",
- "time",
+ "time 0.3.34",
 ]
 
 [[package]]
@@ -4881,7 +4930,7 @@ dependencies = [
 [[package]]
 name = "stacks-common"
 version = "0.0.2"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#860d7da5af0a46b07d24cb29aa425247cf2b6820"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#1a5cb8861f7b9d0cef5ad0293da151728e97d5dc"
 dependencies = [
  "chrono",
  "curve25519-dalek 2.0.0",
@@ -4905,7 +4954,7 @@ dependencies = [
  "slog",
  "slog-json",
  "slog-term",
- "time",
+ "time 0.3.34",
  "winapi 0.3.9",
  "wsts 9.0.0",
 ]
@@ -4984,7 +5033,7 @@ dependencies = [
 [[package]]
 name = "stackslib"
 version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#860d7da5af0a46b07d24cb29aa425247cf2b6820"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#1a5cb8861f7b9d0cef5ad0293da151728e97d5dc"
 dependencies = [
  "chrono",
  "clar2wasm",
@@ -5017,10 +5066,19 @@ dependencies = [
  "slog-term",
  "stacks-common",
  "tikv-jemallocator",
- "time",
+ "time 0.3.34",
  "url",
  "winapi 0.3.9",
  "wsts 9.0.0",
+]
+
+[[package]]
+name = "standback"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e113fb6f3de07a243d434a56ec6f186dfd51cb08448239fe7bcae73f87ff28ff"
+dependencies = [
+ "version_check",
 ]
 
 [[package]]
@@ -5037,6 +5095,55 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "stdweb"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
+dependencies = [
+ "discard",
+ "rustc_version 0.2.3",
+ "stdweb-derive",
+ "stdweb-internal-macros",
+ "stdweb-internal-runtime",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "stdweb-derive"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_derive",
+ "syn 1.0.107",
+]
+
+[[package]]
+name = "stdweb-internal-macros"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
+dependencies = [
+ "base-x",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sha1",
+ "syn 1.0.107",
+]
+
+[[package]]
+name = "stdweb-internal-runtime"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
 name = "strsim"
@@ -5288,6 +5395,21 @@ dependencies = [
 
 [[package]]
 name = "time"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4752a97f8eebd6854ff91f1c1824cd6160626ac4bd44287f7f4ea2035a02a242"
+dependencies = [
+ "const_fn",
+ "libc",
+ "standback",
+ "stdweb",
+ "time-macros 0.1.1",
+ "version_check",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "time"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
@@ -5300,7 +5422,7 @@ dependencies = [
  "powerfmt",
  "serde",
  "time-core",
- "time-macros",
+ "time-macros 0.2.17",
 ]
 
 [[package]]
@@ -5311,12 +5433,35 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957e9c6e26f12cb6d0dd7fc776bb67a706312e7299aed74c8dd5b17ebb27e2f1"
+dependencies = [
+ "proc-macro-hack",
+ "time-macros-impl",
+]
+
+[[package]]
+name = "time-macros"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "time-macros-impl"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd3c141a1b43194f3f56a1411225df8646c55781d5f26db825b3d98507eb482f"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "standback",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -5562,7 +5707,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09d48f71a791638519505cefafe162606f706c25592e4bde4d97600c0195312e"
 dependencies = [
  "crossbeam-channel",
- "time",
+ "time 0.3.34",
  "tracing-subscriber",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -798,7 +798,7 @@ checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 [[package]]
 name = "clar2wasm"
 version = "0.1.0"
-source = "git+https://github.com/stacks-network/clarity-wasm.git?branch=main#f1573a4c6f9698a49f5f17ad4a2f0f78c5fe92f1"
+source = "git+https://github.com/stacks-network/clarity-wasm.git?branch=main#09fe754d57943ff40b8da48ae6367c1e085cb1f3"
 dependencies = [
  "chrono",
  "clap",
@@ -949,7 +949,7 @@ dependencies = [
 [[package]]
 name = "clarity"
 version = "2.3.0"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#455653214ea64d062c3b6fb6e72ac137d1a86343"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#dcd5b4ecdbb12f7ce394ae1bcb5898599caac1f8"
 dependencies = [
  "getrandom 0.2.8",
  "hashbrown 0.14.3",
@@ -2862,7 +2862,7 @@ dependencies = [
 [[package]]
 name = "libstackerdb"
 version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#455653214ea64d062c3b6fb6e72ac137d1a86343"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#dcd5b4ecdbb12f7ce394ae1bcb5898599caac1f8"
 dependencies = [
  "clarity",
  "secp256k1 0.24.3",
@@ -3593,7 +3593,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 [[package]]
 name = "pox-locking"
 version = "2.4.0"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#455653214ea64d062c3b6fb6e72ac137d1a86343"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#dcd5b4ecdbb12f7ce394ae1bcb5898599caac1f8"
 dependencies = [
  "clarity",
  "slog",
@@ -4881,7 +4881,7 @@ dependencies = [
 [[package]]
 name = "stacks-common"
 version = "0.0.2"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#455653214ea64d062c3b6fb6e72ac137d1a86343"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#dcd5b4ecdbb12f7ce394ae1bcb5898599caac1f8"
 dependencies = [
  "chrono",
  "curve25519-dalek 2.0.0",
@@ -4984,7 +4984,7 @@ dependencies = [
 [[package]]
 name = "stackslib"
 version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#455653214ea64d062c3b6fb6e72ac137d1a86343"
+source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#dcd5b4ecdbb12f7ce394ae1bcb5898599caac1f8"
 dependencies = [
  "chrono",
  "clar2wasm",

--- a/components/clarity-repl/Cargo.toml
+++ b/components/clarity-repl/Cargo.toml
@@ -36,7 +36,7 @@ getrandom = { version = "0.2.3", features = ["js"] }
 atty = "0.2.14"
 # clarity-vm = { version = "2.3.0", default-features = false }
 clarity = { git = "https://github.com/stacks-network/stacks-core.git", branch="feat/clarity-wasm-develop", package = "clarity", default-features = false }
-clar2wasm = { git = "https://github.com/stacks-network/clarity-wasm.git", branch = "chore/update-clarity", optional = true }
+clar2wasm = { git = "https://github.com/stacks-network/clarity-wasm.git", branch = "main", optional = true }
 # clar2wasm = { path="../../../clarity-wasm/clar2wasm", optional = true }
 pox-locking = { git = "https://github.com/stacks-network/stacks-core.git", branch="feat/clarity-wasm-develop", optional = true, default-features = false }
 prettytable-rs = { version = "0.10.0" }

--- a/components/clarity-repl/src/repl/datastore.rs
+++ b/components/clarity-repl/src/repl/datastore.rs
@@ -8,7 +8,6 @@ use clarity::types::chainstate::StacksAddress;
 use clarity::types::chainstate::StacksBlockId;
 use clarity::types::chainstate::VRFSeed;
 use clarity::types::StacksEpochId;
-use clarity::types::PEER_VERSION_EPOCH_2_1;
 use clarity::util::hash::Sha512Trunc256Sum;
 use clarity::vm::analysis::AnalysisDatabase;
 use clarity::vm::database::BurnStateDB;
@@ -21,6 +20,21 @@ use pox_locking::handle_contract_call_special_cases;
 use sha2::{Digest, Sha512_256};
 
 use super::interpreter::BLOCK_LIMIT_MAINNET;
+
+fn epoch_to_peer_version(epoch: StacksEpochId) -> u8 {
+    use clarity::consts::*;
+    match epoch {
+        StacksEpochId::Epoch10 => PEER_VERSION_EPOCH_1_0,
+        StacksEpochId::Epoch20 => PEER_VERSION_EPOCH_2_0,
+        StacksEpochId::Epoch2_05 => PEER_VERSION_EPOCH_2_05,
+        StacksEpochId::Epoch21 => PEER_VERSION_EPOCH_2_1,
+        StacksEpochId::Epoch22 => PEER_VERSION_EPOCH_2_2,
+        StacksEpochId::Epoch23 => PEER_VERSION_EPOCH_2_3,
+        StacksEpochId::Epoch24 => PEER_VERSION_EPOCH_2_4,
+        StacksEpochId::Epoch25 => PEER_VERSION_EPOCH_2_5,
+        StacksEpochId::Epoch30 => PEER_VERSION_EPOCH_3_0,
+    }
+}
 
 #[derive(Clone, Debug)]
 pub struct Datastore {
@@ -571,7 +585,7 @@ impl BurnStateDB for BurnDatastore {
             start_height: self.current_epoch_start_height.into(),
             end_height: u64::MAX,
             block_limit: BLOCK_LIMIT_MAINNET,
-            network_epoch: PEER_VERSION_EPOCH_2_1,
+            network_epoch: epoch_to_peer_version(self.current_epoch),
         })
     }
 
@@ -794,7 +808,7 @@ mod tests {
                 start_height: 0,
                 end_height: u64::MAX,
                 block_limit: BLOCK_LIMIT_MAINNET,
-                network_epoch: PEER_VERSION_EPOCH_2_1,
+                network_epoch: clarity::consts::PEER_VERSION_EPOCH_2_05,
             })
         );
     }
@@ -811,7 +825,7 @@ mod tests {
                 start_height: 0,
                 end_height: u64::MAX,
                 block_limit: BLOCK_LIMIT_MAINNET,
-                network_epoch: PEER_VERSION_EPOCH_2_1,
+                network_epoch: clarity::consts::PEER_VERSION_EPOCH_2_05,
             })
         );
     }

--- a/components/clarity-repl/src/repl/interpreter.rs
+++ b/components/clarity-repl/src/repl/interpreter.rs
@@ -1676,9 +1676,6 @@ mod tests {
         let boot_contracts_data = BOOT_CONTRACTS_DATA.clone();
 
         for (_, (boot_contract, ast)) in boot_contracts_data {
-            if boot_contract.name == "signers-voting" {
-                continue;
-            }
             let res = interpreter
                 .run(&boot_contract, Some(&ast), false, None)
                 .unwrap_or_else(|err| {


### PR DESCRIPTION
Get the latest version of clarity and clarity-wasm.

Also allowing to properly handle the `PEER_VERSION_EPOCH` in the datastore (the versions where previously not all properly exported from stacks-core)