### PR TITLE
feat: auto extend stacking_orders in devnet config by default

### DIFF
--- a/components/clarinet-cli/src/generate/project.rs
+++ b/components/clarinet-cli/src/generate/project.rs
@@ -354,24 +354,28 @@ disable_stacks_api = false
 # Send some stacking orders
 [[devnet.pox_stacking_orders]]
 start_at_cycle = 1
-duration = 12
+duration = 10
+auto_extend = true
 wallet = "wallet_1"
 slots = 2
 btc_address = "mr1iPkD9N3RJZZxXRk7xF9d36gffa6exNC"
 
 [[devnet.pox_stacking_orders]]
 start_at_cycle = 1
-duration = 12
+duration = 10
+auto_extend = true
 wallet = "wallet_2"
 slots = 1
 btc_address = "muYdXKmX9bByAueDe6KFfHd5Ff1gdN9ErG"
 
 [[devnet.pox_stacking_orders]]
 start_at_cycle = 1
-duration = 12
+duration = 10
+auto_extend = true
 wallet = "wallet_3"
 slots = 1
 btc_address = "mvZtbibDAAA3WLpY7zXXFqRa3T4XSknBX7"
+
 "#,
             default_derivation_path = DEFAULT_DERIVATION_PATH,
             default_bitcoin_node_image = DEFAULT_BITCOIN_NODE_IMAGE,


### PR DESCRIPTION
The Devnet.toml config generated by default should auto_extend stacking orders by default.
Auto extending stacking orders allows to maintain epoch 3.0


