### PR TITLE
feat: update testnet epochs heights

### DIFF
--- a/components/clarinet-deployments/src/requirements.rs
+++ b/components/clarinet-deployments/src/requirements.rs
@@ -131,15 +131,14 @@ pub const MAINNET_25_START_HEIGHT: u32 = 147_290;
 // @TODO: set right heights once live on mainnet
 pub const MAINNET_30_START_HEIGHT: u32 = 300_000;
 
-pub const TESTNET_20_START_HEIGHT: u32 = 1;
-pub const TESTNET_2_05_START_HEIGHT: u32 = 20_216;
-pub const TESTNET_21_START_HEIGHT: u32 = 99_113;
-pub const TESTNET_22_START_HEIGHT: u32 = 105_923;
-pub const TESTNET_23_START_HEIGHT: u32 = 106_196;
-pub const TESTNET_24_START_HEIGHT: u32 = 106_979;
-pub const TESTNET_25_START_HEIGHT: u32 = 152_256;
-// @TODO: set right heights once live on testnet
-pub const TESTNET_30_START_HEIGHT: u32 = 300_000;
+pub const TESTNET_20_START_HEIGHT: u32 = 0;
+pub const TESTNET_2_05_START_HEIGHT: u32 = 1;
+pub const TESTNET_21_START_HEIGHT: u32 = 2;
+pub const TESTNET_22_START_HEIGHT: u32 = 3;
+pub const TESTNET_23_START_HEIGHT: u32 = 4;
+pub const TESTNET_24_START_HEIGHT: u32 = 5;
+pub const TESTNET_25_START_HEIGHT: u32 = 6;
+pub const TESTNET_30_START_HEIGHT: u32 = 56_457;
 
 fn epoch_for_height(is_mainnet: bool, height: u32) -> StacksEpochId {
     if is_mainnet {


### PR DESCRIPTION
These values has been outdated for a while now (4 months). When the primary testnet was restarted to use the bitcoin regtest.

And the epoch 3.0 switch is set to happen at block 56457 (today).

Check epoch values here: https://api.testnet.hiro.so/v2/pox