### PR TITLE
refactor: improve handling of enums with big size variations

### DIFF
--- a/components/clarinet-cli/src/lsp/native_bridge.rs
+++ b/components/clarinet-cli/src/lsp/native_bridge.rs
@@ -101,14 +101,14 @@ impl LspNativeBridge {
 impl LanguageServer for LspNativeBridge {
     async fn initialize(&self, params: InitializeParams) -> Result<InitializeResult> {
         let _ = match self.request_tx.lock() {
-            Ok(tx) => tx.send(LspRequest::Initialize(params)),
+            Ok(tx) => tx.send(LspRequest::Initialize(Box::new(params))),
             Err(_) => return Err(Error::new(ErrorCode::InternalError)),
         };
 
         let response_rx = self.response_rx.lock().expect("failed to lock response_rx");
         let response = &response_rx.recv().expect("failed to get value from recv");
         if let LspResponse::Request(LspRequestResponse::Initialize(initialize)) = response {
-            return Ok(initialize.to_owned());
+            return Ok(*initialize.to_owned());
         }
         Err(Error::new(ErrorCode::InternalError))
     }

--- a/components/clarinet-deployments/src/onchain/mod.rs
+++ b/components/clarinet-deployments/src/onchain/mod.rs
@@ -198,6 +198,7 @@ pub fn encode_contract_publish(
     )
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug)]
 pub enum TransactionStatus {
     Queued,
@@ -221,6 +222,7 @@ pub enum TransactionCheck {
     BtcTransfer,
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug)]
 pub enum DeploymentEvent {
     TransactionUpdate(TransactionTracker),

--- a/components/clarity-lsp/src/common/backend.rs
+++ b/components/clarity-lsp/src/common/backend.rs
@@ -258,7 +258,7 @@ pub enum LspRequest {
     Definition(GotoDefinitionParams),
     Hover(HoverParams),
     DocumentSymbol(DocumentSymbolParams),
-    Initialize(InitializeParams),
+    Initialize(Box<InitializeParams>),
 }
 
 #[derive(Debug, PartialEq, Deserialize, Serialize)]
@@ -268,7 +268,7 @@ pub enum LspRequestResponse {
     Definition(Option<Location>),
     DocumentSymbol(Vec<DocumentSymbol>),
     Hover(Option<Hover>),
-    Initialize(InitializeResult),
+    Initialize(Box<InitializeResult>),
 }
 
 pub fn process_request(
@@ -376,10 +376,10 @@ pub fn process_mutating_request(
                 .unwrap_or(InitializationOptions::default());
 
             match editor_state.try_write(|es| es.settings = initialization_options.clone()) {
-                Ok(_) => Ok(LspRequestResponse::Initialize(InitializeResult {
+                Ok(_) => Ok(LspRequestResponse::Initialize(Box::new(InitializeResult {
                     server_info: None,
                     capabilities: get_capabilities(&initialization_options),
-                })),
+                }))),
                 Err(err) => Err(err),
             }
         }


### PR DESCRIPTION
Clippy fixes for [large_enum_variant](https://rust-lang.github.io/rust-clippy/master/index.html#large_enum_variant)

In the LSP, the `Initialize` Response and Request are only sent at the initialization of the LSP, then it's only the other kinds that are used. So it really makes sense to box those.

I preferred to ignored the changes in deployments, because clarinet onchain deployments are less memory intensive (and, less used as well). So the benefits in changing those was less obvious
