### PR TITLE
chore: remove unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -836,54 +836,28 @@ version = "2.7.0"
 dependencies = [
  "ansi_term",
  "atty",
- "base58 0.2.0",
- "bitcoin 0.29.2",
- "chrono",
  "clap",
  "clap_complete",
  "clarinet-deployments",
  "clarinet-files",
- "clarinet-utils",
  "clarity-lsp",
  "clarity-repl",
  "crossbeam-channel",
  "crossterm",
- "ctrlc",
  "dirs",
- "encoding_rs",
- "futures",
  "fwdansi",
- "hex",
  "hiro-system-kit 0.1.0",
- "hmac 0.12.1",
  "lazy_static",
- "libc",
- "libsecp256k1 0.7.1",
- "log",
  "mac_address",
- "mio 0.8.11",
  "nix 0.24.2",
- "num_cpus",
- "pbkdf2",
- "percent-encoding",
- "pin-project",
  "ratatui",
- "regex",
- "reqwest",
  "segment",
  "serde",
  "serde_derive",
  "serde_json",
- "sha2 0.10.8",
- "signal-hook-registry",
  "similar",
  "stacks-network",
- "strum 0.23.0",
- "tempfile",
- "termcolor",
- "tiny-hderive",
  "tokio",
- "tokio-util",
  "toml 0.5.11",
  "tower-lsp",
  "winapi 0.3.9",
@@ -1000,7 +974,6 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "toml 0.5.11",
 ]
 
 [[package]]
