### PR TITLE
refactor: better eval hooks handling in contract calls

### DIFF
--- a/components/clarinet-cli/src/generate/contract.rs
+++ b/components/clarinet-cli/src/generate/contract.rs
@@ -31,11 +31,6 @@ impl GetChangesForRmContract {
         f.append_path("tests")?;
         f.append_path(&name)?;
         if !f.exists() {
-            format!(
-                "{} tests/{} doesn't exist. Skipping removal",
-                red!("Warning"),
-                name
-            );
             return Ok(());
         }
         let change = FileDeletion {

--- a/components/clarinet-deployments/src/lib.rs
+++ b/components/clarinet-deployments/src/lib.rs
@@ -239,7 +239,6 @@ fn handle_emulated_contract_call(
         true,
         false,
         vec![],
-        "deployment".to_string(),
     );
     if let Err(errors) = &result {
         println!("error: {:?}", errors.first().unwrap().message);

--- a/components/clarinet-sdk/node/tests/reports.test.ts
+++ b/components/clarinet-sdk/node/tests/reports.test.ts
@@ -107,3 +107,31 @@ describe("simnet can report both costs and coverage", () => {
     expect(reports.coverage.length).greaterThan(0);
   });
 });
+
+describe.only("run-snippet and execute also report coverage", () => {
+  it("simnet.execute reports coverage", async () => {
+    const simnet = await initSimnet("tests/fixtures/Clarinet.toml", true, {
+      trackCoverage: true,
+      trackCosts: false,
+    });
+    simnet.execute("(contract-call? .counter increment)");
+    simnet.execute("(contract-call? .counter increment)");
+
+    const reports = simnet.collectReport(false, "");
+    // line 26, within the increment function, is executed twice
+    expect(reports.coverage).toContain("DA:26,2");
+  });
+
+  it("simnet.runSnippet reports coverage", async () => {
+    const simnet = await initSimnet("tests/fixtures/Clarinet.toml", true, {
+      trackCoverage: true,
+      trackCosts: false,
+    });
+    simnet.runSnippet("(contract-call? .counter increment)");
+    simnet.runSnippet("(contract-call? .counter increment)");
+
+    const reports = simnet.collectReport(false, "");
+    // line 26, within the increment function, is executed twice
+    expect(reports.coverage).toContain("DA:26,2");
+  });
+});

--- a/components/clarinet-sdk/node/tests/reports.test.ts
+++ b/components/clarinet-sdk/node/tests/reports.test.ts
@@ -43,6 +43,7 @@ describe("simnet can get code coverage", () => {
       trackCosts: false,
     });
 
+    simnet.setCurrentTestName("test1");
     simnet.callPublicFn("counter", "increment", [], address1);
     simnet.callPublicFn("counter", "increment", [], address1);
     simnet.callPrivateFn("counter", "inner-increment", [], address1);
@@ -53,7 +54,6 @@ describe("simnet can get code coverage", () => {
     expect(reports.coverage.includes("FNDA:2,increment")).toBe(true);
     // inner-increment is called one time directly and twice by `increment`
     expect(reports.coverage.includes("FNDA:3,inner-increment")).toBe(true);
-
     expect(reports.coverage.startsWith("TN:")).toBe(true);
     expect(reports.coverage.endsWith("end_of_record\n")).toBe(true);
   });

--- a/components/clarinet-sdk/node/tests/reports.test.ts
+++ b/components/clarinet-sdk/node/tests/reports.test.ts
@@ -108,7 +108,7 @@ describe("simnet can report both costs and coverage", () => {
   });
 });
 
