### PR TITLE
feat: add stacks_node_next_initiative_delay in devnet config

### DIFF
--- a/components/clarinet-cli/src/generate/project.rs
+++ b/components/clarinet-cli/src/generate/project.rs
@@ -341,7 +341,6 @@ disable_stacks_api = false
 # subnet_api_image_url = "{default_subnet_api_image}"
 # subnet_api_postgres_database = "subnet_api"
 
-# For testing in epoch 2.1 / using Clarity2
 # epoch_2_0 = {DEFAULT_EPOCH_2_0}
 # epoch_2_05 = {DEFAULT_EPOCH_2_05}
 # epoch_2_1 = {DEFAULT_EPOCH_2_1}
@@ -349,6 +348,7 @@ disable_stacks_api = false
 # epoch_2_3 = {DEFAULT_EPOCH_2_3}
 # epoch_2_4 = {DEFAULT_EPOCH_2_4}
 # epoch_2_5 = {DEFAULT_EPOCH_2_5}
+# epoch_3_0 = 144
 
 
 # Send some stacking orders

--- a/components/clarinet-files/src/network_manifest.rs
+++ b/components/clarinet-files/src/network_manifest.rs
@@ -86,6 +86,7 @@ pub struct DevnetConfigFile {
     pub stacks_node_first_attempt_time_ms: Option<u32>,
     pub stacks_node_subsequent_attempt_time_ms: Option<u32>,
     pub stacks_node_env_vars: Option<Vec<String>>,
+    pub stacks_node_next_initiative_delay: Option<u16>,
     pub stacks_api_env_vars: Option<Vec<String>>,
     pub stacks_explorer_env_vars: Option<Vec<String>>,
     pub subnet_node_env_vars: Option<Vec<String>>,
@@ -243,6 +244,7 @@ pub struct DevnetConfig {
     pub stacks_node_subsequent_attempt_time_ms: u32,
     pub stacks_node_events_observers: Vec<String>,
     pub stacks_node_env_vars: Vec<String>,
+    pub stacks_node_next_initiative_delay: u16,
     pub stacks_api_port: u16,
     pub stacks_api_events_port: u16,
     pub stacks_api_env_vars: Vec<String>,
@@ -508,6 +510,10 @@ impl NetworkManifest {
 
                 if let Some(ref val) = devnet_override.stacks_node_events_observers {
                     devnet_config.stacks_node_events_observers = Some(val.clone());
+                }
+
+                if let Some(val) = devnet_override.stacks_node_next_initiative_delay {
+                    devnet_config.stacks_node_next_initiative_delay = Some(val);
                 }
 
                 if let Some(val) = devnet_override.stacks_api_port {
@@ -835,6 +841,9 @@ impl NetworkManifest {
                 stacks_node_subsequent_attempt_time_ms: devnet_config
                     .stacks_node_subsequent_attempt_time_ms
                     .unwrap_or(1_000),
+                stacks_node_next_initiative_delay: devnet_config
+                    .stacks_node_next_initiative_delay
+                    .unwrap_or(4000),
                 stacks_api_port: devnet_config.stacks_api_port.unwrap_or(3999),
                 stacks_api_events_port: devnet_config.stacks_api_events_port.unwrap_or(3700),
                 stacks_explorer_port: devnet_config.stacks_explorer_port.unwrap_or(8000),

--- a/components/stacks-network/src/chains_coordinator.rs
+++ b/components/stacks-network/src/chains_coordinator.rs
@@ -6,6 +6,7 @@ use crate::event::Status;
 use crate::orchestrator::ServicesMapHosts;
 
 use base58::FromBase58;
+use bitcoincore_rpc::bitcoin::Address;
 use chainhook_sdk::chainhooks::types::ChainhookStore;
 use chainhook_sdk::observer::{
     start_event_observer, EventObserverConfig, ObserverCommand, ObserverEvent,
@@ -34,6 +35,7 @@ use clarity::vm::Value as ClarityValue;
 use hiro_system_kit;
 use hiro_system_kit::slog;
 use hiro_system_kit::yellow;
+use serde_json::json;
 use stacks_rpc_client::rpc_client::PoxInfo;
 use stacks_rpc_client::StacksRpc;
 use stackslib::chainstate::stacks::address::PoxAddress;
@@ -44,6 +46,7 @@ use stackslib::util_lib::signed_structured_data::pox4::make_pox_4_signer_key_sig
 use stackslib::util_lib::signed_structured_data::pox4::Pox4SignatureTopic;
 use std::convert::TryFrom;
 use std::str;
+use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{channel, Receiver, Sender};
 use std::sync::Arc;
@@ -434,7 +437,11 @@ pub async fn start_chains_coordinator(
             }
             ObserverEvent::NotifyBitcoinTransactionProxied => {
                 if !boot_completed.load(Ordering::SeqCst) {
-                    std::thread::sleep(std::time::Duration::from_secs(1));
+                    let _ = devnet_event_tx
+                        .send(DevnetEvent::info("1 - Waiting for boot mining".to_string()));
+                    std::thread::sleep(std::time::Duration::from_millis(2000));
+                    let _ = devnet_event_tx
+                        .send(DevnetEvent::info("1 - Trigger boot mining".to_string()));
                     let res = mine_bitcoin_block(
                         &config.services_map_hosts.bitcoin_node_host,
                         config.devnet_config.bitcoin_node_username.as_str(),
@@ -802,14 +809,9 @@ pub async fn mine_bitcoin_block(
     bitcoin_node_password: &str,
     miner_btc_address: &str,
 ) -> Result<(), String> {
-    use bitcoincore_rpc::bitcoin::Address;
-    use reqwest::Client as HttpClient;
-    use serde_json::json;
-    use std::str::FromStr;
-
     let miner_address = Address::from_str(miner_btc_address).unwrap();
-    let _ = HttpClient::builder()
-        .timeout(Duration::from_secs(5))
+    let _ = reqwest::Client::builder()
+        .timeout(Duration::from_secs(2))
         .build()
         .expect("Unable to build http client")
         .post(format!("http://{}", bitcoin_node_host))

--- a/components/stacks-network/src/orchestrator.rs
+++ b/components/stacks-network/src/orchestrator.rs
@@ -1059,7 +1059,7 @@ local_peer_seed = "{miner_secret_key_hex}"
 pox_sync_sample_secs = 0
 wait_time_for_blocks = 0
 wait_time_for_microblocks = 0
-next_initiative_delay = 4000
+next_initiative_delay = {next_initiative_delay}
 mine_microblocks = false
 microblock_frequency = 1000
 
@@ -1086,6 +1086,7 @@ mining_key = "19ec1c3e31d139c989a23a27eac60d1abfad5277d3ae9604242514c738258efa01
             stacks_node_rpc_port = devnet_config.stacks_node_rpc_port,
             stacks_node_p2p_port = devnet_config.stacks_node_p2p_port,
             miner_secret_key_hex = devnet_config.miner_secret_key_hex,
+            next_initiative_delay = devnet_config.stacks_node_next_initiative_delay,
             first_attempt_time_ms = devnet_config.stacks_node_first_attempt_time_ms,
             subsequent_attempt_time_ms = devnet_config.stacks_node_subsequent_attempt_time_ms,
             miner_coinbase_recipient = devnet_config.miner_coinbase_recipient,

--- a/components/stacks-network/src/ui/ui.rs
+++ b/components/stacks-network/src/ui/ui.rs
@@ -112,8 +112,7 @@ fn draw_devnet_status(f: &mut Frame, app: &mut App, area: Rect) {
         .style(Style::default().fg(Color::White))
         .borders(Borders::ALL)
         .title("Stacks Devnet");
-    let mut inner_area = block.inner(area);
-    inner_area.height = inner_area.height.saturating_sub(1);
+    let inner_area = block.inner(area);
     f.render_widget(block, area);
 
     let logs_component = List::new(logs).direction(ListDirection::BottomToTop);


### PR DESCRIPTION
This setting has been introduced in stacks-node for nakamoto.
We should experiment around having a default of value of 3 or 4 seconds. Lower values could allow to handle faster Bitcoin blocks but can also break the blockchain.
Maybe in the future we'll warn the users that can't put a value lower than X seconds, but that ok for now, we'll communicate about epoch 3.0 support as "beta"