### PR TITLE
fix: LSP initialization options

### DIFF
--- a/components/clarity-lsp/src/common/backend.rs
+++ b/components/clarity-lsp/src/common/backend.rs
@@ -372,7 +372,7 @@ pub fn process_mutating_request(
         LspRequest::Initialize(params) => {
             let initialization_options = params
                 .initialization_options
-                .and_then(|o| serde_json::from_str(o.as_str()?).ok())
+                .and_then(|o| serde_json::from_value(o).ok())
                 .unwrap_or(InitializationOptions::default());
 
             match editor_state.try_write(|es| es.settings = initialization_options.clone()) {

--- a/components/clarity-lsp/src/common/requests/capabilities.rs
+++ b/components/clarity-lsp/src/common/requests/capabilities.rs
@@ -6,7 +6,7 @@ use lsp_types::{
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", default)]
 pub struct InitializationOptions {
     completion: bool,
     pub completion_smart_parenthesis_wrap: bool,


### PR DESCRIPTION
### Description

A client can send partial initialization options, e.g.:

```lua
require('clarinet') -- Adds clarinet LSP
lspconfig.clarinet.setup(extend_config({
    cmd = {'/run/current-system/sw/bin/bash', '/tmp/wrapper.sh'},
    init_options = {completion = true}
}))
```

When that happens, the deserialization from the following code would fail, because all other required fields of `InitializationOptions` would be missing.

https://github.com/hirosystems/clarinet/blob/90cb0158d532dd34d29fa9e396f6dc65cb26a89d/components/clarity-lsp/src/common/backend.rs#L372-L376

This PR fixes that. In addition, it removes the unnecessary (I think) cast to string as we are already dealing with a `serde_json::Value` instance.

#### Breaking change?

No.

### Example

See above.

---

### Checklist

- [X] Tests added in this PR (if applicable). Note: I have tested it manually through `nvim` LSP. It would be good if someone using VSCode could test it as well.