-describe.only("run-snippet and execute also report coverage", () => {
+describe("simnet.run-snippet and .execute also report coverage", () => {
   it("simnet.execute reports coverage", async () => {
     const simnet = await initSimnet("tests/fixtures/Clarinet.toml", true, {
       trackCoverage: true,

--- a/components/clarinet-sdk/node/tests/reports.test.ts
+++ b/components/clarinet-sdk/node/tests/reports.test.ts
@@ -37,7 +37,7 @@ describe("simnet can get code coverage", () => {
     expect(reports.coverage.length).toBe(0);
   });
 
-  it.only("reports coverage if enabled", async () => {
+  it("reports coverage if enabled", async () => {
     const simnet = await initSimnet("tests/fixtures/Clarinet.toml", true, {
       trackCoverage: true,
       trackCosts: false,

--- a/components/clarinet-sdk/node/tests/reports.test.ts
+++ b/components/clarinet-sdk/node/tests/reports.test.ts
@@ -45,12 +45,11 @@ describe("simnet can get code coverage", () => {
 
     simnet.callPublicFn("counter", "increment", [], address1);
     simnet.callPublicFn("counter", "increment", [], address1);
-    // simnet.callPrivateFn("counter", "inner-increment", [], address1);
+    simnet.callPrivateFn("counter", "inner-increment", [], address1);
 
     const reports = simnet.collectReport(false, "");
 
     // increment is called twice
-    console.log("reports.coverage", reports.coverage);
     expect(reports.coverage.includes("FNDA:2,increment")).toBe(true);
     // inner-increment is called one time directly and twice by `increment`
     expect(reports.coverage.includes("FNDA:3,inner-increment")).toBe(true);
@@ -86,7 +85,6 @@ describe("simnet can get costs reports", () => {
     expect(parsedReports).toHaveLength(1);
 
     const report = parsedReports[0];
-    console.log("report", report);
     expect(report.contract_id).toBe(`${simnet.deployer}.counter`);
     expect(report.method).toBe("increment");
     expect(report.cost_result.total.write_count).toBe(3);

--- a/components/clarinet-sdk/node/tests/reports.test.ts
+++ b/components/clarinet-sdk/node/tests/reports.test.ts
@@ -37,7 +37,7 @@ describe("simnet can get code coverage", () => {
     expect(reports.coverage.length).toBe(0);
   });
 
-  it("reports coverage if enabled", async () => {
+  it.only("reports coverage if enabled", async () => {
     const simnet = await initSimnet("tests/fixtures/Clarinet.toml", true, {
       trackCoverage: true,
       trackCosts: false,
@@ -45,11 +45,12 @@ describe("simnet can get code coverage", () => {
 
     simnet.callPublicFn("counter", "increment", [], address1);
     simnet.callPublicFn("counter", "increment", [], address1);
-    simnet.callPrivateFn("counter", "inner-increment", [], address1);
+    // simnet.callPrivateFn("counter", "inner-increment", [], address1);
 
     const reports = simnet.collectReport(false, "");
 
     // increment is called twice
+    console.log("reports.coverage", reports.coverage);
     expect(reports.coverage.includes("FNDA:2,increment")).toBe(true);
     // inner-increment is called one time directly and twice by `increment`
     expect(reports.coverage.includes("FNDA:3,inner-increment")).toBe(true);
@@ -85,6 +86,7 @@ describe("simnet can get costs reports", () => {
     expect(parsedReports).toHaveLength(1);
 
     const report = parsedReports[0];
+    console.log("report", report);
     expect(report.contract_id).toBe(`${simnet.deployer}.counter`);
     expect(report.method).toBe("increment");
     expect(report.cost_result.total.write_count).toBe(3);

--- a/components/clarity-lsp/src/common/state.rs
+++ b/components/clarity-lsp/src/common/state.rs
@@ -654,7 +654,6 @@ pub async fn build_state(
         &mut session,
         &deployment,
         Some(&artifacts.asts),
-        false,
         Some(StacksEpochId::Epoch21),
     );
     for (contract_id, mut result) in contracts.into_iter() {

--- a/components/clarity-repl/src/analysis/coverage.rs
+++ b/components/clarity-repl/src/analysis/coverage.rs
@@ -23,9 +23,21 @@ pub struct CoverageReport {
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct CoverageHook {
     pub reports: Vec<CoverageReport>,
-    pub current_test_name: Option<String>,
-    pub contracts_coverage: HashMap<QualifiedContractIdentifier, ExprCoverage>,
+    current_test_name: Option<String>,
+    contracts_coverage: HashMap<QualifiedContractIdentifier, ExprCoverage>,
 }
+
+// LCOV format:
+// TN: test name
+// SF: source file path
+// FN: line number,function name
+// FNDA: execution count, function name
+// FNF: number functions found
+// FNH: number functions hit
+// DA: line data: line number, hit count
+// BRF: number branches found
+// BRH: number branches hit
+// BRDA: branch data: line number, expr_id, branch_nb, hit count
 
 impl CoverageHook {
     pub fn new() -> Self {
@@ -34,6 +46,192 @@ impl CoverageHook {
             current_test_name: None,
             contracts_coverage: HashMap::new(),
         }
+    }
+
+    pub fn set_current_test_name(&mut self, test_name: String) {
+        self.current_test_name = Some(test_name);
+    }
+
+    fn clear(&mut self) {
+        self.current_test_name = None;
+        self.contracts_coverage.clear();
+        self.reports.clear();
+    }
+
+    pub fn collect_lcov_content(
+        &mut self,
+        asts: &BTreeMap<QualifiedContractIdentifier, ContractAST>,
+        contract_paths: &BTreeMap<String, String>,
+    ) -> String {
+        let mut file_content = String::new();
+
+        let mut filtered_asts = HashMap::new();
+        for (contract_id, ast) in asts.iter() {
+            let contract_name = contract_id.name.to_string();
+            if contract_paths.contains_key(&contract_name) {
+                filtered_asts.insert(
+                    contract_name,
+                    (
+                        contract_id,
+                        retrieve_functions(&ast.expressions),
+                        retrieve_executable_lines_and_branches(&ast.expressions),
+                    ),
+                );
+            }
+        }
+
+        // for consistency in the result, we use a btreemap instead of a hashmap
+        let reports_per_tests: BTreeMap<&String, Vec<&CoverageReport>> =
+            self.reports
+                .iter()
+                .fold(BTreeMap::new(), |mut acc, report| {
+                    acc.entry(&report.test_name).or_default().push(report);
+                    acc
+                });
+
+        for (test_name, test_reports) in reports_per_tests.iter() {
+            file_content.push_str(&format!("TN:{}\n", **test_name));
+            for (contract_name, contract_path) in contract_paths.iter() {
+                file_content.push_str(&format!("SF:{}\n", contract_path));
+
+                if let Some((contract_id, functions, executable)) = filtered_asts.get(contract_name)
+                {
+                    for (function, line_start, _) in functions.iter() {
+                        file_content.push_str(&format!("FN:{},{}\n", line_start, function));
+                    }
+                    let (executable_lines, executables_branches) = executable;
+
+                    let mut function_hits = BTreeMap::new();
+                    let mut line_execution_counts = BTreeMap::new();
+
+                    let mut branches = HashSet::new();
+                    let mut branches_hits = HashSet::new();
+                    let mut branch_execution_counts = BTreeMap::new();
+
+                    for report in test_reports {
+                        if let Some(coverage) = report.coverage.get(contract_id) {
+                            let mut local_function_hits = BTreeSet::new();
+
+                            for (line, expr_ids) in executable_lines.iter() {
+                                // in case of code branches on the line
+                                // retrieve the expression with the most hits
+                                let mut counts = vec![];
+                                for id in expr_ids {
+                                    if let Some(c) = coverage.get(id) {
+                                        counts.push(*c);
+                                    }
+                                }
+                                let count = counts.iter().max().unwrap_or(&0);
+
+                                let total_count = line_execution_counts.entry(line).or_insert(0);
+                                *total_count += count;
+
+                                if count == &0 {
+                                    continue;
+                                }
+
+                                for (function, line_start, line_end) in functions.iter() {
+                                    if line >= line_start && line <= line_end {
+                                        local_function_hits.insert(function);
+                                        // functions hits must have a matching line hit
+                                        // if we hit a line inside a function, make sure to count one line hit
+                                        if line > line_start {
+                                            let hit_count = line_execution_counts.get(&line_start);
+                                            if hit_count.is_none() || hit_count == Some(&0) {
+                                                line_execution_counts.insert(line_start, 1);
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+
+                            for (expr_id, args) in executables_branches.iter() {
+                                for (i, (line, arg_expr_id)) in args.iter().enumerate() {
+                                    let count = coverage.get(arg_expr_id).unwrap_or(&0);
+
+                                    branches.insert(arg_expr_id);
+                                    if count > &0 {
+                                        branches_hits.insert(arg_expr_id);
+                                    }
+
+                                    let total_count = branch_execution_counts
+                                        .entry((line, expr_id, i))
+                                        .or_insert(0);
+                                    *total_count += count;
+                                }
+                            }
+
+                            for function in local_function_hits.into_iter() {
+                                let hits = function_hits.entry(function).or_insert(0);
+                                *hits += 1
+                            }
+                        }
+                    }
+
+                    for (function, hits) in function_hits.iter() {
+                        file_content.push_str(&format!("FNDA:{},{}\n", hits, function));
+                    }
+                    file_content.push_str(&format!("FNF:{}\n", functions.len()));
+                    file_content.push_str(&format!("FNH:{}\n", function_hits.len()));
+
+                    for (line, count) in line_execution_counts.iter() {
+                        // the ast can contain elements with a span starting at line 0 that we want to ignore
+                        if line > &&0 {
+                            file_content.push_str(&format!("DA:{},{}\n", line, count));
+                        }
+                    }
+
+                    file_content.push_str(&format!("BRF:{}\n", branches.len()));
+                    file_content.push_str(&format!("BRH:{}\n", branches_hits.len()));
+
+                    for ((line, block_id, branch_nb), count) in branch_execution_counts.iter() {
+                        // the ast can contain elements with a span starting at line 0 that we want to ignore
+                        if line > &&0 {
+                            file_content.push_str(&format!(
+                                "BRDA:{},{},{},{}\n",
+                                line, block_id, branch_nb, count
+                            ));
+                        }
+                    }
+                }
+                file_content.push_str("end_of_record\n");
+            }
+        }
+
+        self.clear();
+
+        file_content
+    }
+}
+
+impl EvalHook for CoverageHook {
+    fn will_begin_eval(
+        &mut self,
+        env: &mut clarity::vm::Environment,
+        _context: &clarity::vm::LocalContext,
+        expr: &SymbolicExpression,
+    ) {
+        let contract = &env.contract_context.contract_identifier;
+        let mut contract_report = self.contracts_coverage.remove(contract).unwrap_or_default();
+        report_eval(&mut contract_report, expr);
+        self.contracts_coverage
+            .insert(contract.clone(), contract_report);
+    }
+
+    fn did_finish_eval(
+        &mut self,
+        _env: &mut clarity::vm::Environment,
+        _context: &clarity::vm::LocalContext,
+        _expr: &SymbolicExpression,
+        _res: &Result<clarity::vm::Value, clarity::vm::errors::Error>,
+    ) {
+    }
+
+    fn did_complete(&mut self, _result: Result<&mut clarity::vm::ExecutionResult, String>) {
+        self.reports.push(CoverageReport {
+            test_name: self.current_test_name.clone().unwrap_or_default(),
+            coverage: self.contracts_coverage.drain().collect(),
+        });
     }
 }
 
@@ -159,191 +357,6 @@ fn retrieve_executable_lines_and_branches(
     }
     (lines, branches)
 }
-
-impl EvalHook for CoverageHook {
-    fn will_begin_eval(
-        &mut self,
-        env: &mut clarity::vm::Environment,
-        _context: &clarity::vm::LocalContext,
-        expr: &SymbolicExpression,
-    ) {
-        let contract = &env.contract_context.contract_identifier;
-        let mut contract_report = self.contracts_coverage.remove(contract).unwrap_or_default();
-        report_eval(&mut contract_report, expr);
-        self.contracts_coverage
-            .insert(contract.clone(), contract_report);
-    }
-
-    fn did_finish_eval(
-        &mut self,
-        _env: &mut clarity::vm::Environment,
-        _context: &clarity::vm::LocalContext,
-        _expr: &SymbolicExpression,
-        _res: &Result<clarity::vm::Value, clarity::vm::errors::Error>,
-    ) {
-    }
-
-    fn did_complete(&mut self, _result: Result<&mut clarity::vm::ExecutionResult, String>) {
-        self.reports.push(CoverageReport {
-            test_name: self.current_test_name.clone().unwrap_or_default(),
-            coverage: std::mem::take(&mut self.contracts_coverage),
-        });
-    }
-}
-
-// LCOV format:
-
-// TN: test name
-// SF: source file path
-// FN: line number,function name
-// FNDA: execution count, function name
-// FNF: number functions found
-// FNH: number functions hit
-// DA: line data: line number, hit count
-// BRF: number branches found
-// BRH: number branches hit
-// BRDA: branch data: line number, expr_id, branch_nb, hit count
-
-pub fn build_lcov_content(
-    reports: &[CoverageReport],
-    asts: &BTreeMap<QualifiedContractIdentifier, ContractAST>,
-    contract_paths: &BTreeMap<String, String>,
-) -> String {
-    let mut file_content = String::new();
-
-    let mut filtered_asts = HashMap::new();
-    for (contract_id, ast) in asts.iter() {
-        let contract_name = contract_id.name.to_string();
-        if contract_paths.contains_key(&contract_name) {
-            filtered_asts.insert(
-                contract_name,
-                (
-                    contract_id,
-                    retrieve_functions(&ast.expressions),
-                    retrieve_executable_lines_and_branches(&ast.expressions),
-                ),
-            );
-        }
-    }
-
-    // for consistency in the result, we use a btreemap instead of a hashmap
-    let reports_per_tests: BTreeMap<&String, Vec<&CoverageReport>> =
-        reports.iter().fold(BTreeMap::new(), |mut acc, report| {
-            acc.entry(&report.test_name).or_default().push(report);
-            acc
-        });
-
-    for (test_name, test_reports) in reports_per_tests.iter() {
-        for (contract_name, contract_path) in contract_paths.iter() {
-            file_content.push_str(&format!("TN:{}\n", test_name));
-            file_content.push_str(&format!("SF:{}\n", contract_path));
-
-            if let Some((contract_id, functions, executable)) = filtered_asts.get(contract_name) {
-                for (function, line_start, _) in functions.iter() {
-                    file_content.push_str(&format!("FN:{},{}\n", line_start, function));
-                }
-                let (executable_lines, executables_branches) = executable;
-
-                let mut function_hits = BTreeMap::new();
-                let mut line_execution_counts = BTreeMap::new();
-
-                let mut branches = HashSet::new();
-                let mut branches_hits = HashSet::new();
-                let mut branch_execution_counts = BTreeMap::new();
-
-                for report in test_reports {
-                    if let Some(coverage) = report.coverage.get(contract_id) {
-                        let mut local_function_hits = BTreeSet::new();
-
-                        for (line, expr_ids) in executable_lines.iter() {
-                            // in case of code branches on the line
-                            // retrieve the expression with the most hits
-                            let mut counts = vec![];
-                            for id in expr_ids {
-                                if let Some(c) = coverage.get(id) {
-                                    counts.push(*c);
-                                }
-                            }
-                            let count = counts.iter().max().unwrap_or(&0);
-
-                            let total_count = line_execution_counts.entry(line).or_insert(0);
-                            *total_count += count;
-
-                            if count == &0 {
-                                continue;
-                            }
-
-                            for (function, line_start, line_end) in functions.iter() {
-                                if line >= line_start && line <= line_end {
-                                    local_function_hits.insert(function);
-                                    // functions hits must have a matching line hit
-                                    // if we hit a line inside a function, make sure to count one line hit
-                                    if line > line_start {
-                                        let hit_count = line_execution_counts.get(&line_start);
-                                        if hit_count.is_none() || hit_count == Some(&0) {
-                                            line_execution_counts.insert(line_start, 1);
-                                        }
-                                    }
-                                }
-                            }
-                        }
-
-                        for (expr_id, args) in executables_branches.iter() {
-                            for (i, (line, arg_expr_id)) in args.iter().enumerate() {
-                                let count = coverage.get(arg_expr_id).unwrap_or(&0);
-
-                                branches.insert(arg_expr_id);
-                                if count > &0 {
-                                    branches_hits.insert(arg_expr_id);
-                                }
-
-                                let total_count = branch_execution_counts
-                                    .entry((line, expr_id, i))
-                                    .or_insert(0);
-                                *total_count += count;
-                            }
-                        }
-
-                        for function in local_function_hits.into_iter() {
-                            let hits = function_hits.entry(function).or_insert(0);
-                            *hits += 1
-                        }
-                    }
-                }
-
-                for (function, hits) in function_hits.iter() {
-                    file_content.push_str(&format!("FNDA:{},{}\n", hits, function));
-                }
-                file_content.push_str(&format!("FNF:{}\n", functions.len()));
-                file_content.push_str(&format!("FNH:{}\n", function_hits.len()));
-
-                for (line, count) in line_execution_counts.iter() {
-                    // the ast can contain elements with a span starting at line 0 that we want to ignore
-                    if line > &&0 {
-                        file_content.push_str(&format!("DA:{},{}\n", line, count));
-                    }
-                }
-
-                file_content.push_str(&format!("BRF:{}\n", branches.len()));
-                file_content.push_str(&format!("BRH:{}\n", branches_hits.len()));
-
-                for ((line, block_id, branch_nb), count) in branch_execution_counts.iter() {
-                    // the ast can contain elements with a span starting at line 0 that we want to ignore
-                    if line > &&0 {
-                        file_content.push_str(&format!(
-                            "BRDA:{},{},{},{}\n",
-                            line, block_id, branch_nb, count
-                        ));
-                    }
-                }
-            }
-            file_content.push_str("end_of_record\n");
-        }
-    }
-
-    file_content
-}
-// }
 
 fn try_parse_native_func(
     expr: &[SymbolicExpression],

--- a/components/clarity-repl/src/analysis/coverage_tests.rs
+++ b/components/clarity-repl/src/analysis/coverage_tests.rs
@@ -1,14 +1,15 @@
 use std::collections::BTreeMap;
 
-use super::coverage::{build_lcov_content, CoverageHook};
+use super::coverage::CoverageHook;
 use crate::repl::session::Session;
 use crate::repl::SessionSettings;
 
-fn get_coverage_report(contract: &str, snippets: Vec<String>, test_name: Option<String>) -> String {
+fn get_coverage_report(contract: &str, snippets: Vec<String>) -> String {
     let mut session = Session::new(SessionSettings::default());
 
     let mut coverage_hook = CoverageHook::new();
-    coverage_hook.current_test_name = Some(test_name.unwrap_or("test_scenario".to_string()));
+    coverage_hook.set_current_test_name("test_scenario".to_string());
+
     let _ = session.eval(contract.into(), Some(vec![&mut coverage_hook]), false);
     for snippet in snippets {
         let _ = session.eval(snippet, Some(vec![&mut coverage_hook]), false);
@@ -20,7 +21,7 @@ fn get_coverage_report(contract: &str, snippets: Vec<String>, test_name: Option<
     let asts = BTreeMap::from([(contract_id.clone(), ast.clone())]);
     let paths = BTreeMap::from([(contract_id.name.to_string(), "/contract-0.clar".into())]);
 
-    build_lcov_content(&coverage_hook.reports, &asts, &paths)
+    coverage_hook.collect_lcov_content(&asts, &paths)
 }
 
 fn get_expected_report(body: String) -> String {
@@ -31,7 +32,7 @@ fn get_expected_report(body: String) -> String {
 fn line_is_executed() {
     let contract = "(define-read-only (add) (+ 1 2))";
     let snippet = "(contract-call? .contract-0 add)";
-    let cov = get_coverage_report(contract, vec![snippet.into()], None);
+    let cov = get_coverage_report(contract, vec![snippet.into()]);
 
     let expect = get_expected_report(
         [
@@ -53,7 +54,7 @@ fn line_is_executed_twice() {
     let contract = "(define-read-only (add) (+ 1 2))";
     // call it twice
     let snippet = "(contract-call? .contract-0 add) (contract-call? .contract-0 add)";
-    let cov = get_coverage_report(contract, vec![snippet.into()], None);
+    let cov = get_coverage_report(contract, vec![snippet.into()]);
 
     let expect = get_expected_report(
         [
@@ -80,7 +81,7 @@ fn line_count_in_iterator() {
     ]
     .join("\n");
     let snippet = "(contract-call? .contract-0 map-add-1)";
-    let cov = get_coverage_report(contract.as_str(), vec![snippet.into()], None);
+    let cov = get_coverage_report(contract.as_str(), vec![snippet.into()]);
 
     let expect = get_expected_report(
         [
@@ -107,7 +108,7 @@ fn function_hit_should_have_line_hit() {
     let contract = ["(define-read-only (t)", "  true", ")"].join("\n");
 
     let snippet = "(contract-call? .contract-0 t)";
-    let cov = get_coverage_report(contract.as_str(), vec![snippet.into()], None);
+    let cov = get_coverage_report(contract.as_str(), vec![snippet.into()]);
 
     let expect = get_expected_report(
         [
@@ -131,7 +132,7 @@ fn multiple_line_execution() {
     .join("\n");
 
     let snippet = "(contract-call? .contract-0 add)";
-    let cov = get_coverage_report(contract.as_str(), vec![snippet.into()], None);
+    let cov = get_coverage_report(contract.as_str(), vec![snippet.into()]);
 
     let expect = get_expected_report(
         [
@@ -165,7 +166,7 @@ fn let_binding() {
     .join("\n");
 
     let snippet = "(contract-call? .contract-0 add-print)";
-    let cov = get_coverage_report(contract.as_str(), vec![snippet.into()], None);
+    let cov = get_coverage_report(contract.as_str(), vec![snippet.into()]);
 
     let expect = get_expected_report(
         [
@@ -207,7 +208,7 @@ fn simple_if_branching() {
 
     // left path
     let snippet = "(contract-call? .contract-0 one-or-two true)";
-    let cov = get_coverage_report(contract.as_str(), vec![snippet.into()], None);
+    let cov = get_coverage_report(contract.as_str(), vec![snippet.into()]);
 
     let expect = get_expected_report(
         [&expect_base[..], &["BRDA:2,8,0,1", "BRDA:2,8,1,0"]]
@@ -218,7 +219,7 @@ fn simple_if_branching() {
 
     // right path
     let snippet = "(contract-call? .contract-0 one-or-two false)";
-    let cov = get_coverage_report(contract.as_str(), vec![snippet.into()], None);
+    let cov = get_coverage_report(contract.as_str(), vec![snippet.into()]);
 
     let expect = get_expected_report(
         [&expect_base[..], &["BRDA:2,8,0,0", "BRDA:2,8,1,1"]]
@@ -237,7 +238,7 @@ fn simple_if_branches_with_exprs() {
     ]
     .join("\n");
     let snippet = "(contract-call? .contract-0 add-or-sub true)";
-    let cov = get_coverage_report(contract.as_str(), vec![snippet.into()], None);
+    let cov = get_coverage_report(contract.as_str(), vec![snippet.into()]);
 
     let expect = get_expected_report(
         [
@@ -274,7 +275,7 @@ fn hit_all_if_branches() {
         "(contract-call? .contract-0 add-or-sub false)".into(),
         "(contract-call? .contract-0 add-or-sub false)".into(),
     ];
-    let cov = get_coverage_report(&contract, snippets, None);
+    let cov = get_coverage_report(&contract, snippets);
 
     let expect = get_expected_report(
         [
@@ -305,7 +306,7 @@ fn simple_asserts_branching() {
 
     // no hit on (err u1)
     let snippets: Vec<String> = vec!["(contract-call? .contract-0 is-one 1)".into()];
-    let cov = get_coverage_report(&contract, snippets, None);
+    let cov = get_coverage_report(&contract, snippets);
 
     let expect = get_expected_report(
         [
@@ -325,7 +326,7 @@ fn simple_asserts_branching() {
 
     // hit on (err u1)
     let snippets: Vec<String> = vec!["(contract-call? .contract-0 is-one 2)".into()];
-    let cov = get_coverage_report(&contract, snippets, None);
+    let cov = get_coverage_report(&contract, snippets);
 
     let expect = get_expected_report(
         [
@@ -357,7 +358,7 @@ fn branch_if_plus_and() {
     .join("\n");
     // calling with `2`, so that evualuation should stop at (> v 2) (which is false)
     let snippet = "(contract-call? .contract-0 unecessary-ifs 2)";
-    let cov = get_coverage_report(contract.as_str(), vec![snippet.into()], None);
+    let cov = get_coverage_report(contract.as_str(), vec![snippet.into()]);
 
     let expect = get_expected_report(
         vec![
@@ -396,7 +397,7 @@ fn branch_if_plus_or() {
     .join("\n");
     // calling with 1, so that evualuation should stop at (is-eq v 1)
     let snippet = "(contract-call? .contract-0 unecessary-ors 1)";
-    let cov = get_coverage_report(contract.as_str(), vec![snippet.into()], None);
+    let cov = get_coverage_report(contract.as_str(), vec![snippet.into()]);
 
     let expect = get_expected_report(
         vec![
@@ -444,7 +445,7 @@ fn match_opt_oneline() {
 
     // left path
     let snippets: Vec<String> = vec!["(contract-call? .contract-0 match-opt (some 1))".into()];
-    let cov = get_coverage_report(&contract, snippets, None);
+    let cov = get_coverage_report(&contract, snippets);
 
     let expect = get_expected_report(
         [&expect_base[..], &["BRDA:2,10,0,1", "BRDA:2,10,1,0"]]
@@ -455,7 +456,7 @@ fn match_opt_oneline() {
 
     // right path
     let snippets: Vec<String> = vec!["(contract-call? .contract-0 match-opt none)".into()];
-    let cov = get_coverage_report(&contract, snippets, None);
+    let cov = get_coverage_report(&contract, snippets);
 
     let expect = get_expected_report(
         [&expect_base[..], &["BRDA:2,10,0,0", "BRDA:2,10,1,1"]]
@@ -489,7 +490,7 @@ fn match_opt_multiline() {
 
     // left path
     let snippets: Vec<String> = vec!["(contract-call? .contract-0 match-opt (some 1))".into()];
-    let cov = get_coverage_report(&contract, snippets, None);
+    let cov = get_coverage_report(&contract, snippets);
 
     let expect = get_expected_report(
         [
@@ -510,7 +511,7 @@ fn match_opt_multiline() {
 
     // right path
     let snippets: Vec<String> = vec!["(contract-call? .contract-0 match-opt none)".into()];
-    let cov = get_coverage_report(&contract, snippets, None);
+    let cov = get_coverage_report(&contract, snippets);
 
     let expect = get_expected_report(
         [
@@ -547,7 +548,7 @@ fn match_res_oneline() {
         "(contract-call? .contract-0 match-res (ok 2))".into(),
         "(contract-call? .contract-0 match-res (err u1))".into(),
     ];
-    let cov = get_coverage_report(&contract, snippets, None);
+    let cov = get_coverage_report(&contract, snippets);
 
     let expect = get_expected_report(
         [
@@ -585,7 +586,7 @@ fn fold_iterator() {
     .join("\n");
 
     let snippets: Vec<String> = vec!["(contract-call? .contract-0 sum)".into()];
-    let cov = get_coverage_report(&contract, snippets, None);
+    let cov = get_coverage_report(&contract, snippets);
 
     let expect = get_expected_report(
         vec![
@@ -624,7 +625,7 @@ fn map_iterator() {
     .join("\n");
 
     let snippets: Vec<String> = vec!["(contract-call? .contract-0 square (list 1 2 3))".into()];
-    let cov = get_coverage_report(&contract, snippets, None);
+    let cov = get_coverage_report(&contract, snippets);
 
     let expect = get_expected_report(
         [
@@ -662,7 +663,7 @@ fn filter_iterator() {
 
     let snippets: Vec<String> =
         vec!["(contract-call? .contract-0 get-positive (list -1 2 3))".into()];
-    let cov = get_coverage_report(&contract, snippets, None);
+    let cov = get_coverage_report(&contract, snippets);
 
     let expect = get_expected_report(
         [
@@ -689,40 +690,42 @@ fn filter_iterator() {
 fn multiple_test_files() {
     let mut session = Session::new(SessionSettings::default());
 
-    let mut reports = vec![];
-
     let contract = "(define-read-only (add) (+ 1 2))";
+
+    // insert 2 contracts
+    // contract-0
+    let _ = session.eval(contract.into(), None, false);
+    // contract-1
     let _ = session.eval(contract.into(), None, false);
 
     let mut coverage_hook = CoverageHook::new();
-    coverage_hook.current_test_name = Some("a_test".to_string());
+
+    // call contract-0 twice in test-1
+    coverage_hook.set_current_test_name("test-1".to_string());
     let snippet = "(contract-call? .contract-0 add)";
     let _ = session.eval(snippet.to_owned(), Some(vec![&mut coverage_hook]), false);
-    reports.append(coverage_hook.reports.as_mut());
-
-    let mut coverage_hook = CoverageHook::new();
-    coverage_hook.current_test_name = Some("a_test".to_string());
     let snippet = "(contract-call? .contract-0 add)";
     let _ = session.eval(snippet.to_owned(), Some(vec![&mut coverage_hook]), false);
-    reports.append(coverage_hook.reports.as_mut());
 
-    let mut coverage_hook = CoverageHook::new();
-    coverage_hook.current_test_name = Some("b_test".to_string());
+    // call contract-0 once and contract-1 once in test-2
+    coverage_hook.set_current_test_name("test-2".to_string());
     let snippet = "(contract-call? .contract-0 add)";
     let _ = session.eval(snippet.to_owned(), Some(vec![&mut coverage_hook]), false);
-    reports.append(coverage_hook.reports.as_mut());
+    let snippet = "(contract-call? .contract-1 add)";
+    let _ = session.eval(snippet.to_owned(), Some(vec![&mut coverage_hook]), false);
 
-    let (contract_id, contract) = session.contracts.pop_first().unwrap();
-    let ast = contract.ast;
+    let mut asts = BTreeMap::new();
+    let mut paths = BTreeMap::new();
+    for (i, (contract_id, contract)) in session.contracts.iter().enumerate() {
+        asts.insert(contract_id.clone(), contract.ast.clone());
+        paths.insert(contract_id.name.to_string(), format!("/contract-{i}.clar"));
+    }
 
-    let asts = BTreeMap::from([(contract_id.clone(), ast.clone())]);
-    let paths = BTreeMap::from([(contract_id.name.to_string(), "/contract-0.clar".into())]);
-
-    let cov = build_lcov_content(&reports, &asts, &paths);
+    let cov = coverage_hook.collect_lcov_content(&asts, &paths);
 
     assert_eq!(
         [
-            "TN:a_test",
+            "TN:test-1",
             "SF:/contract-0.clar",
             "FN:1,add",
             "FNDA:2,add",
@@ -732,7 +735,14 @@ fn multiple_test_files() {
             "BRF:0",
             "BRH:0",
             "end_of_record",
-            "TN:b_test",
+            "SF:/contract-1.clar",
+            "FN:1,add",
+            "FNF:1",
+            "FNH:0",
+            "BRF:0",
+            "BRH:0",
+            "end_of_record",
+            "TN:test-2",
             "SF:/contract-0.clar",
             "FN:1,add",
             "FNDA:1,add",
@@ -742,7 +752,16 @@ fn multiple_test_files() {
             "BRF:0",
             "BRH:0",
             "end_of_record",
-            "",
+            "SF:/contract-1.clar",
+            "FN:1,add",
+            "FNDA:1,add",
+            "FNF:1",
+            "FNH:1",
+            "DA:1,1",
+            "BRF:0",
+            "BRH:0",
+            "end_of_record",
+            ""
         ]
         .join("\n"),
         cov

--- a/components/clarity-repl/src/analysis/mod.rs
+++ b/components/clarity-repl/src/analysis/mod.rs
@@ -154,9 +154,8 @@ where
     F: FnOnce(&mut AnalysisDatabase) -> std::result::Result<T, E>,
 {
     conn.begin();
-    let result = f(conn).map_err(|e| {
+    let result = f(conn).inspect_err(|_| {
         conn.roll_back().expect("Failed to roll back");
-        e
     })?;
     conn.commit().expect("Failed to commit");
     Ok(result)

--- a/components/clarity-repl/src/repl/interpreter.rs
+++ b/components/clarity-repl/src/repl/interpreter.rs
@@ -832,7 +832,7 @@ impl ClarityInterpreter {
         clarity_version: ClarityVersion,
         track_costs: bool,
         allow_private: bool,
-        eval_hooks: Option<Vec<&mut dyn EvalHook>>,
+        mut eval_hooks: Vec<&mut dyn EvalHook>,
     ) -> Result<ExecutionResult, String> {
         let mut conn = ClarityDatabase::new(
             &mut self.clarity_datastore,
@@ -860,11 +860,11 @@ impl ClarityInterpreter {
         let mut global_context =
             GlobalContext::new(false, CHAIN_ID_TESTNET, conn, cost_tracker, epoch);
 
-        if let Some(mut in_hooks) = eval_hooks {
-            let mut hooks: Vec<&mut dyn EvalHook> = Vec::new();
-            for hook in in_hooks.drain(..) {
-                hooks.push(hook);
-            }
+        let mut hooks: Vec<&mut dyn EvalHook> = Vec::new();
+        for hook in eval_hooks.drain(..) {
+            hooks.push(hook);
+        }
+        if !hooks.is_empty() {
             global_context.eval_hooks = Some(hooks);
         }
 
@@ -1807,7 +1807,7 @@ mod tests {
             ClarityVersion::Clarity2,
             false,
             false,
-            None,
+            vec![],
         );
         assert_execution_result_value(
             result,
@@ -1826,7 +1826,7 @@ mod tests {
             ClarityVersion::Clarity2,
             false,
             false,
-            None,
+            vec![],
         );
         assert_execution_result_value(
             result,
@@ -1879,7 +1879,7 @@ mod tests {
             ClarityVersion::Clarity2,
             false,
             false,
-            None,
+            vec![],
         );
         assert_execution_result_value(
             result,
@@ -1941,7 +1941,7 @@ mod tests {
             ClarityVersion::Clarity3,
             false,
             false,
-            None,
+            vec![],
         );
         assert_execution_result_value(
             result,
@@ -1964,7 +1964,7 @@ mod tests {
             ClarityVersion::Clarity3,
             false,
             false,
-            None,
+            vec![],
         );
         assert_execution_result_value(
             result,
@@ -2153,7 +2153,7 @@ mod tests {
             ClarityVersion::Clarity2,
             false,
             allow_private,
-            None,
+            vec![],
         );
 
         assert!(result.is_ok());
@@ -2184,7 +2184,7 @@ mod tests {
             ClarityVersion::Clarity2,
             false,
             allow_private,
-            None,
+            vec![],
         );
 
         assert!(result.is_ok());
@@ -2215,7 +2215,7 @@ mod tests {
             ClarityVersion::Clarity2,
             false,
             allow_private,
-            None,
+            vec![],
         );
 
         assert!(result.is_err());

--- a/components/clarity-repl/src/repl/session.rs
+++ b/components/clarity-repl/src/repl/session.rs
@@ -183,7 +183,7 @@ impl Session {
                 };
 
                 // Result ignored, boot contracts are trusted to be valid
-                let _ = self.deploy_contract(&contract, None, false, None, None);
+                let _ = self.deploy_contract(&contract, None, false, None);
             }
         }
     }
@@ -528,7 +528,6 @@ impl Session {
         contract: &ClarityContract,
         eval_hooks: Option<Vec<&mut dyn EvalHook>>,
         cost_track: bool,
-        test_name: Option<String>,
         ast: Option<&ContractAST>,
     ) -> Result<ExecutionResult, Vec<Diagnostic>> {
         if contract.epoch != self.current_epoch {
@@ -556,32 +555,17 @@ impl Session {
             };
             return Err(vec![diagnostic]);
         }
-        let mut hooks: Vec<&mut dyn EvalHook> = Vec::new();
-        let mut coverage = test_name.map(TestCoverageReport::new);
-        if let Some(coverage) = &mut coverage {
-            hooks.push(coverage);
-        };
-
-        if let Some(mut in_hooks) = eval_hooks {
-            for hook in in_hooks.drain(..) {
-                hooks.push(hook);
-            }
-        }
 
         let contract_id =
             contract.expect_resolved_contract_identifier(Some(&self.interpreter.get_tx_sender()));
 
-        let result = self.interpreter.run(contract, ast, cost_track, Some(hooks));
+        let result = self.interpreter.run(contract, ast, cost_track, eval_hooks);
 
-        result.map(|result| {
+        result.inspect(|result| {
             if let EvaluationResult::Contract(contract_result) = &result.result {
                 self.contracts
                     .insert(contract_id.clone(), contract_result.contract.clone());
             }
-            if let Some(coverage) = coverage {
-                self.coverage_reports.push(coverage);
-            }
-            result
         })
     }
 
@@ -593,36 +577,28 @@ impl Session {
         sender: &str,
         allow_private: bool,
         track_costs: bool,
-        track_coverage: bool,
+        eval_hooks: Vec<&mut dyn EvalHook>,
         test_name: String,
     ) -> Result<ExecutionResult, Vec<Diagnostic>> {
         let initial_tx_sender = self.get_tx_sender();
+
         // Handle fully qualified contract_id and sugared syntax
         let contract_id_str = if contract.starts_with('S') {
             contract.to_string()
         } else {
             format!("{}.{}", initial_tx_sender, contract)
         };
-        let contract_id = QualifiedContractIdentifier::parse(&contract_id_str).unwrap();
-
-        let mut hooks: Vec<&mut dyn EvalHook> = vec![];
-        let mut coverage = TestCoverageReport::new(test_name.clone());
-        if track_coverage {
-            hooks.push(&mut coverage);
-        }
-
-        let clarity_version = ClarityVersion::default_for_epoch(self.current_epoch);
 
         self.set_tx_sender(sender);
         let execution = match self.interpreter.call_contract_fn(
-            &contract_id,
+            &QualifiedContractIdentifier::parse(&contract_id_str).unwrap(),
             method,
             args,
             self.current_epoch,
-            clarity_version,
+            ClarityVersion::default_for_epoch(self.current_epoch),
             track_costs,
             allow_private,
-            Some(hooks),
+            eval_hooks,
         ) {
             Ok(result) => result,
             Err(e) => {
@@ -636,10 +612,6 @@ impl Session {
             }
         };
         self.set_tx_sender(&initial_tx_sender);
-
-        if track_coverage {
-            self.coverage_reports.push(coverage);
-        }
 
         if let Some(ref cost) = execution.cost {
             self.costs_reports.push(CostsReport {
@@ -1543,7 +1515,7 @@ mod tests {
             epoch: StacksEpochId::Epoch2_05,
         };
 
-        let result = session.deploy_contract(&contract, None, false, None, None);
+        let result = session.deploy_contract(&contract, None, false, None);
         assert!(result.is_err(), "Expected error for clarity mismatch");
     }
 
@@ -1561,7 +1533,7 @@ mod tests {
             .clarity_version(ClarityVersion::Clarity2)
             .build();
 
-        let result = session.deploy_contract(&contract, None, false, None, None);
+        let result = session.deploy_contract(&contract, None, false, None);
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(err.len() == 1);
@@ -1601,7 +1573,7 @@ mod tests {
             epoch: StacksEpochId::Epoch25,
         };
 
-        let _ = session.deploy_contract(&contract, None, false, None, None);
+        let _ = session.deploy_contract(&contract, None, false, None);
 
         // assert data-var is set to 0
         assert_eq!(
@@ -1659,7 +1631,7 @@ mod tests {
 
         // deploy default contract
         let contract = ClarityContractBuilder::default().build();
-        let result = session.deploy_contract(&contract, None, false, None, None);
+        let result = session.deploy_contract(&contract, None, false, None);
         assert!(result.is_ok());
     }
 
@@ -1681,7 +1653,7 @@ mod tests {
             BOOT_TESTNET_ADDRESS,
             false,
             false,
-            false,
+            vec![],
             "test".to_string(),
         );
         assert_execution_result_value(
@@ -1710,7 +1682,7 @@ mod tests {
 
         // deploy default contract
         let contract = ClarityContractBuilder::default().build();
-        let _ = session.deploy_contract(&contract, None, false, None, None);
+        let _ = session.deploy_contract(&contract, None, false, None);
 
         dbg!(&contract);
 
@@ -1721,7 +1693,7 @@ mod tests {
             &session.get_tx_sender(),
             false,
             false,
-            false,
+            vec![],
             "test".to_owned(),
         );
         assert_execution_result_value(&result, Value::okay(Value::UInt(1)).unwrap());
@@ -1733,7 +1705,7 @@ mod tests {
             &session.get_tx_sender(),
             false,
             false,
-            false,
+            vec![],
             "test".to_owned(),
         );
         assert_execution_result_value(&result, Value::UInt(1));

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,20 +25,20 @@
     },
     "components/clarinet-sdk-wasm/pkg-browser": {
       "name": "@hirosystems/clarinet-sdk-wasm-browser",
-      "version": "2.9.0",
+      "version": "2.10.0-beta-1",
       "license": "GPL-3.0"
     },
     "components/clarinet-sdk-wasm/pkg-node": {
       "name": "@hirosystems/clarinet-sdk-wasm",
-      "version": "2.9.0",
+      "version": "2.10.0-beta-1",
       "license": "GPL-3.0"
     },
     "components/clarinet-sdk/browser": {
       "name": "@hirosystems/clarinet-sdk-browser",
-      "version": "2.9.0",
+      "version": "2.10.0-beta-1",
       "license": "GPL-3.0",
       "dependencies": {
-        "@hirosystems/clarinet-sdk-wasm-browser": "^2.9.0",
+        "@hirosystems/clarinet-sdk-wasm-browser": "^2.10.0-beta-1",
         "@stacks/transactions": "^6.13.0"
       }
     },
@@ -48,10 +48,10 @@
     },
     "components/clarinet-sdk/node": {
       "name": "@hirosystems/clarinet-sdk",
-      "version": "2.9.0",
+      "version": "2.10.0-beta-1",
       "license": "GPL-3.0",
       "dependencies": {
-        "@hirosystems/clarinet-sdk-wasm": "^2.9.0",
+        "@hirosystems/clarinet-sdk-wasm": "^2.10.0-beta-1",
         "@stacks/transactions": "^6.13.0",
         "kolorist": "^1.8.0",
         "prompts": "^2.4.2",


### PR DESCRIPTION
### Context

Refactoring how we handle the code coverage hook in the session, in order to make it easier to pass more hooks to the contract-calls. Should be merged before #1574 

This also fixes some of the behavior in the PR: 
- function hit count
- report coverage for `simnet.runSnippet` and `snippet.execute`


There's still room for improvement, but I think this a ready to start adding more hooks in the sdk