### PR TITLE
feat: session.eval_with_hooks

### DIFF
--- a/components/clarinet-cli/src/frontend/dap.rs
+++ b/components/clarinet-cli/src/frontend/dap.rs
@@ -41,7 +41,7 @@ pub fn run_dap() -> Result<(), String> {
             }
 
             // Begin execution of the expression in debug mode
-            match session.eval(expression.clone(), Some(vec![&mut dap]), false) {
+            match session.eval_with_hooks(expression.clone(), Some(vec![&mut dap]), false) {
                 Ok(_result) => Ok(()),
                 Err(_diagnostics) => Err("unable to interpret expression".to_string()),
             }

--- a/components/clarinet-deployments/src/lib.rs
+++ b/components/clarinet-deployments/src/lib.rs
@@ -203,7 +203,7 @@ fn handle_emulated_contract_publish(
         epoch,
     };
 
-    let result = session.deploy_contract(&contract, None, false, contract_ast);
+    let result = session.deploy_contract(&contract, false, contract_ast);
 
     session.set_tx_sender(&default_tx_sender);
     result
@@ -211,7 +211,7 @@ fn handle_emulated_contract_publish(
 
 /// Used to evalutate function arguments passed in deployment plans
 fn eval_clarity_string(session: &mut Session, snippet: &str) -> SymbolicExpression {
-    let eval_result = session.eval(snippet.to_string(), None, false);
+    let eval_result = session.eval(snippet.to_string(), false);
     let value = match eval_result.unwrap().result {
         EvaluationResult::Contract(_) => unreachable!(),
         EvaluationResult::Snippet(snippet_result) => snippet_result.result,
@@ -238,7 +238,6 @@ fn handle_emulated_contract_call(
         &tx.emulated_sender.to_string(),
         true,
         false,
-        vec![],
     );
     if let Err(errors) = &result {
         println!("error: {:?}", errors.first().unwrap().message);

--- a/components/clarinet-deployments/src/onchain/mod.rs
+++ b/components/clarinet-deployments/src/onchain/mod.rs
@@ -268,7 +268,7 @@ pub fn update_deployment_costs(
                         .parameters
                         .iter()
                         .map(|value| {
-                            let execution = session.eval(value.to_string(), None, false).unwrap();
+                            let execution = session.eval(value.to_string(), false).unwrap();
                             match execution.result {
                                 EvaluationResult::Snippet(result) => result.result,
                                 _ => unreachable!("Contract result from snippet"),
@@ -499,7 +499,7 @@ pub fn apply_on_chain_deployment(
 
                     let mut function_args = vec![];
                     for value in tx.parameters.iter() {
-                        let execution = match session.eval(value.to_string(), None, false) {
+                        let execution = match session.eval(value.to_string(), false) {
                             Ok(res) => res,
                             Err(_e) => {
                                 let _ = deployment_event_tx.send(DeploymentEvent::Interrupted(

--- a/components/clarity-events/src/bin.rs
+++ b/components/clarity-events/src/bin.rs
@@ -50,7 +50,7 @@ pub fn main() {
             let file = FileLocation::from_path_string(&cmd.file_path).unwrap();
             let snippet = file.read_content_as_utf8().unwrap();
             let mut session = Session::new(SessionSettings::default());
-            let mut contract_analysis = match session.eval(snippet, None, false) {
+            let mut contract_analysis = match session.eval(snippet, false) {
                 Ok(execution) => match execution.result {
                     EvaluationResult::Contract(evaluation) => evaluation.contract.analysis,
                     _ => {


### PR DESCRIPTION
wip - exploring an other interface for session hooks

With this approach:
- the Session is more aware of it's hooks
  - instead of passing `eval_hooks` to every functions (`eval`, `deploy_contract` , `call_contract`), the caller only enable an hook once
  - in the future we could have `session.enable_debug_print_hook`, `session.enable_tracer_hook`, etc
- I added `.eval_with_hooks` that keeps the same behaviour and is backward compatible with exisintg implementation. It allows to evaluated snippets with arbitrary hooks
  - Should we choose to use the implemation, I should add some documentation in the comments for the `eval_with_hooks` method

Concerns: 
- is the Session supposed to be that aware of the hooks, or is it better to keep them as parameters, so that the Sessionis mor versatile

