### PR TITLE
tests: setup basic wasm-bindgen tests for the sdk

### DIFF
--- a/.github/workflows/ci-sdk.yaml
+++ b/.github/workflows/ci-sdk.yaml
@@ -58,6 +58,9 @@ jobs:
       - name: Install wasm-pack
         run: npm install -g wasm-pack
 
+      - name: Run wasm-bindgen-test
+        run: wasm-pack test --node components/clarinet-sdk-wasm
+
       - name: Build Wasm packages
         run: npm run build:sdk-wasm
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -773,6 +773,7 @@ version = "2.11.2"
 dependencies = [
  "clarinet-deployments",
  "clarinet-files",
+ "clarity",
  "clarity-repl",
  "colored",
  "console_error_panic_hook",
@@ -783,6 +784,7 @@ dependencies = [
  "serde_json",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-bindgen-test",
  "web-sys",
 ]
 
@@ -2810,6 +2812,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
+name = "minicov"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27fe9f1cc3c22e1687f9446c2083c4c5fc7f0bcf1c7a86bdbded14985895b4b"
+dependencies = [
+ "cc",
+ "walkdir",
+]
+
+[[package]]
 name = "miniscript"
 version = "11.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4011,6 +4023,15 @@ name = "ryu"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schemars"
@@ -5379,6 +5400,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "walrus"
 version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5494,6 +5525,32 @@ name = "wasm-bindgen-shared"
 version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d381749acb0943d357dcbd8f0b100640679883fcdeeef04def49daf8d33a5426"
+dependencies = [
+ "console_error_panic_hook",
+ "js-sys",
+ "minicov",
+ "scoped-tls",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c97b2ef2c8d627381e51c071c2ab328eac606d3f69dd82bcbca20a9e389d95f0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.82",
+]
 
 [[package]]
 name = "wasm-encoder"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,8 @@ reqwest = { version = "0.12", default-features = false, features = [
     "json",
     "rustls-tls",
 ] }
-web-sys = { version = "0.3" }
 wasm-bindgen = { version = "0.2" }
+web-sys = { version = "0.3" }
 
 [patch.crates-io]
 chainhook-sdk = { git = "https://github.com/hirosystems/chainhook.git" }

--- a/components/clarinet-files/Cargo.toml
+++ b/components/clarinet-files/Cargo.toml
@@ -25,7 +25,7 @@ clarity-repl = { path = "../clarity-repl", default-features = false, optional = 
 js-sys = { version = "0.3", optional = true }
 serde-wasm-bindgen = { version = "0.6.4", optional = true }
 wasm-bindgen = { workspace = true, optional = true }
-wasm-bindgen-futures = { version = "0.4.41", optional = true }
+wasm-bindgen-futures = { version = "0.4", optional = true }
 serde_json = "1.0.114"
 
 [features]

--- a/components/clarinet-sdk-wasm/Cargo.toml
+++ b/components/clarinet-sdk-wasm/Cargo.toml
@@ -19,13 +19,17 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
 serde-wasm-bindgen = { version = "0.6.4", optional = true }
 wasm-bindgen = { workspace = true, optional = true }
-wasm-bindgen-futures = { version = "0.4.41", optional = true }
+wasm-bindgen-futures = { version = "0.4", optional = true }
 web-sys = { workspace = true, features = ["console"], optional = true }
 colored = "2.1.0"
 
 clarinet-files = { path = "../clarinet-files", default-features = false }
 clarity-repl = { path = "../clarity-repl", default-features = false, optional = true }
 clarinet-deployments = { path = "../clarinet-deployments", default-features = false }
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3.0"
+clarity = { workspace = true }
 
 [features]
 default = ["wasm"]

--- a/components/clarinet-sdk-wasm/src/core.rs
+++ b/components/clarinet-sdk-wasm/src/core.rs
@@ -54,6 +54,14 @@ extern "C" {
     pub type IContractInterfaces;
 }
 
+impl EpochString {
+    pub fn new(obj: &str) -> Self {
+        Self {
+            obj: JsValue::from_str(obj),
+        }
+    }
+}
+
 macro_rules! log {
     ( $( $t:tt )* ) => {
         web_sys::console::log_1(&format!( $( $t )* ).into());

--- a/components/clarinet-sdk-wasm/src/lib.rs
+++ b/components/clarinet-sdk-wasm/src/lib.rs
@@ -2,3 +2,6 @@ pub mod core;
 mod ts_types;
 
 mod utils;
+
+#[cfg(all(target_arch = "wasm32", test))]
+mod test_wasm;

--- a/components/clarinet-sdk-wasm/src/test_wasm.rs
+++ b/components/clarinet-sdk-wasm/src/test_wasm.rs
@@ -1,0 +1,63 @@
+use super::core::DeployContractArgs;
+use crate::core::{CallFnArgs, ContractOptions, EpochString, TransactionRes, SDK};
+use clarity::vm::Value as ClarityValue;
+use js_sys::Function as JsFunction;
+use wasm_bindgen_test::*;
+
+async fn init_sdk() -> SDK {
+    let js_noop = JsFunction::new_no_args("return");
+    let mut sdk = SDK::new(js_noop, None);
+    let _ = sdk.init_empty_session().await;
+    sdk.set_epoch(EpochString::new("3.0"));
+    sdk
+}
+
+#[track_caller]
+fn deploy_basic_contract(sdk: &mut SDK) -> TransactionRes {
+    let contract = DeployContractArgs::new(
+        "basic-contract".into(),
+        "(define-private (two) (+ u1 u1))".into(),
+        ContractOptions::new(None),
+        "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM".into(),
+    );
+    sdk.deploy_contract(&contract).unwrap()
+}
+
+#[wasm_bindgen_test]
+async fn it_cn_execute_clarity_code() {
+    let mut sdk = init_sdk().await;
+    let tx = sdk.execute("(+ u41 u1)".into()).unwrap();
+    let expected = format!("0x{}", ClarityValue::UInt(42).serialize_to_hex().unwrap());
+    assert_eq!(tx.result, expected);
+}
+
+#[wasm_bindgen_test]
+async fn it_can_set_epoch() {
+    let mut sdk = init_sdk().await;
+    assert_eq!(sdk.block_height(), 1);
+    assert_eq!(sdk.current_epoch(), "3.0");
+}
+
+#[wasm_bindgen_test]
+async fn it_can_deploy_contract() {
+    let mut sdk = init_sdk().await;
+    let tx = deploy_basic_contract(&mut sdk);
+    let expected = format!("0x{}", ClarityValue::Bool(true).serialize_to_hex().unwrap());
+    assert_eq!(tx.result, expected);
+}
+
+#[wasm_bindgen_test]
+async fn it_can_call_a_private_function() {
+    let mut sdk = init_sdk().await;
+    let _ = deploy_basic_contract(&mut sdk);
+    let tx = sdk
+        .call_private_fn(&CallFnArgs::new(
+            "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.basic-contract".into(),
+            "two".into(),
+            vec![],
+            "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM".into(),
+        ))
+        .unwrap();
+    let expected = format!("0x{}", ClarityValue::UInt(2).serialize_to_hex().unwrap());
+    assert_eq!(tx.result, expected);
+}

--- a/components/clarinet-sdk/clarinet-sdk.code-workspace
+++ b/components/clarinet-sdk/clarinet-sdk.code-workspace
@@ -4,10 +4,9 @@
     "rust-analyzer.check.overrideCommand": [
       "cargo",
       "clippy",
-      "--no-default-features",
       "--package=clarinet-sdk-wasm",
-      "--features=wasm",
       "--target=wasm32-unknown-unknown",
+      "--tests",
       "--message-format=json",
     ],
     "rust-analyzer.cargo.allTargets": false,
@@ -16,10 +15,9 @@
     "rust-analyzer.cargo.buildScripts.overrideCommand": [
       "cargo",
       "build",
-      "--no-default-features",
       "--package=clarinet-sdk-wasm",
-      "--features=wasm",
       "--target=wasm32-unknown-unknown",
+      "--tests",
       "--message-format=json",
     ],
   },

--- a/components/clarity-lsp/Cargo.toml
+++ b/components/clarity-lsp/Cargo.toml
@@ -18,7 +18,7 @@ console_error_panic_hook = { version = "0.1", optional = true }
 js-sys = { version = "0.3", optional = true }
 serde-wasm-bindgen = { version = "0.6.4", optional = true }
 wasm-bindgen = { workspace = true, optional = true }
-wasm-bindgen-futures = { version = "0.4.41", optional = true }
+wasm-bindgen-futures = { version = "0.4", optional = true }
 web-sys = { workspace = true, features = ["console"], optional = true }
 
 [features]


### PR DESCRIPTION
### Description

- set up wasm-bindgen
- add some simple tests
- run in CI


It kind of test the same thing as the existing clarinet-sdk wasm tests, more in a more "unit testing way" since it only test the wasm part. It also wayy faster to run. Both test strategies are useful
