### PR TITLE
ci: upgrade actions/upload-artifact and download-artifact to v4

### DIFF
--- a/.github/workflows/ci-cli.yaml
+++ b/.github/workflows/ci-cli.yaml
@@ -259,14 +259,14 @@ jobs:
       # Separate uploads to prevent paths from being preserved
       - name: Upload cargo artifacts (Linux)
         if: matrix.os != 'windows-latest'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: clarinet-${{ env.SHORT_TARGET_NAME }}
           path: clarinet-${{ env.SHORT_TARGET_NAME }}.tar.gz
 
       - name: Upload cargo artifact (Windows)
         if: matrix.os == 'windows-latest'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: clarinet-${{ env.SHORT_TARGET_NAME }}
           path: clarinet-${{ env.SHORT_TARGET_NAME }}.msi
@@ -323,7 +323,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Download pre-built dist
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ matrix.artifact }}
 
@@ -356,7 +356,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download pre-built dists
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
 
       - name: Tag and Release
         uses: ncipollo/release-action@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -302,14 +302,14 @@ jobs:
       # Separate uploads to prevent paths from being preserved
       - name: Upload cargo artifacts (Linux)
         if: matrix.os != 'windows-latest'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: clarinet-${{ env.SHORT_TARGET_NAME }}
           path: clarinet-${{ env.SHORT_TARGET_NAME }}.tar.gz
 
       - name: Upload cargo artifact (Windows)
         if: matrix.os == 'windows-latest'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: clarinet-${{ env.SHORT_TARGET_NAME }}
           path: clarinet-${{ env.SHORT_TARGET_NAME }}.msi
@@ -442,7 +442,7 @@ jobs:
 
       - name: Upload node artifact
         if: github.event_name != 'pull_request' || matrix.target == 'x86_64-unknown-linux-gnu'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: stacks-devnet-js-${{ env.PRE_GYP_TARGET_NAME }}
           path: stacks-devnet-js-${{ env.PRE_GYP_TARGET_NAME }}.tar.gz
@@ -498,14 +498,14 @@ jobs:
         run: tar -C target/x86_64-unknown-linux-gnu/release -zcvf clarity-repl-${{ env.SHORT_TARGET_NAME }}.tar.gz clarity-repl
 
       - name: Upload cargo artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: clarity-repl-${{ env.SHORT_TARGET_NAME }}
           path: clarity-repl-${{ env.SHORT_TARGET_NAME }}.tar.gz
 
       - name: Publish clarity-repl to crates.io
         if: startsWith(github.ref, 'refs/heads/main') && needs.get_release_info.outputs.tag != ''
-        run: |
+        run: 4
           cargo login ${{ secrets.CARGO_CRATES_IO_API_KEY }}
           cargo publish
 
@@ -552,7 +552,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Download pre-built dist
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ matrix.artifact }}
 
@@ -587,7 +587,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download pre-built dists
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
 
       - name: Tag and Release
         uses: ncipollo/release-action@v1


### PR DESCRIPTION
Upgrade actions/upload-artifacts and actions/download-artifacts to v4.


https://github.com/hirosystems/clarinet/security/dependabot/211