### PR TITLE
fix: improve vitest matcher sources resolver

### DIFF
--- a/.github/workflows/ci-sdk.yaml
+++ b/.github/workflows/ci-sdk.yaml
@@ -59,7 +59,7 @@ jobs:
         run: npm install -g wasm-pack
 
       - name: Build Wasm packages
-        run: npm run build:wasm
+        run: npm run build:sdk-wasm
 
       - name: Install dependencies
         run: npm ci

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -939,7 +939,7 @@ dependencies = [
 
 [[package]]
 name = "clarinet-sdk-wasm"
-version = "2.8.0-beta1"
+version = "2.8.0-beta6"
 dependencies = [
  "clarinet-deployments",
  "clarinet-files",

--- a/components/clarinet-sdk-wasm/Cargo.toml
+++ b/components/clarinet-sdk-wasm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "clarinet-sdk-wasm"
 # version.workspace = true
-version = "2.8.0-beta1"
+version = "2.8.0-beta6"
 edition = "2021"
 license = "GPL-3.0"
 repository = "https://github.com/hirosystems/clarinet"

--- a/components/clarinet-sdk-wasm/README.md
+++ b/components/clarinet-sdk-wasm/README.md
@@ -15,7 +15,7 @@ In the root directory of Clarinet, run the following command to build the packag
 Under the hood, it will run `wasm-pack build` twice, once for each target.
 
 ```sh
-npm run build:wasm
+npm run build:sdk-wasm
 ```
 
 Alternatively, it's also possible to build the packages separately. It should only be done for development purpose.
@@ -39,7 +39,7 @@ The following script will build for both target, it will also rename the package
 browser build.
 
 ```sh
-npm run build:wasm
+npm run build:sdk-wasm
 ```
 
 Once built, the packages can be released by running the following command. Note that by default we

--- a/components/clarinet-sdk/README.md
+++ b/components/clarinet-sdk/README.md
@@ -38,7 +38,7 @@ wasm-pack (install [wasm-pack](https://rustwasm.github.io/wasm-pack/installer)).
 
 ```sh
 # build the wasm package
-npm run build:wasm
+npm run build:sdk-wasm
 # install dependencies and build the node package
 npm install
 # make sure the installation works

--- a/components/clarinet-sdk/browser/package.json
+++ b/components/clarinet-sdk/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hirosystems/clarinet-sdk-browser",
-  "version": "2.8.0-beta1",
+  "version": "2.8.0-beta6",
   "description": "A SDK to interact with Clarity Smart Contracts in the browser",
   "homepage": "https://www.hiro.so/clarinet",
   "repository": {
@@ -28,7 +28,7 @@
   "license": "GPL-3.0",
   "readme": "./README.md",
   "dependencies": {
-    "@hirosystems/clarinet-sdk-wasm-browser": "^2.8.0-beta1",
+    "@hirosystems/clarinet-sdk-wasm-browser": "^2.8.0-beta6",
     "@stacks/transactions": "^6.13.0"
   }
 }

--- a/components/clarinet-sdk/node/package.json
+++ b/components/clarinet-sdk/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hirosystems/clarinet-sdk",
-  "version": "2.8.0-beta1",
+  "version": "2.8.0-beta6",
   "description": "A SDK to interact with Clarity Smart Contracts in node.js",
   "homepage": "https://www.hiro.so/clarinet",
   "repository": {
@@ -61,7 +61,7 @@
   "license": "GPL-3.0",
   "readme": "./README.md",
   "dependencies": {
-    "@hirosystems/clarinet-sdk-wasm": "^2.8.0-beta1",
+    "@hirosystems/clarinet-sdk-wasm": "^2.8.0-beta6",
     "@stacks/transactions": "^6.13.0",
     "kolorist": "^1.8.0",
     "prompts": "^2.4.2",

--- a/components/clarinet-sdk/node/src/vitest/index.ts
+++ b/components/clarinet-sdk/node/src/vitest/index.ts
@@ -1,3 +1,6 @@
+import path from "node:path";
+import url from "node:url";
+
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 
@@ -39,5 +42,12 @@ export function getClarinetVitestsArgv() {
     }).argv;
 }
 
-export const vitestHelpersPath = "node_modules/@hirosystems/clarinet-sdk/vitest-helpers/src/";
-export const vitestSetupFilePath = `${vitestHelpersPath}vitest.setup.ts`;
+// ensure vitest helpers can be imported even in workspace setup
+// import.meta.resolve return an url like "file:///absolute/path/to/clarinet-sdk/dist/esm/index.js"
+const sdkURL = import.meta.resolve("@hirosystems/clarinet-sdk");
+const sdkPath = url.fileURLToPath(sdkURL);
+const sdkDir = path.dirname(sdkPath);
+
+// sdkDir is in /dist/esm/node/src, hence the ../../../../
+export const vitestHelpersPath = path.join(sdkDir, "../../../../vitest-helpers/src/");
+export const vitestSetupFilePath = path.join(vitestHelpersPath, "vitest.setup.ts");

--- a/components/clarinet-sdk/node/tsconfig.cjs.json
+++ b/components/clarinet-sdk/node/tsconfig.cjs.json
@@ -4,5 +4,6 @@
     "module": "commonjs",
     "outDir": "dist/cjs",
     "target": "ESNext"
-  }
+  },
+  "exclude": ["./src/vitest"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,28 +17,28 @@
         "@types/node": "^20.4.5",
         "@types/prompts": "^2.4.5",
         "@types/yargs": "^17.0.24",
-        "prettier": "^3.0.3",
-        "rimraf": "^5.0.1",
+        "prettier": "^3.3.3",
+        "rimraf": "^6.0.1",
         "ts-loader": "^9.4.4",
         "typescript": "^5.1.6"
       }
     },
     "components/clarinet-sdk-wasm/pkg-browser": {
       "name": "@hirosystems/clarinet-sdk-wasm-browser",
-      "version": "2.8.0-beta1",
+      "version": "2.8.0-beta6",
       "license": "GPL-3.0"
     },
     "components/clarinet-sdk-wasm/pkg-node": {
       "name": "@hirosystems/clarinet-sdk-wasm",
-      "version": "2.8.0-beta1",
+      "version": "2.8.0-beta6",
       "license": "GPL-3.0"
     },
     "components/clarinet-sdk/browser": {
       "name": "@hirosystems/clarinet-sdk-browser",
-      "version": "2.8.0-beta1",
+      "version": "2.8.0-beta6",
       "license": "GPL-3.0",
       "dependencies": {
-        "@hirosystems/clarinet-sdk-wasm-browser": "^2.8.0-beta1",
+        "@hirosystems/clarinet-sdk-wasm-browser": "^2.8.0-beta6",
         "@stacks/transactions": "^6.13.0"
       }
     },
@@ -48,10 +48,10 @@
     },
     "components/clarinet-sdk/node": {
       "name": "@hirosystems/clarinet-sdk",
-      "version": "2.8.0-beta1",
+      "version": "2.8.0-beta6",
       "license": "GPL-3.0",
       "dependencies": {
-        "@hirosystems/clarinet-sdk-wasm": "^2.8.0-beta1",
+        "@hirosystems/clarinet-sdk-wasm": "^2.8.0-beta6",
         "@stacks/transactions": "^6.13.0",
         "kolorist": "^1.8.0",
         "prompts": "^2.4.2",
@@ -2038,24 +2038,24 @@
       }
     },
     "node_modules/glob": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.3.tgz",
-      "integrity": "sha512-Q38SGlYRpVtDBPSWEylRyctn7uDeTp4NQERTLiCT1FqA9JXPYWqAVmQU6qh4r/zMM5ehxTcbaO8EjhWnvEhmyg==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.0.tgz",
+      "integrity": "sha512-9UiX/Bl6J2yaBbxKoEBRm4Cipxgok8kQYcOPEhScPwebu2I0HoQOuYdIO6S3hLuWoZgpDpwQZMzTFxgpkyT76g==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
+        "jackspeak": "^4.0.1",
+        "minimatch": "^10.0.0",
         "minipass": "^7.1.2",
         "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
+        "path-scurry": "^2.0.0"
       },
       "bin": {
         "glob": "dist/esm/bin.mjs"
       },
       "engines": {
-        "node": ">=18"
+        "node": "20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -2133,16 +2133,16 @@
       "license": "ISC"
     },
     "node_modules/jackspeak": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.1.tgz",
-      "integrity": "sha512-U23pQPDnmYybVkYjObcuYMk43VRlMLLqLI+RdZy8s8WV8WsxO9SnqSroKaluuvcNOdCAlauKszDwd+umbot5Mg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.0.1.tgz",
+      "integrity": "sha512-cub8rahkh0Q/bw1+GxP7aeSe29hHHn2V4m29nnDlvCdlgU+3UGxkZp7Z53jLUdpX3jdTO0nJZUDl3xvbWc2Xog==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": "20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -2264,13 +2264,13 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.0.tgz",
-      "integrity": "sha512-bfJaPTuEiTYBu+ulDaeQ0F+uLmlfFkMgXj4cbwfuMSjgObGMzb55FMMbDvbRU0fAHZ4sLGkz2mKwcMg8Dvm8Ww==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.0.tgz",
+      "integrity": "sha512-Qv32eSV1RSCfhY3fpPE2GNZ8jgM9X7rdAfemLWqTUxwiyIC4jJ6Sy0fZ8H+oLWevO6i4/bizg7c8d8i6bxrzbA==",
       "dev": true,
       "license": "ISC",
       "engines": {
-        "node": ">=18"
+        "node": "20 || >=22"
       }
     },
     "node_modules/magic-string": {
@@ -2340,16 +2340,16 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
+      "integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": "20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -2511,17 +2511,17 @@
       }
     },
     "node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
+      "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.18"
+        "node": "20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -2601,9 +2601,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.2.tgz",
-      "integrity": "sha512-rAVeHYMcv8ATV5d508CFdn+8/pHPpXeIid1DdrPwXnaAdH7cqjVbpJaT5eq4yRAFU/lsbwYwSF/n5iNrdJHPQA==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
+      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -2693,19 +2693,20 @@
       }
     },
     "node_modules/rimraf": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.8.tgz",
-      "integrity": "sha512-XSh0V2/yNhDEi8HwdIefD8MLgs4LQXPag/nEJWs3YUc3Upn+UHa1GyIkEg9xSSNt7HnkO5FjTvmcRzgf+8UZuw==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.0.1.tgz",
+      "integrity": "sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "glob": "^10.3.7"
+        "glob": "^11.0.0",
+        "package-json-from-dist": "^1.0.0"
       },
       "bin": {
         "rimraf": "dist/esm/bin.mjs"
       },
       "engines": {
-        "node": ">=18"
+        "node": "20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "components/clarinet-sdk/browser"
   ],
   "scripts": {
-    "build:wasm": "node components/clarinet-sdk-wasm/build.mjs",
+    "build:sdk-wasm": "node components/clarinet-sdk-wasm/build.mjs",
+    "build:sdk": "npm run -w components/clarinet-sdk/node -w components/clarinet-sdk/browser build",
     "test": "npm test --workspaces --if-present",
     "publish:sdk-wasm": "npm publish -w components/clarinet-sdk-wasm/pkg-node -w components/clarinet-sdk-wasm/pkg-browser --tag beta",
     "publish:sdk": "npm publish -w components/clarinet-sdk/node -w components/clarinet-sdk/browser --tag beta"
@@ -22,8 +23,8 @@
     "@types/node": "^20.4.5",
     "@types/prompts": "^2.4.5",
     "@types/yargs": "^17.0.24",
-    "prettier": "^3.0.3",
-    "rimraf": "^5.0.1",
+    "prettier": "^3.3.3",
+    "rimraf": "^6.0.1",
     "ts-loader": "^9.4.4",
     "typescript": "^5.1.6"
   }


### PR DESCRIPTION
Superseding #1500

From @bradleyayers: 
> The location of node_modules is not guaranteed to be relative to the current directory (e.g. in workspaces). A better solution here is to update package.json exports to include the file.

This fixes it and also update some of the sdk dependencies.

The fix is available and can be tested with `npm i --force @hirosystems/clarinet-sdk@2.8.0-beta6`.
I also tested in an npm workspace setup (not tested with pnpm or yarn, @bradleyayers let me know if you can give it a try)