### PR TITLE
Feat/customize number of signers in devnet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -555,11 +555,11 @@ dependencies = [
 
 [[package]]
 name = "bollard"
-version = "0.16.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83545367eb6428eb35c29cdec3a1f350fa8d6d9085d59a7d7bcb637f2e38db5a"
+checksum = "d41711ad46fda47cd701f6908e59d1bd6b9a2b7464c0d0aeab95c6d37096ff8a"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "bollard-stubs",
  "bytes",
  "futures-core",
@@ -567,10 +567,10 @@ dependencies = [
  "hex",
  "http 1.1.0",
  "http-body-util",
- "hyper 1.2.0",
+ "hyper 1.4.1",
  "hyper-named-pipe",
  "hyper-util",
- "hyperlocal-next",
+ "hyperlocal",
  "log",
  "pin-project-lite",
  "serde",
@@ -588,9 +588,9 @@ dependencies = [
 
 [[package]]
 name = "bollard-stubs"
-version = "1.44.0-rc.2"
+version = "1.45.0-rc.26.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "709d9aa1c37abb89d40f19f5d0ad6f0d88cb1581264e571c9350fc5bb89cf1c5"
+checksum = "6d7c5415e3a6bc6d3e99eff6268e488fd4ee25e7b28c10f08fa6760bd9de16e4"
 dependencies = [
  "serde",
  "serde_repr",
@@ -644,9 +644,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.4.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 
 [[package]]
 name = "cassowary"
@@ -2385,9 +2385,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.2.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186548d73ac615b32a73aafe38fb4f56c0d340e110e5a200bcadbaf2e199263a"
+checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2395,6 +2395,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.0",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec 1.13.1",
@@ -2409,7 +2410,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
 dependencies = [
  "hex",
- "hyper 1.2.0",
+ "hyper 1.4.1",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -2425,7 +2426,7 @@ checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
 dependencies = [
  "futures-util",
  "http 1.1.0",
- "hyper 1.2.0",
+ "hyper 1.4.1",
  "hyper-util",
  "rustls",
  "rustls-pki-types",
@@ -2437,16 +2438,16 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.3"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
+checksum = "da62f120a8a37763efb0cf8fdf264b884c7b8b9ac8660b900c8661030c00e6ba"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
  "http 1.1.0",
  "http-body 1.0.0",
- "hyper 1.2.0",
+ "hyper 1.4.1",
  "pin-project-lite",
  "socket2 0.5.5",
  "tokio",
@@ -2456,14 +2457,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyperlocal-next"
-version = "0.9.0"
+name = "hyperlocal"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acf569d43fa9848e510358c07b80f4adf34084ddc28c6a4a651ee8474c070dcc"
+checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
 dependencies = [
  "hex",
  "http-body-util",
- "hyper 1.2.0",
+ "hyper 1.4.1",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -4018,7 +4019,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.0",
  "http-body-util",
- "hyper 1.2.0",
+ "hyper 1.4.1",
  "hyper-rustls",
  "hyper-util",
  "ipnet",
@@ -5504,7 +5505,6 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -5560,7 +5560,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if 1.0.0",
- "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -899,6 +899,7 @@ dependencies = [
  "clarity",
  "clarity-repl",
  "js-sys",
+ "lazy_static",
  "libsecp256k1 0.7.1",
  "serde",
  "serde-wasm-bindgen",
@@ -1818,9 +1819,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
@@ -1864,9 +1865,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.26"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1874,9 +1875,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.26"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
 
 [[package]]
 name = "futures-executor"
@@ -1891,32 +1892,32 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.26"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.26"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn 2.0.50",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.26"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
 
 [[package]]
 name = "futures-task"
-version = "0.3.26"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
 name = "futures-timer"
@@ -1926,9 +1927,9 @@ checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
-version = "0.3.26"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2418,9 +2419,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.26.0"
+version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
+checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
 dependencies = [
  "futures-util",
  "http 1.1.0",
@@ -2431,6 +2432,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2500,9 +2502,9 @@ checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 
 [[package]]
 name = "idna"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -3340,9 +3342,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "opaque-debug"
@@ -3487,9 +3489,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.2.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pico-args"
@@ -3706,6 +3708,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c7c5fdde3cdae7203427dc4f0a68fe0ed09833edc525a03456b153b79828684"
+dependencies = [
+ "bytes",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 2.0.0",
+ "rustls",
+ "socket2 0.5.5",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fadfaed2cd7f389d0161bb73eeb07b7b78f8691047a6f3e73caaeae55310a4a6"
+dependencies = [
+ "bytes",
+ "rand 0.8.5",
+ "ring",
+ "rustc-hash 2.0.0",
+ "rustls",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bffec3605b73c6f1754535084a85229fa8a30f86014e6c81aeec4abb68b0285"
+dependencies = [
+ "libc",
+ "once_cell",
+ "socket2 0.5.5",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3905,7 +3955,7 @@ checksum = "ad156d539c879b7a24a363a2016d77961786e71f48f2e2fc8302a92abd2429a6"
 dependencies = [
  "hashbrown 0.13.2",
  "log",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "slice-group-by",
  "smallvec 1.13.1",
 ]
@@ -3956,9 +4006,9 @@ checksum = "56d84fdd47036b038fc80dd333d10b6aab10d5d31f4a366e20014def75328d33"
 
 [[package]]
 name = "reqwest"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
+checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3978,6 +4028,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
  "rustls",
  "rustls-pemfile",
  "rustls-pki-types",
@@ -4167,6 +4218,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc-hash"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
+
+[[package]]
 name = "rustc-hex"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4209,11 +4266,11 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.4"
+version = "0.23.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+checksum = "f2dabaac7466917e566adb06783a81ca48944c6898a1b08b9374106dd671f4c8"
 dependencies = [
- "log",
+ "once_cell",
  "ring",
  "rustls-pki-types",
  "rustls-webpki",
@@ -4239,9 +4296,9 @@ checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.5"
+version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a6fccd794a42c2c105b513a2f62bc3fd8f3ba57a4593677ceb0bd035164d78"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -5093,9 +5150,9 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
 
 [[package]]
 name = "take_mut"
@@ -5333,9 +5390,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
  "rustls",
  "rustls-pki-types",
@@ -5681,9 +5738,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.3.1"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
+checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
 dependencies = [
  "form_urlencoded",
  "idna",

--- a/components/clarinet-files/Cargo.toml
+++ b/components/clarinet-files/Cargo.toml
@@ -15,6 +15,7 @@ toml = { version = "0.5.6", features = ["preserve_order"] }
 url = { version = "2.2.2", features = ["serde"] }
 tiny-hderive = "0.3.0"
 bitcoin = { version = "0.29.2", optional = true }
+lazy_static = { workspace = true}
 
 clarity = { workspace = true }
 

--- a/components/clarinet-files/src/network_manifest.rs
+++ b/components/clarinet-files/src/network_manifest.rs
@@ -121,7 +121,7 @@ pub struct DevnetConfigFile {
     pub faucet_derivation_path: Option<String>,
     pub bitcoin_controller_block_time: Option<u32>,
     pub bitcoin_controller_automining_disabled: Option<bool>,
-    pub pre_nakamoto_block_signing: Option<bool>,
+    pub pre_nakamoto_mock_signing: Option<bool>,
     pub working_dir: Option<String>,
     pub postgres_port: Option<u16>,
     pub postgres_username: Option<String>,
@@ -285,7 +285,7 @@ pub struct DevnetConfig {
     pub faucet_btc_address: String,
     pub faucet_mnemonic: String,
     pub faucet_derivation_path: String,
-    pub pre_nakamoto_block_signing: bool,
+    pub pre_nakamoto_mock_signing: bool,
     pub working_dir: String,
     pub postgres_port: u16,
     pub postgres_username: String,
@@ -878,8 +878,8 @@ impl NetworkManifest {
                     .miner_coinbase_recipient
                     .unwrap_or(miner_stx_address),
                 miner_wallet_name: devnet_config.miner_wallet_name.unwrap_or("".to_string()),
-                pre_nakamoto_block_signing: devnet_config
-                    .pre_nakamoto_block_signing
+                pre_nakamoto_mock_signing: devnet_config
+                    .pre_nakamoto_mock_signing
                     .unwrap_or_default(),
                 faucet_btc_address,
                 faucet_stx_address,

--- a/components/clarinet-sdk/node/tests/pox-locking.test.ts
+++ b/components/clarinet-sdk/node/tests/pox-locking.test.ts
@@ -151,7 +151,7 @@ describe("test pox-3", () => {
 describe("test pox-4", () => {
   const poxContract = `${poxDeployer}.pox-4`;
 
-  // wallet_1, wallet_2, wallet_3 private keys
+  // wallet_1 and wallet_2 private keys
   const stackingKeys = [
     "7287ba251d44a4d3fd9276c88ce34c5c52a038955511cccaf77e61068649c17801",
     "530d9f61984c888536871c6573073bdfc0058896dc1adfe9a6a10dfacadc209101",

--- a/components/stacks-network/Cargo.toml
+++ b/components/stacks-network/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 atty = "0.2.14"
 ansi_term = "0.12.1"
-bollard = "0.16.0"
+bollard = "0.17"
 bitcoin = "0.29.2"
 bitcoincore-rpc = "0.16.0"
 serde = { version = "1", features = ["derive"] }

--- a/components/stacks-network/src/chains_coordinator.rs
+++ b/components/stacks-network/src/chains_coordinator.rs
@@ -655,10 +655,9 @@ pub async fn publish_stacking_orders(
             Ok(pox_info) => Some(pox_info),
             Err(e) => {
                 let _ = devnet_event_tx.send(DevnetEvent::warning(format!(
-                    "Unable to parse pox info: {}",
+                    "unable to parse pox info: {}",
                     e
                 )));
-
                 None
             }
         },

--- a/components/stacks-network/src/event.rs
+++ b/components/stacks-network/src/event.rs
@@ -79,20 +79,17 @@ pub fn send_status_update(
     status: Status,
     comment: &str,
 ) {
-    // leaving it a variable in case we want to make it dynamic in the future
-    let signers_services = 2;
     let subnet_services = if with_subnets { 2 } else { 0 };
 
     let order = match name {
         "bitcoin-node" => 0,
         "stacks-node" => 1,
-        "stacks-signer-1" => 2,
-        "stacks-signer-2" => 3,
-        "stacks-api" => signers_services + 2,
-        "subnet-node" => signers_services + 3,
-        "subnet-api" => signers_services + 4,
-        "stacks-explorer" => signers_services + subnet_services + 3,
-        "bitcoin-explorer" => signers_services + subnet_services + 4,
+        "stacks-signers" => 2,
+        "stacks-api" => 3,
+        "subnet-node" => 4,
+        "subnet-api" => 5,
+        "stacks-explorer" => subnet_services + 4,
+        "bitcoin-explorer" => subnet_services + 5,
         _ => return,
     };
 

--- a/components/stacks-network/src/orchestrator.rs
+++ b/components/stacks-network/src/orchestrator.rs
@@ -1098,8 +1098,6 @@ amount = {}
                 r#"
 [[events_observer]]
 endpoint = "stacks-signer-{i}.{}:{}"
-retry_count = 255
-include_data_events = false
 events_keys = ["stackerdb", "block_proposal", "burn_blocks"]
 "#,
                 self.network_name,
@@ -1109,13 +1107,11 @@ events_keys = ["stackerdb", "block_proposal", "burn_blocks"]
 
         stacks_conf.push_str(&format!(
             r#"
-# Add orchestrator (docker-host) as an event observer
-[[events_observer]]
-endpoint = "host.docker.internal:{orchestrator_ingestion_port}"
-retry_count = 255
-include_data_events = true
-events_keys = ["*"]
-"#,
+        # Add orchestrator (docker-host) as an event observer
+        [[events_observer]]
+        endpoint = "host.docker.internal:{orchestrator_ingestion_port}"
+        events_keys = ["burn_blocks", "memtx"]
+        "#,
             orchestrator_ingestion_port = devnet_config.orchestrator_ingestion_port,
         ));
 
@@ -1125,8 +1121,6 @@ events_keys = ["*"]
 # Add stacks-api as an event observer
 [[events_observer]]
 endpoint = "stacks-api.{}:{}"
-retry_count = 255
-include_data_events = false
 events_keys = ["*"]
 "#,
                 self.network_name, devnet_config.stacks_api_events_port
@@ -1139,7 +1133,6 @@ events_keys = ["*"]
 # Add subnet-node as an event observer
 [[events_observer]]
 endpoint = "subnet-node.{}:{}"
-retry_count = 255
 events_keys = ["*"]
 "#,
                 self.network_name, devnet_config.subnet_events_ingestion_port
@@ -1151,7 +1144,6 @@ events_keys = ["*"]
                 r#"
 [[events_observer]]
 endpoint = "{}"
-retry_count = 255
 events_keys = ["*"]
 "#,
                 chains_coordinator,
@@ -1600,7 +1592,6 @@ observer_port = {subnet_events_ingestion_port}
 # Add orchestrator (docker-host) as an event observer
 # [[events_observer]]
 # endpoint = "host.docker.internal:{orchestrator_port}"
-# retry_count = 255
 # include_data_events = true
 # events_keys = ["*"]
 "#,
@@ -1623,7 +1614,6 @@ observer_port = {subnet_events_ingestion_port}
                 r#"
 [[events_observer]]
 endpoint = "{}"
-retry_count = 255
 events_keys = ["*"]
 "#,
                 events_observer,
@@ -1636,7 +1626,6 @@ events_keys = ["*"]
 # Add subnet-api as an event observer
 [[events_observer]]
 endpoint = "subnet-api.{}:{}"
-retry_count = 255
 include_data_events = false
 events_keys = ["*"]
 "#,

--- a/components/stacks-network/src/orchestrator.rs
+++ b/components/stacks-network/src/orchestrator.rs
@@ -1066,8 +1066,8 @@ second_attempt_time_ms = {subsequent_attempt_time_ms}
 block_reward_recipient = "{miner_coinbase_recipient}"
 wait_for_block_download = false
 microblock_attempt_time_ms = 10
+pre_nakamoto_mock_signing = false
 mining_key = "19ec1c3e31d139c989a23a27eac60d1abfad5277d3ae9604242514c738258efa01"
-# microblock_attempt_time_ms = 15000
 "#,
             stacks_node_rpc_port = devnet_config.stacks_node_rpc_port,
             stacks_node_p2p_port = devnet_config.stacks_node_p2p_port,

--- a/components/stacks-network/src/orchestrator.rs
+++ b/components/stacks-network/src/orchestrator.rs
@@ -1058,6 +1058,9 @@ disable_inbound_handshakes = true
 disable_inbound_walks = true
 public_ip_address = "1.1.1.1:1234"
 auth_token = "12345"
+# block_proposal_token has been replaced by auth_token
+# we keep it for backward compatibility
+block_proposal_token = "12345"
 
 [miner]
 min_tx_fee = 1
@@ -1107,11 +1110,11 @@ events_keys = ["stackerdb", "block_proposal", "burn_blocks"]
 
         stacks_conf.push_str(&format!(
             r#"
-        # Add orchestrator (docker-host) as an event observer
-        [[events_observer]]
-        endpoint = "host.docker.internal:{orchestrator_ingestion_port}"
-        events_keys = ["burn_blocks", "memtx"]
-        "#,
+# Add orchestrator (docker-host) as an event observer
+[[events_observer]]
+endpoint = "host.docker.internal:{orchestrator_ingestion_port}"
+events_keys = ["burn_blocks", "memtx"]
+"#,
             orchestrator_ingestion_port = devnet_config.orchestrator_ingestion_port,
         ));
 
@@ -1154,14 +1157,14 @@ events_keys = ["*"]
             r#"
 [burnchain]
 chain = "bitcoin"
-mode = "{burnchain_mode}"
+mode = "krypton"
 magic_bytes = "T3"
 first_burn_block_height = 100
 pox_prepare_length = 5
 pox_reward_length = 20
 burn_fee_cap = 20_000
 poll_time_secs = 1
-timeout = 30
+timeout = 2
 peer_host = "host.docker.internal"
 rpc_ssl = false
 wallet_name = "{miner_wallet_name}"
@@ -1170,7 +1173,6 @@ password = "{bitcoin_node_password}"
 rpc_port = {orchestrator_ingestion_port}
 peer_port = {bitcoin_node_p2p_port}
 "#,
-            burnchain_mode = "nakamoto-neon",
             bitcoin_node_username = devnet_config.bitcoin_node_username,
             bitcoin_node_password = devnet_config.bitcoin_node_password,
             bitcoin_node_p2p_port = devnet_config.bitcoin_node_p2p_port,

--- a/components/stacks-network/src/orchestrator.rs
+++ b/components/stacks-network/src/orchestrator.rs
@@ -1595,7 +1595,6 @@ observer_port = {subnet_events_ingestion_port}
 # Add orchestrator (docker-host) as an event observer
 # [[events_observer]]
 # endpoint = "host.docker.internal:{orchestrator_port}"
-# include_data_events = true
 # events_keys = ["*"]
 "#,
             subnet_node_rpc_port = devnet_config.subnet_node_rpc_port,
@@ -1629,7 +1628,6 @@ events_keys = ["*"]
 # Add subnet-api as an event observer
 [[events_observer]]
 endpoint = "subnet-api.{}:{}"
-include_data_events = false
 events_keys = ["*"]
 "#,
                 self.network_name, devnet_config.subnet_api_events_port

--- a/components/stacks-network/src/orchestrator.rs
+++ b/components/stacks-network/src/orchestrator.rs
@@ -1112,7 +1112,7 @@ disable_block_download = true
 disable_inbound_handshakes = true
 disable_inbound_walks = true
 public_ip_address = "1.1.1.1:1234"
-block_proposal_token = "12345"
+auth_token = "12345"
 
 [miner]
 min_tx_fee = 1

--- a/components/stacks-network/src/orchestrator.rs
+++ b/components/stacks-network/src/orchestrator.rs
@@ -1069,7 +1069,7 @@ second_attempt_time_ms = {subsequent_attempt_time_ms}
 block_reward_recipient = "{miner_coinbase_recipient}"
 wait_for_block_download = false
 microblock_attempt_time_ms = 10
-pre_nakamoto_mock_signing = false
+pre_nakamoto_mock_signing = {pre_nakamoto_mock_signing}
 mining_key = "19ec1c3e31d139c989a23a27eac60d1abfad5277d3ae9604242514c738258efa01"
 "#,
             stacks_node_rpc_port = devnet_config.stacks_node_rpc_port,
@@ -1079,6 +1079,7 @@ mining_key = "19ec1c3e31d139c989a23a27eac60d1abfad5277d3ae9604242514c738258efa01
             first_attempt_time_ms = devnet_config.stacks_node_first_attempt_time_ms,
             subsequent_attempt_time_ms = devnet_config.stacks_node_subsequent_attempt_time_ms,
             miner_coinbase_recipient = devnet_config.miner_coinbase_recipient,
+            pre_nakamoto_mock_signing = devnet_config.pre_nakamoto_mock_signing,
         );
 
         for (_, account) in network_config.accounts.iter() {

--- a/dockerfiles/devnet/Stacks.dockerfile
+++ b/dockerfiles/devnet/Stacks.dockerfile
@@ -5,16 +5,13 @@ RUN test -n "$GIT_COMMIT" || (echo "GIT_COMMIT not set" && false)
 
 RUN echo "Building stacks-node from commit: https://github.com/stacks-network/stacks-blockchain/commit/$GIT_COMMIT"
 
-RUN apt-get update && apt-get install -y libclang-dev
-RUN rustup toolchain install stable
-
 WORKDIR /stacks
 RUN git init && \
     git remote add origin https://github.com/stacks-network/stacks-blockchain.git && \
-    git -c protocol.version=2 fetch --depth=1 origin "$GIT_COMMIT" && \
+    git fetch --depth=1 origin "$GIT_COMMIT" && \
     git reset --hard FETCH_HEAD
 
-RUN cargo build --release --package stacks-node --bin stacks-node
+RUN cargo build --package stacks-node --bin stacks-node --features monitoring_prom,slog_json --release
 
 FROM debian:bookworm-slim
 


### PR DESCRIPTION
Adding a new `devnet.stacks_signers_keys` configuratoin key, that is an array of strings.
Each keys will result in a stacks signer container being booted as part of the devnet.

Stackers will also use these key to send the stacking txs.

This PR also adds a `devnet.stacks_signers_env_vars` (similar to `stacks_node_env_vars`)


resolves #1530 
