### PR TITLE
fix sdk function name typo with `initEmptySession`

### DIFF
--- a/components/clarinet-sdk-wasm/src/core.rs
+++ b/components/clarinet-sdk-wasm/src/core.rs
@@ -348,7 +348,7 @@ impl SDK {
         }
     }
 
-    #[wasm_bindgen(js_name=initEmtpySession)]
+    #[wasm_bindgen(js_name=initEmptySession)]
     pub async fn init_empty_session(&mut self) -> Result<(), String> {
         let session = Session::new(SessionSettings::default());
         self.session = Some(session);

--- a/components/clarinet-sdk/browser/README.md
+++ b/components/clarinet-sdk/browser/README.md
@@ -27,7 +27,7 @@ There are two ways to use the sdk in the browser:
 - With an empty clarinet session:
 ```js
 const simnet = await initSimnet();
-await simnet.initEmtpySession();
+await simnet.initEmptySession();
 simnet.runSnippet("(+ 1 2)")
 ```
 


### PR DESCRIPTION
fixes typo with `initEmptySession` function for sdk

https://github.com/hirosystems/clarinet/blob/aaaebac1655590cabc5c295efa7a9955521433d4/components/clarinet-sdk-wasm/src/core.rs#L351