### PR TITLE
fix: convert correctly from uSTX to STX when applying a deployment on issue #1447

### DIFF
--- a/components/clarinet-cli/src/deployments/types.rs
+++ b/components/clarinet-cli/src/deployments/types.rs
@@ -48,7 +48,7 @@ impl Display for DeploymentSynthesis {
         let base: u64 = 10;
         let int_part = self.total_cost / base.pow(6);
         let frac_part = self.total_cost % base.pow(6);
-        let formatted_total_cost = format!("{}.{:08}", int_part, frac_part);
+        let formatted_total_cost = format!("{}.{:06}", int_part, frac_part);
         write!(
             f,
             "{}\n\n{}\n{}",


### PR DESCRIPTION
### Description

This PR addresses an issue with the conversion from micro STX (uSTX) to STX during deployment. Previously, the conversion was not handled correctly, leading to incorrect STX values being applied. This fix ensures that the conversion is accurate and that the correct STX values are used.

Related issues and PRs:

Issue: #1447

#### Breaking change?

No breaking changes are introduced by this PR.

### Example

Example
Before this fix, deploying with micro STX values would result in incorrect STX values being applied. After this fix, the conversion is handled correctly, ensuring that the deployed values are accurate.