@@ -1039,7 +1012,6 @@ dependencies = [
  "getrandom 0.2.8",
  "hiro-system-kit 0.1.0",
  "httparse",
- "integer-sqrt",
  "lazy_static",
  "log",
  "memchr",
@@ -1384,9 +1356,9 @@ checksum = "697c714f50560202b1f4e2e09cd50a421881c83e9025db75d15f276616f04f40"
 
 [[package]]
 name = "csv"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af91f40b7355f82b0a891f50e70399475945bb0b0da4f1700ce60761c9d3e359"
+checksum = "ac574ff4d437a7b5ad237ef331c17ccca63c46479e5b5453eb8e10bb99a759fe"
 dependencies = [
  "csv-core",
  "itoa",
@@ -1396,9 +1368,9 @@ dependencies = [
 
 [[package]]
 name = "csv-core"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
+checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
 dependencies = [
  "memchr",
 ]
@@ -2229,7 +2201,6 @@ version = "0.1.0"
 dependencies = [
  "ansi_term",
  "atty",
- "lazy_static",
  "slog",
  "slog-async",
  "slog-atomic",
@@ -2942,7 +2913,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if 1.0.0",
- "serde",
 ]
 
 [[package]]
@@ -4918,8 +4888,6 @@ version = "2.7.0"
 dependencies = [
  "clarinet-deployments",
  "clarinet-files",
- "clarinet-utils",
- "crossbeam-channel",
  "error-chain",
  "hiro-system-kit 0.1.0",
  "neon",
@@ -4938,13 +4906,11 @@ dependencies = [
  "bitcoin 0.29.2",
  "bitcoincore-rpc 0.16.0",
  "bollard",
- "bytes",
  "chainhook-sdk",
  "chrono",
  "clap",
  "clarinet-deployments",
  "clarinet-files",
- "clarinet-utils",
  "clarity",
  "crossbeam-channel",
  "crossterm",

--- a/components/clarinet-cli/Cargo.toml
+++ b/components/clarinet-cli/Cargo.toml
@@ -23,42 +23,17 @@ toml = { version = "0.5.6", features = ["preserve_order"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1.0.79", features = ["preserve_order"] }
 serde_derive = "1"
-log = { version = "=0.4.17", features = ["serde"] }
-signal-hook-registry = "1.4.0"
-secure_tempfile = { version = "3.8.0", package = "tempfile" }
-libsecp256k1 = "0.7.0"
-hmac = "0.12.0"
-pbkdf2 = { version = "0.12.2", features = ["simple"], default-features = false }
-futures = "0.3.12"
 tokio = { version = "1.35.1", features = ["full"] }
-tokio-util = { version = "0.7.10", features = ["io"], optional = true }
 lazy_static = { workspace = true }
 atty = "0.2.14"
-termcolor = "1.1.2"
-regex = "1.7"
 dirs = { version = "4.0.0" }
-libc = "0.2.86"
-encoding_rs = "0.8.31"
-percent-encoding = "2.1.0"
-pin-project = "1.0.5"
-reqwest = { workspace = true, features = ["blocking"]}
 crossterm = "0.27.0"
 ratatui = { version = "0.27.0", default-features = false, features = ["crossterm"] }
-base58 = "0.2.0"
-ctrlc = "3.1.9"
-strum = { version = "0.23.0", features = ["derive"] }
-bitcoin = "0.29.2"
-tiny-hderive = "0.3.0"
 segment = { version = "0.2.4", optional = true }
 mac_address = { version = "1.1.2", optional = true }
 tower-lsp = { version = "0.19.0", optional = true }
-hex = "0.4.3"
-num_cpus = "1.13.1"
-mio = "0.8"
 similar = "2.1.0"
 crossbeam-channel = "0.5.6"
-chrono = "0.4.31"
-sha2 = "0.10.0"
 
 clarity_repl = { package = "clarity-repl", path = "../clarity-repl", features = [
     "cli",
@@ -67,7 +42,6 @@ clarinet-files = { path = "../clarinet-files", features = ["cli"] }
 clarity-lsp = { path = "../clarity-lsp", features = ["cli"] }
 clarinet-deployments = { path = "../clarinet-deployments", features = ["cli"] }
 hiro-system-kit = { path = "../hiro-system-kit" }
-clarinet-utils = { path = "../clarinet-utils" }
 stacks-network = { path = "../stacks-network" }
 
 [target.'cfg(unix)'.dependencies]
@@ -107,5 +81,5 @@ path = "src/bin.rs"
 
 [features]
 default = ["cli", "telemetry"]
-cli = ["tokio-util", "clap", "clap_complete", "tower-lsp"]
+cli = ["clap", "clap_complete", "tower-lsp"]
 telemetry = ["segment", "mac_address"]

--- a/components/clarinet-deployments/Cargo.toml
+++ b/components/clarinet-deployments/Cargo.toml
@@ -13,6 +13,8 @@ serde_yaml = "0.8.23"
 clarity-repl = { path = "../clarity-repl", default-features = false, optional = true }
 clarinet-files = { path = "../clarinet-files", default-features = false }
 stacks-rpc-client = { path = "../stacks-rpc-client", optional = true }
+clarinet-utils = { path = "../clarinet-utils", optional = true }
+stacks-codec = { path = "../stacks-codec", optional = true }
 
 # CLI
 reqwest = { workspace = true }
@@ -23,8 +25,6 @@ base58 = { version = "0.2.0", optional = true }
 base64 = "0.21.3"
 tiny-hderive = { version = "0.3.0", optional = true }
 libsecp256k1 = { version = "0.7.0", optional = true }
-clarinet_utils = { package = "clarinet-utils", path = "../clarinet-utils", optional = true }
-stacks-codec = { path = "../stacks-codec", optional = true }
 
 clarity = { workspace = true }
 
@@ -40,7 +40,7 @@ onchain = [
     "base58",
     "tiny-hderive",
     "libsecp256k1",
-    "clarinet_utils",
+    "clarinet-utils",
 ]
 
 [lib]

--- a/components/clarity-events/Cargo.toml
+++ b/components/clarity-events/Cargo.toml
@@ -7,14 +7,13 @@ edition = "2021"
 clarinet-files = { path = "../clarinet-files", default-features = false, optional = true }
 clarity-repl = { path = "../clarity-repl", default-features = false }
 clap = { version = "4.4.8", features = ["derive"], optional = true }
-toml = { version = "0.5.6", features = ["preserve_order"], optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1.0.79", features = ["preserve_order"] }
 serde_derive = "1"
 
 [features]
 default = ["cli"]
-cli = ["clarity-repl/cli", "clarinet-files/cli", "clap", "toml"]
+cli = ["clarity-repl/cli", "clarinet-files/cli", "clap"]
 lib = ["clarity-repl/cli"]
 
 [lib]

--- a/components/clarity-repl/Cargo.toml
+++ b/components/clarity-repl/Cargo.toml
@@ -31,7 +31,6 @@ serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1.0.47", features = ["unbounded_depth"] }
 sha2 = "0.10"
 serde_derive = "1.0"
-integer-sqrt = "0.1.3"
 getrandom = { version = "0.2.3", features = ["js"] }
 atty = "0.2.14"
 clarity = { workspace = true }

--- a/components/hiro-system-kit/Cargo.toml
+++ b/components/hiro-system-kit/Cargo.toml
@@ -11,7 +11,6 @@ edition = "2021"
 tokio = { version = "1.35.1", optional = true }
 ansi_term = "0.12.1"
 atty = "0.2.14"
-lazy_static = { workspace = true }
 slog = { version = "2.7.0", optional = true }
 slog-json = { version = "2.6.1", optional = true }
 slog-scope = { version = "4.4.0", optional = true }

--- a/components/stacks-devnet-js/Cargo.toml
+++ b/components/stacks-devnet-js/Cargo.toml
@@ -12,11 +12,9 @@ crate-type = ["cdylib"]
 serde = "1"
 error-chain = "0.12"
 clarinet-files = { path = "../clarinet-files" }
-clarinet-utils = { path = "../clarinet-utils" }
 clarinet-deployments = { path = "../clarinet-deployments" }
 stacks-network = { path = "../stacks-network" }
 hiro-system-kit = { path = "../hiro-system-kit" }
-crossbeam-channel = "0.5.6"
 
 [dependencies.neon]
 version = "0.9.1"

--- a/components/stacks-network/Cargo.toml
+++ b/components/stacks-network/Cargo.toml
@@ -9,7 +9,6 @@ edition = "2021"
 atty = "0.2.14"
 ansi_term = "0.12.1"
 bollard = "0.16.0"
-bytes = "1.4.0"
 bitcoin = "0.29.2"
 bitcoincore-rpc = "0.16.0"
 serde = { version = "1", features = ["derive"] }
@@ -38,7 +37,6 @@ chainhook-sdk = { version = "0.12" }
 stacks-rpc-client = { path = "../stacks-rpc-client" }
 clarinet-files = { path = "../clarinet-files", features = ["cli"] }
 clarinet-deployments = { path = "../clarinet-deployments", features = ["cli"] }
-clarinet-utils = { path = "../clarinet-utils" }
 hiro-system-kit = { path = "../hiro-system-kit", features = ["log"] }
 stacks-codec = { path = "../stacks-codec" }
 


### PR DESCRIPTION
### Description

Remove unused dependencies.

- Lot's of dependencies in clarinet-cli/Cargo.toml are unused. This is likely caused by the fact that `clarinet-cli` was the original crate and was then split into many crates (about 2 years ago). But this Cargo.toml wasn't cleaned. 
- clarinet-utils was often imported but unused

This as a low impact on the cargo.lock and the workspace number of dependencies, since the dependencies removed from clarinet-cli are spread in other components. Still a nice clean of the clarinet-cli cargo.toml with about a third of the direct dependencies removed

### Context

I sued `cargo machete` to get an idea of the dependencies that could be removed. Along with carefully checking that whole still compiles. The CI will also ensure that for all targets