### PR TITLE
chore: update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4182,12 +4182,13 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.120"
+version = "1.0.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
+checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
 dependencies = [
  "indexmap 2.2.3",
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,9 +94,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.2"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15c4c2c83f81532e5845a733998b6971faca23490340a418e9b72a3ec9de12ea"
+checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
 
 [[package]]
 name = "anstyle-parse"
@@ -178,7 +178,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -189,7 +189,7 @@ checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -621,9 +621,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.9"
+version = "4.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64acc1846d54c1fe936a78dc189c34e28d3f5afc348403f28ecf53660b9b8462"
+checksum = "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -631,9 +631,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.9"
+version = "4.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb8393d67ba2e7bfaf28a23458e4e2b543cc73a99595511eb207fdb8aede942"
+checksum = "19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54"
 dependencies = [
  "anstream",
  "anstyle",
@@ -652,14 +652,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.8"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bac35c6dafb060fd4d275d9a4ffae97917c13a6327903a8be2153cd964f7085"
+checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -750,7 +750,6 @@ version = "2.10.0"
 dependencies = [
  "bip39",
  "bitcoin",
- "chainhook-types",
  "clarinet-utils",
  "clarity",
  "clarity-repl",
@@ -1279,7 +1278,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -1409,7 +1408,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -1731,7 +1730,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -2452,9 +2451,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.69"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2862,6 +2861,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
+dependencies = [
+ "hermit-abi 0.3.9",
+ "libc",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "miow"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3213,7 +3224,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -3344,9 +3355,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "7c3a7fc5db1e57d5a779a352c8cdb57b29aa4c40cc69c3a68a7fedc815fbf2f9"
 dependencies = [
  "unicode-ident",
 ]
@@ -3359,7 +3370,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.82",
  "version_check",
  "yansi",
 ]
@@ -3625,7 +3636,7 @@ checksum = "a930b010d9effee5834317bb7ff406b76af7724348fd572b38705b4bd099fa92"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -3687,9 +3698,9 @@ checksum = "56d84fdd47036b038fc80dd333d10b6aab10d5d31f4a366e20014def75328d33"
 
 [[package]]
 name = "reqwest"
-version = "0.12.5"
+version = "0.12.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
+checksum = "f713147fbe92361e52392c73b8c9e48c04c6625bce969ef54dc901e58e042a7b"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3725,7 +3736,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "webpki-roots",
- "winreg",
+ "windows-registry",
 ]
 
 [[package]]
@@ -3801,7 +3812,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rocket_http",
- "syn 2.0.50",
+ "syn 2.0.82",
  "unicode-xid",
  "version_check",
 ]
@@ -4118,9 +4129,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.204"
+version = "1.0.211"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
+checksum = "1ac55e59090389fb9f0dd9e0f3c09615afed1d19094284d0b200441f13550793"
 dependencies = [
  "serde_derive",
 ]
@@ -4138,9 +4149,9 @@ dependencies = [
 
 [[package]]
 name = "serde-wasm-bindgen"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c1432112bce8b966497ac46519535189a3250a3812cd27a999678a69756f79f"
+checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
 dependencies = [
  "js-sys",
  "serde",
@@ -4149,13 +4160,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.204"
+version = "1.0.211"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
+checksum = "54be4f245ce16bc58d57ef2716271d0d4519e0f6defa147f6e081005bcb278ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -4510,7 +4521,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d904e7009df136af5297832a3ace3370cd14ff1546a232f4f185036c2736fcac"
 dependencies = [
  "quote",
- "syn 2.0.50",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -4604,6 +4615,7 @@ dependencies = [
  "bitcoincore-rpc",
  "bollard",
  "chainhook-sdk",
+ "chainhook-types",
  "chrono",
  "clap",
  "clarinet-deployments",
@@ -4750,7 +4762,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.50",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -4778,9 +4790,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.50"
+version = "2.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f1bdc9872430ce9b75da68329d1c1746faf50ffac5f19e02b71e37ff881ffb"
+checksum = "83540f837a8afc019423a8edb95b52a8effe46957ee402287f4292fae35be021"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4792,6 +4804,9 @@ name = "sync_wrapper"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "take_mut"
@@ -4856,7 +4871,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -4867,7 +4882,7 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.82",
  "test-case-core",
 ]
 
@@ -4888,7 +4903,7 @@ checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -4993,32 +5008,31 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.38.1"
+version = "1.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb2caba9f80616f438e09748d5acda951967e1ea58508ef53d9c6402485a46df"
+checksum = "145f3413504347a2be84393cc8a7d2fb4d863b375909ea59f2158261aa258bbb"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
- "mio 0.8.11",
- "num_cpus",
+ "mio 1.0.2",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.5.5",
  "tokio-macros",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -5415,34 +5429,35 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.92"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
 dependencies = [
  "cfg-if 1.0.0",
+ "once_cell",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.92"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.82",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.41"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877b9c3f61ceea0e56331985743b13f3d25c406a7098d45180fb5f09bc19ed97"
+checksum = "cc7ec4f8827a71586374db3e87abdb5a2bb3a15afed140221307c3ec06b1f63b"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -5452,9 +5467,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.92"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5462,22 +5477,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.92"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.82",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.92"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
 
 [[package]]
 name = "wasm-encoder"
@@ -5597,7 +5612,7 @@ dependencies = [
  "anyhow",
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.82",
  "wasmtime-component-util",
  "wasmtime-wit-bindgen",
  "wit-parser",
@@ -5785,7 +5800,7 @@ checksum = "f50f51f8d79bfd2aa8e9d9a0ae7c2d02b45fe412e62ff1b87c0c81b07c738231"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -5899,6 +5914,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-registry"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+dependencies = [
+ "windows-result",
+ "windows-strings",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5922,7 +5967,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.4",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5957,17 +6002,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.4",
- "windows_aarch64_msvc 0.52.4",
- "windows_i686_gnu 0.52.4",
- "windows_i686_msvc 0.52.4",
- "windows_x86_64_gnu 0.52.4",
- "windows_x86_64_gnullvm 0.52.4",
- "windows_x86_64_msvc 0.52.4",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -5984,9 +6030,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -6002,9 +6048,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6020,9 +6066,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -6038,9 +6090,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6056,9 +6108,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -6074,9 +6126,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -6092,9 +6144,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
@@ -6103,16 +6155,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829846f3e3db426d4cee4510841b71a8e58aa2a76b1132579487ae430ccd9c7b"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "winreg"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
-dependencies = [
- "cfg-if 1.0.0",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6177,7 +6219,7 @@ checksum = "b3c129550b3e6de3fd0ba67ba5c81818f9805e58b8d7fee80a3a59d2c9fc601a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.82",
 ]
 
 [[package]]

--- a/components/clarinet-cli/src/deployments/mod.rs
+++ b/components/clarinet-cli/src/deployments/mod.rs
@@ -6,8 +6,7 @@ use std::path::PathBuf;
 pub use ui::start_ui;
 
 use clarinet_deployments::types::{DeploymentGenerationArtifacts, DeploymentSpecification};
-use clarinet_files::chainhook_types::StacksNetwork;
-use clarinet_files::{FileLocation, ProjectManifest};
+use clarinet_files::{FileLocation, ProjectManifest, StacksNetwork};
 
 pub fn get_absolute_deployment_path(
     manifest: &ProjectManifest,

--- a/components/clarinet-cli/src/devnet/package.rs
+++ b/components/clarinet-cli/src/devnet/package.rs
@@ -4,7 +4,7 @@ use std::process;
 
 use clarinet_deployments::get_default_deployment_path;
 use clarinet_deployments::types::DeploymentSpecification;
-use clarinet_files::chainhook_types::StacksNetwork;
+use clarinet_files::StacksNetwork;
 use clarinet_files::{NetworkManifest, ProjectManifest};
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/components/clarinet-cli/src/frontend/cli.rs
+++ b/components/clarinet-cli/src/frontend/cli.rs
@@ -22,7 +22,7 @@ use clarinet_deployments::types::{DeploymentGenerationArtifacts, DeploymentSpeci
 use clarinet_deployments::{
     get_default_deployment_path, load_deployment, setup_session_with_deployment,
 };
-use clarinet_files::chainhook_types::StacksNetwork;
+use clarinet_files::StacksNetwork;
 use clarinet_files::{
     get_manifest_location, FileLocation, NetworkManifest, ProjectManifest, ProjectManifestFile,
     RequirementConfig,
@@ -624,7 +624,9 @@ pub fn main() {
                         }
                     };
 
-                if !cmd.manual_cost && network.either_testnet_or_mainnet() {
+                if !cmd.manual_cost
+                    && matches!(network, StacksNetwork::Testnet | StacksNetwork::Mainnet)
+                {
                     let priority = match (cmd.low_cost, cmd.medium_cost, cmd.high_cost) {
                         (_, _, true) => 2,
                         (_, true, _) => 1,

--- a/components/clarinet-cli/src/frontend/dap.rs
+++ b/components/clarinet-cli/src/frontend/dap.rs
@@ -1,6 +1,6 @@
 use crate::deployments::generate_default_deployment;
 use clarinet_deployments::setup_session_with_deployment;
-use clarinet_files::chainhook_types::StacksNetwork;
+use clarinet_files::StacksNetwork;
 use clarinet_files::{FileLocation, ProjectManifest};
 use clarity_repl::repl::debug::dap::DAPDebugger;
 use std::path::PathBuf;

--- a/components/clarinet-cli/src/frontend/telemetry.rs
+++ b/components/clarinet-cli/src/frontend/telemetry.rs
@@ -5,7 +5,7 @@ use segment::{
     Client, HttpClient,
 };
 
-use clarinet_files::chainhook_types::StacksNetwork;
+use clarinet_files::StacksNetwork;
 
 pub enum DeveloperUsageEvent {
     NewProject(DeveloperUsageDigest),

--- a/components/clarinet-deployments/Cargo.toml
+++ b/components/clarinet-deployments/Cargo.toml
@@ -30,7 +30,7 @@ clarity = { workspace = true }
 
 [features]
 default = ["cli"]
-cli = ["clarity-repl/cli", "clarinet-files/cli", "stacks-codec", "onchain"]
+cli = ["clarity-repl/sdk", "clarinet-files/cli", "stacks-codec", "onchain"]
 wasm = ["clarity-repl/wasm", "clarinet-files/wasm"]
 onchain = [
     "stacks-rpc-client",

--- a/components/clarinet-deployments/Cargo.toml
+++ b/components/clarinet-deployments/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 colored = "2.1.0"
 serde = "1"
-serde_json = "1"
+serde_json = "1.0.123"
 serde_derive = "1"
 serde_yaml = "0.8.23"
 

--- a/components/clarinet-deployments/src/deployment_plan_test.rs
+++ b/components/clarinet-deployments/src/deployment_plan_test.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use clarinet_files::{chainhook_types::StacksNetwork, FileLocation};
+use clarinet_files::{FileLocation, StacksNetwork};
 use clarity_repl::clarity::{
     vm::types::QualifiedContractIdentifier, ClarityName, ClarityVersion, ContractName,
 };

--- a/components/clarinet-deployments/src/types.rs
+++ b/components/clarinet-deployments/src/types.rs
@@ -1,4 +1,4 @@
-use clarinet_files::chainhook_types::StacksNetwork;
+use clarinet_files::StacksNetwork;
 use clarinet_files::{FileAccessor, FileLocation};
 use clarity_repl::clarity::util::hash::{hex_bytes, to_hex};
 use clarity_repl::clarity::vm::analysis::ContractAnalysis;
@@ -1103,7 +1103,7 @@ impl DeploymentSpecification {
                                     TransactionSpecification::ContractCall(ContractCallSpecification::from_specifications(spec)?)
                                 }
                                 TransactionSpecificationFile::RequirementPublish(spec) => {
-                                    if network.is_mainnet() {
+                                    if matches!(network, StacksNetwork::Mainnet) {
                                         return Err(format!("{} only supports transactions of type 'contract-call' and 'contract-publish", specs.network.to_lowercase()))
                                     }
                                     let spec = RequirementPublishSpecification::from_specifications(spec, project_root_location)?;

--- a/components/clarinet-files/Cargo.toml
+++ b/components/clarinet-files/Cargo.toml
@@ -8,7 +8,6 @@ license = "GPL-3.0"
 [dependencies]
 serde = "1"
 serde_derive = "1"
-chainhook-types = { version = "1.3" }
 bip39 = { version = "1.0.1", default-features = false }
 libsecp256k1 = "0.7.0"
 toml = { version = "0.5.6", features = ["preserve_order"] }

--- a/components/clarinet-files/Cargo.toml
+++ b/components/clarinet-files/Cargo.toml
@@ -30,7 +30,7 @@ serde_json = "1.0.114"
 
 [features]
 default = ["cli"]
-cli = ["bitcoin", "clarity-repl/cli"]
+cli = ["bitcoin", "clarity-repl/sdk"]
 wasm = [
   "js-sys",
   "serde-wasm-bindgen",

--- a/components/clarinet-files/src/lib.rs
+++ b/components/clarinet-files/src/lib.rs
@@ -9,14 +9,13 @@ pub extern crate url;
 mod network_manifest;
 mod project_manifest;
 
+pub use network_manifest::{BitcoinNetwork, StacksNetwork};
+
 #[cfg(feature = "wasm")]
 mod wasm_fs_accessor;
 #[cfg(feature = "wasm")]
 pub use wasm_fs_accessor::WASMFileSystemAccessor;
 
-pub use chainhook_types;
-
-use chainhook_types::StacksNetwork;
 pub use network_manifest::{
     compute_addresses, AccountConfig, DevnetConfig, DevnetConfigFile, NetworkManifest,
     NetworkManifestFile, PoxStackingOrder, DEFAULT_BITCOIN_EXPLORER_IMAGE,

--- a/components/clarinet-files/src/network_manifest.rs
+++ b/components/clarinet-files/src/network_manifest.rs
@@ -2,7 +2,6 @@ use std::collections::BTreeMap;
 
 use super::{FileAccessor, FileLocation};
 use bip39::{Language, Mnemonic};
-use chainhook_types::{BitcoinNetwork, StacksNetwork};
 use clarinet_utils::get_bip39_seed_from_mnemonic;
 use clarity::address::AddressHashMode;
 use clarity::types::chainstate::{StacksAddress, StacksPrivateKey};
@@ -67,6 +66,32 @@ lazy_static! {
         )
         .unwrap(),
     ];
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum StacksNetwork {
+    Simnet,
+    Devnet,
+    Testnet,
+    Mainnet,
+}
+
+pub enum BitcoinNetwork {
+    Regtest,
+    Testnet,
+    Signet,
+    Mainnet,
+}
+
+impl StacksNetwork {
+    pub fn get_networks(&self) -> (BitcoinNetwork, StacksNetwork) {
+        match &self {
+            StacksNetwork::Simnet => (BitcoinNetwork::Regtest, StacksNetwork::Simnet),
+            StacksNetwork::Devnet => (BitcoinNetwork::Testnet, StacksNetwork::Devnet),
+            StacksNetwork::Testnet => (BitcoinNetwork::Testnet, StacksNetwork::Testnet),
+            StacksNetwork::Mainnet => (BitcoinNetwork::Mainnet, StacksNetwork::Mainnet),
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -444,7 +469,7 @@ impl NetworkManifest {
         };
 
         let mut accounts = BTreeMap::new();
-        let is_mainnet = networks.1.is_mainnet();
+        let is_mainnet = matches!(networks.1, StacksNetwork::Mainnet);
 
         if let Some(Value::Table(entries)) = &network_manifest_file.accounts {
             for (account_name, account_settings) in entries.iter() {
@@ -499,7 +524,7 @@ impl NetworkManifest {
             }
         };
 
-        let devnet = if networks.1.is_devnet() {
+        let devnet = if matches!(networks.1, StacksNetwork::Devnet) {
             let mut devnet_config = network_manifest_file.devnet.take().unwrap_or_default();
 
             if let Some(ref devnet_override) = devnet_override {
@@ -1057,7 +1082,7 @@ pub fn compute_addresses(
 
     let public_key = PublicKey::from_secret_key(&secret_key);
     let pub_key = Secp256k1PublicKey::from_slice(&public_key.serialize_compressed()).unwrap();
-    let version = if networks.1.is_mainnet() {
+    let version = if matches!(networks.1, StacksNetwork::Mainnet) {
         clarity::address::C32_ADDRESS_VERSION_MAINNET_SINGLESIG
     } else {
         clarity::address::C32_ADDRESS_VERSION_TESTNET_SINGLESIG

--- a/components/clarinet-files/src/network_manifest.rs
+++ b/components/clarinet-files/src/network_manifest.rs
@@ -69,6 +69,7 @@ lazy_static! {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum StacksNetwork {
     Simnet,
     Devnet,
@@ -76,6 +77,8 @@ pub enum StacksNetwork {
     Mainnet,
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum BitcoinNetwork {
     Regtest,
     Testnet,

--- a/components/clarinet-sdk-wasm/src/core.rs
+++ b/components/clarinet-sdk-wasm/src/core.rs
@@ -7,7 +7,7 @@ use clarinet_deployments::{
     generate_default_deployment, initiate_session_from_manifest,
     update_session_with_deployment_plan,
 };
-use clarinet_files::chainhook_types::StacksNetwork;
+use clarinet_files::StacksNetwork;
 use clarinet_files::{FileAccessor, FileLocation, ProjectManifest, WASMFileSystemAccessor};
 use clarity_repl::analysis::coverage::CoverageHook;
 use clarity_repl::clarity::analysis::contract_interface_builder::{

--- a/components/clarity-lsp/src/common/state.rs
+++ b/components/clarity-lsp/src/common/state.rs
@@ -3,8 +3,8 @@ use clarinet_deployments::{
     generate_default_deployment, initiate_session_from_manifest,
     update_session_with_deployment_plan, UpdateSessionExecutionResult,
 };
-use clarinet_files::chainhook_types::StacksNetwork;
 use clarinet_files::ProjectManifest;
+use clarinet_files::StacksNetwork;
 use clarinet_files::{FileAccessor, FileLocation};
 use clarity_repl::analysis::ast_dependency_detector::DependencySet;
 use clarity_repl::clarity::analysis::ContractAnalysis;

--- a/components/clarity-repl/Cargo.toml
+++ b/components/clarity-repl/Cargo.toml
@@ -68,17 +68,6 @@ path = "src/bin.rs"
 
 [features]
 default = ["cli", "dap"]
-cli = [
-    "pico-args",
-    "rustyline",
-    "clarity/canonical",
-    "clarity/developer-mode",
-    "clarity/devtools",
-    "clarity/log",
-    "hiro_system_kit/tokio_helpers",
-    "clar2wasm",
-    "pox-locking/default"
-]
 sdk = [
     "clarity/canonical",
     "clarity/developer-mode",
@@ -86,6 +75,12 @@ sdk = [
     "clarity/log",
     "hiro_system_kit/tokio_helpers",
     "pox-locking/default"
+]
+cli = [
+    "sdk",
+    "pico-args",
+    "rustyline",
+    "clar2wasm",
 ]
 dap = [
     "tokio",

--- a/components/clarity-repl/src/repl/datastore.rs
+++ b/components/clarity-repl/src/repl/datastore.rs
@@ -323,7 +323,7 @@ impl ClarityBackingStore for ClarityDatastore {
         Some(&handle_contract_call_special_cases)
     }
 
-    #[cfg(any(feature = "cli", feature = "cli"))]
+    #[cfg(feature = "sdk")]
     fn get_side_store(&mut self) -> &::clarity::rusqlite::Connection {
         panic!("Datastore cannot get_side_store")
     }

--- a/components/clarity-repl/src/repl/mod.rs
+++ b/components/clarity-repl/src/repl/mod.rs
@@ -7,7 +7,7 @@ pub mod session;
 pub mod settings;
 pub mod tracer;
 
-#[cfg(not(feature = "wasm"))]
+#[cfg(feature = "dap")]
 pub mod debug;
 
 use serde::ser::{Serialize, SerializeMap, Serializer};

--- a/components/stacks-devnet-js/src/lib.rs
+++ b/components/stacks-devnet-js/src/lib.rs
@@ -8,13 +8,13 @@ use clarinet_deployments::{get_default_deployment_path, load_deployment};
 use clarinet_files::bip39::{Language, Mnemonic};
 use clarinet_files::{
     compute_addresses, AccountConfig, DevnetConfigFile, FileLocation, PoxStackingOrder,
-    ProjectManifest, DEFAULT_DERIVATION_PATH,
+    ProjectManifest, StacksNetwork, DEFAULT_DERIVATION_PATH,
 };
 use hiro_system_kit::{o, slog, slog_async, slog_term, Drain};
 use neon::context::Context as NeonContext;
 use stacks_network::chainhook_sdk::types::{
     BitcoinChainEvent, BitcoinChainUpdatedWithBlocksData, StacksChainEvent,
-    StacksChainUpdatedWithBlocksData, StacksNetwork,
+    StacksChainUpdatedWithBlocksData,
 };
 use stacks_network::chains_coordinator::BitcoinMiningCommand;
 use stacks_network::{self, Context, DevnetEvent, DevnetOrchestrator, LogLevel};

--- a/components/stacks-network/Cargo.toml
+++ b/components/stacks-network/Cargo.toml
@@ -32,6 +32,7 @@ serde_yaml = "0.8.23"
 clarity = { workspace = true }
 stackslib = { git = "https://github.com/stacks-network/stacks-core.git", branch="feat/clarity-wasm-develop", package = "stackslib" }
 chainhook-sdk = { version = "0.12" }
+chainhook-types = { version = "1.3.7" }
 
 stacks-rpc-client = { path = "../stacks-rpc-client" }
 clarinet-files = { path = "../clarinet-files", features = ["cli"] }

--- a/components/stacks-network/src/chains_coordinator.rs
+++ b/components/stacks-network/src/chains_coordinator.rs
@@ -16,7 +16,6 @@ use chainhook_sdk::types::BitcoinBlockSignaling;
 use chainhook_sdk::types::BitcoinChainEvent;
 use chainhook_sdk::types::StacksChainEvent;
 use chainhook_sdk::types::StacksNodeConfig;
-use chainhook_sdk::types::{BitcoinNetwork, StacksNetwork};
 use chainhook_sdk::utils::Context;
 use clarinet_deployments::onchain::TransactionStatus;
 use clarinet_deployments::onchain::{
@@ -24,6 +23,7 @@ use clarinet_deployments::onchain::{
 };
 use clarinet_deployments::types::DeploymentSpecification;
 use clarinet_files::PoxStackingOrder;
+use clarinet_files::StacksNetwork;
 use clarinet_files::DEFAULT_FIRST_BURN_HEADER_HEIGHT;
 use clarinet_files::{self, AccountConfig, DevnetConfig, NetworkManifest, ProjectManifest};
 use clarity::address::AddressHashMode;
@@ -134,8 +134,8 @@ impl DevnetEventObserverConfig {
             }),
 
             display_stacks_ingestion_logs: true,
-            bitcoin_network: BitcoinNetwork::Regtest,
-            stacks_network: StacksNetwork::Devnet,
+            bitcoin_network: chainhook_types::BitcoinNetwork::Regtest,
+            stacks_network: chainhook_types::StacksNetwork::Devnet,
             prometheus_monitoring_port: None,
         };
 

--- a/components/stacks-network/src/orchestrator.rs
+++ b/components/stacks-network/src/orchestrator.rs
@@ -11,7 +11,7 @@ use bollard::service::Ipam;
 use bollard::Docker;
 use chainhook_sdk::bitcoin::hex::DisplayHex;
 use chainhook_sdk::utils::Context;
-use clarinet_files::chainhook_types::StacksNetwork;
+use clarinet_files::StacksNetwork;
 use clarinet_files::{DevnetConfigFile, NetworkManifest, ProjectManifest};
 use clarity::types::chainstate::StacksPrivateKey;
 use clarity::types::PrivateKey;


### PR DESCRIPTION
### Description

- update some the dependencies (clap, ratatui, reqwest, serde)
- implement clarinet's own version of `StacksNetwork` and `BitcoinNetwork`, instead of importing it from `chainhook-types`. This allows to remove the chainhook dependency from `clarinet-files` and only have it in `stacks-network` (with `chainhook-sdk` and `chainhook-types` along each other). So that `clarinet-lsp` and `clarinet-sdk` don't rely on chainhook at all anymore 👍 
  - i could have ported the `is_<network>` methods as well, but I don't think there's a big benieft if adding online helpers when we can just use the `matches!` macro
  - with this, chainhook could even consider merging chainhook-sdk and chainhook-types in only one package