### PR TITLE
chore: Apply Clippy lints  `redundant_clone` and  `clear_with_drain`

### DIFF
--- a/components/clarinet-cli/src/frontend/cli.rs
+++ b/components/clarinet-cli/src/frontend/cli.rs
@@ -510,7 +510,7 @@ pub fn main() {
                 }
             };
             clap_complete::generate(cmd.shell, &mut app, "clarinet", &mut file);
-            println!("{} {}", green!("Created file"), file_name.clone());
+            println!("{} {}", green!("Created file"), file_name);
             println!("Check your shell's documentation for details about using this file to enable completions for clarinet");
         }
         Command::New(project_opts) => {
@@ -962,11 +962,11 @@ pub fn main() {
                         yellow!("Updated Clarinet.toml"),
                         green!(format!("{}", cmd.contract_id))
                     ),
-                    manifest_location: manifest.location.clone(),
+                    manifest_location: manifest.location,
                     contracts_to_rm: vec![],
                     contracts_to_add: HashMap::new(),
                     requirements_to_add: vec![RequirementConfig {
-                        contract_id: cmd.contract_id.clone(),
+                        contract_id: cmd.contract_id,
                     }],
                 };
                 if !execute_changes(vec![Changes::EditTOML(change)]) {

--- a/components/clarinet-cli/src/frontend/dap.rs
+++ b/components/clarinet-cli/src/frontend/dap.rs
@@ -41,7 +41,7 @@ pub fn run_dap() -> Result<(), String> {
             }
 
             // Begin execution of the expression in debug mode
-            match session.eval_with_hooks(expression.clone(), Some(vec![&mut dap]), false) {
+            match session.eval_with_hooks(expression, Some(vec![&mut dap]), false) {
                 Ok(_result) => Ok(()),
                 Err(_diagnostics) => Err("unable to interpret expression".to_string()),
             }

--- a/components/clarinet-cli/src/generate/project.rs
+++ b/components/clarinet-cli/src/generate/project.rs
@@ -26,7 +26,7 @@ impl GetChangesForNewProject {
         telemetry_enabled: bool,
     ) -> Self {
         let project_path = if use_current_dir {
-            project_path.clone()
+            project_path
         } else {
             format!("{}/{}", project_path, project_name)
         };

--- a/components/clarinet-cli/src/lsp/native_bridge.rs
+++ b/components/clarinet-cli/src/lsp/native_bridge.rs
@@ -239,7 +239,7 @@ impl LanguageServer for LspNativeBridge {
                 notification = notification_response.notification.take();
             }
         }
-        for (location, mut diags) in aggregated_diagnostics.drain(..) {
+        for (location, mut diags) in aggregated_diagnostics.into_iter() {
             if let Ok(url) = location.to_url_string() {
                 self.client
                     .publish_diagnostics(
@@ -282,7 +282,7 @@ impl LanguageServer for LspNativeBridge {
             }
         }
 
-        for (location, mut diags) in aggregated_diagnostics.drain(..) {
+        for (location, mut diags) in aggregated_diagnostics.into_iter() {
             if let Ok(url) = location.to_url_string() {
                 self.client
                     .publish_diagnostics(

--- a/components/clarinet-deployments/src/diagnostic_digest.rs
+++ b/components/clarinet-deployments/src/diagnostic_digest.rs
@@ -100,7 +100,7 @@ impl DiagnosticsDigest {
             warnings,
             total,
             contracts_checked,
-            message: outputs.join("\n").to_string(),
+            message: outputs.join("\n"),
         }
     }
 

--- a/components/clarinet-deployments/src/onchain/mod.rs
+++ b/components/clarinet-deployments/src/onchain/mod.rs
@@ -130,8 +130,8 @@ pub fn encode_contract_call(
     let payload = TransactionContractCall {
         contract_name: contract_id.name.clone(),
         address: StacksAddress::from(contract_id.issuer.clone()),
-        function_name: function_name.clone(),
-        function_args: function_args.clone(),
+        function_name,
+        function_args,
     };
     sign_transaction_payload(
         account,

--- a/components/clarinet-files/src/project_manifest.rs
+++ b/components/clarinet-files/src/project_manifest.rs
@@ -255,7 +255,7 @@ impl ProjectManifest {
         };
 
         let project = ProjectConfig {
-            name: project_name.clone(),
+            name: project_name,
             requirements: None,
             description: project_manifest_file
                 .project

--- a/components/clarity-lsp/src/common/backend.rs
+++ b/components/clarity-lsp/src/common/backend.rs
@@ -167,7 +167,7 @@ pub async fn process_notification(
                 };
 
                 let issuer = metadata.and_then(|(_, deployer)| match deployer {
-                    ContractDeployer::ContractIdentifier(id) => Some(id.issuer.to_owned()),
+                    ContractDeployer::ContractIdentifier(id) => Some(id.issuer),
                     _ => None,
                 });
 

--- a/components/clarity-lsp/src/common/requests/completion.rs
+++ b/components/clarity-lsp/src/common/requests/completion.rs
@@ -541,7 +541,7 @@ pub fn build_default_native_keywords_list(version: ClarityVersion) -> Vec<Comple
                     kind: MarkupKind::Markdown,
                     value: api.description,
                 })),
-                insert_text: Some(api.snippet.clone()),
+                insert_text: Some(api.snippet),
                 insert_text_format: Some(InsertTextFormat::SNIPPET),
                 command: Some(command.clone()),
                 ..Default::default()
@@ -566,7 +566,7 @@ pub fn build_default_native_keywords_list(version: ClarityVersion) -> Vec<Comple
                     kind: MarkupKind::Markdown,
                     value: api.description,
                 })),
-                insert_text: Some(api.snippet.clone()),
+                insert_text: Some(api.snippet),
                 insert_text_format: Some(InsertTextFormat::SNIPPET),
                 command: Some(command.clone()),
                 ..Default::default()

--- a/components/clarity-lsp/src/common/state.rs
+++ b/components/clarity-lsp/src/common/state.rs
@@ -419,7 +419,7 @@ impl EditorState {
         Some(Hover {
             contents: lsp_types::HoverContents::Markup(lsp_types::MarkupContent {
                 kind: lsp_types::MarkupKind::Markdown,
-                value: documentation.to_string(),
+                value: documentation,
             }),
             range: None,
         })

--- a/components/clarity-repl/src/repl/debug/dap/mod.rs
+++ b/components/clarity-repl/src/repl/debug/dap/mod.rs
@@ -1004,8 +1004,8 @@ impl EvalHook for DAPDebugger {
             } else {
                 let stack_frame = StackFrame {
                     id: (stack_trace.len() as i32 + 1),
-                    name: current_function.to_string().clone(),
-                    source: Some(source.clone()),
+                    name: current_function.to_string(),
+                    source: Some(source),
                     line: expr.span.start_line,
                     column: expr.span.start_column,
                     end_line: Some(expr.span.end_line),

--- a/components/clarity-repl/src/repl/diagnostic.rs
+++ b/components/clarity-repl/src/repl/diagnostic.rs
@@ -2,9 +2,9 @@ use clarity::vm::diagnostic::{Diagnostic, Level};
 
 fn level_to_string(level: &Level) -> String {
     match level {
-        Level::Note => blue!("note:").to_string(),
-        Level::Warning => yellow!("warning:").to_string(),
-        Level::Error => red!("error:").to_string(),
+        Level::Note => blue!("note:"),
+        Level::Warning => yellow!("warning:"),
+        Level::Error => red!("error:"),
     }
 }
 

--- a/components/clarity-repl/src/repl/session.rs
+++ b/components/clarity-repl/src/repl/session.rs
@@ -252,7 +252,7 @@ impl Session {
         ) {
             Ok((mut output, result)) => {
                 if let EvaluationResult::Contract(contract_result) = result.result.clone() {
-                    let snippet = format!("→ .{} contract successfully stored. Use (contract-call? ...) for invoking the public functions:", contract_result.contract.contract_identifier.clone());
+                    let snippet = format!("→ .{} contract successfully stored. Use (contract-call? ...) for invoking the public functions:", contract_result.contract.contract_identifier);
                     output.push(green!(snippet));
                 };
                 (output, result.cost.clone(), Ok(result))
@@ -380,7 +380,7 @@ impl Session {
         ) {
             Ok((mut output, result)) => {
                 if let EvaluationResult::Contract(contract_result) = result.result {
-                    let snippet = format!("→ .{} contract successfully stored. Use (contract-call? ...) for invoking the public functions:", contract_result.contract.contract_identifier.clone());
+                    let snippet = format!("→ .{} contract successfully stored. Use (contract-call? ...) for invoking the public functions:", contract_result.contract.contract_identifier);
                     output.push(snippet.green().to_string());
                 };
                 output
@@ -474,8 +474,8 @@ impl Session {
         amount: u64,
         recipient: &str,
     ) -> Result<ExecutionResult, Vec<Diagnostic>> {
-        let snippet = format!("(stx-transfer? u{} tx-sender '{})", amount, recipient);
-        self.eval(snippet.clone(), false)
+        let snippet = format!("(stx-transfer? u{amount} tx-sender '{recipient})");
+        self.eval(snippet, false)
     }
 
     pub fn deploy_contract(
@@ -605,15 +605,13 @@ impl Session {
 
         let result = self
             .interpreter
-            .run(&contract.clone(), None, cost_track, Some(hooks));
+            .run(&contract, None, cost_track, Some(hooks));
 
         match result {
             Ok(result) => {
                 if let EvaluationResult::Contract(contract_result) = &result.result {
-                    self.contracts.insert(
-                        contract_identifier.clone(),
-                        contract_result.contract.clone(),
-                    );
+                    self.contracts
+                        .insert(contract_identifier, contract_result.contract.clone());
                 };
                 Ok(result)
             }
@@ -650,15 +648,13 @@ impl Session {
 
         let result = self
             .interpreter
-            .run(&contract.clone(), None, cost_track, eval_hooks);
+            .run(&contract, None, cost_track, eval_hooks);
 
         match result {
             Ok(result) => {
                 if let EvaluationResult::Contract(contract_result) = &result.result {
-                    self.contracts.insert(
-                        contract_identifier.clone(),
-                        contract_result.contract.clone(),
-                    );
+                    self.contracts
+                        .insert(contract_identifier, contract_result.contract.clone());
                 };
                 Ok(result)
             }
@@ -678,7 +674,7 @@ impl Session {
         let mut keys = self
             .api_reference
             .keys()
-            .map(|k| k.to_string())
+            .map(String::from)
             .collect::<Vec<String>>();
         keys.sort();
         keys
@@ -688,7 +684,7 @@ impl Session {
         let mut keys = self
             .keywords_reference
             .keys()
-            .map(|k| k.to_string())
+            .map(String::from)
             .collect::<Vec<String>>();
         keys.sort();
         keys

--- a/components/stacks-network/src/lib.rs
+++ b/components/stacks-network/src/lib.rs
@@ -202,8 +202,8 @@ async fn do_run_devnet(
         }
     } else {
         let moved_orchestrator_terminator_tx = orchestrator_terminator_tx.clone();
-        let moved_observer_command_tx = observer_command_tx.clone();
-        let moved_mining_command_tx = mining_command_tx.clone();
+        let moved_observer_command_tx = observer_command_tx;
+        let moved_mining_command_tx = mining_command_tx;
         let _ = ctrlc::set_handler(move || {
             let _ = moved_orchestrator_terminator_tx.send(true);
             let _ = moved_observer_command_tx.send(ObserverCommand::Terminate);

--- a/components/stacks-network/src/orchestrator.rs
+++ b/components/stacks-network/src/orchestrator.rs
@@ -1342,7 +1342,7 @@ start_height = {epoch_3_1}
             .id;
 
         ctx.try_log(|logger| slog::info!(logger, "Created container stacks-node: {}", container));
-        self.stacks_node_container_id = Some(container.clone());
+        self.stacks_node_container_id = Some(container);
 
         Ok(())
     }
@@ -1504,7 +1504,7 @@ db_path = "stacks-signer-{signer_id}.sqlite"
                 container
             )
         });
-        self.stacks_signers_containers_ids.push(container.clone());
+        self.stacks_signers_containers_ids.push(container);
 
         Ok(())
     }
@@ -1512,9 +1512,8 @@ db_path = "stacks-signer-{signer_id}.sqlite"
     pub async fn boot_stacks_signer_container(&mut self, signer_id: u32) -> Result<(), String> {
         let container = self.stacks_signers_containers_ids[signer_id as usize].clone();
 
-        let docker = match &self.docker_client {
-            Some(ref docker) => docker,
-            _ => return Err("unable to get Docker client".into()),
+        let Some(docker) = &self.docker_client else {
+            return Err("unable to get Docker client".into());
         };
 
         docker
@@ -1750,7 +1749,7 @@ events_keys = ["*"]
             .id;
 
         ctx.try_log(|logger| slog::info!(logger, "Created container subnet-node: {}", container));
-        self.subnet_node_container_id = Some(container.clone());
+        self.subnet_node_container_id = Some(container);
 
         Ok(())
     }

--- a/components/stacks-network/src/ui/ui.rs
+++ b/components/stacks-network/src/ui/ui.rs
@@ -343,7 +343,7 @@ fn draw_help(f: &mut Frame, app: &mut App, area: Rect) {
     // let help =
     //     " ⬅️  ➡️  Explore blocks          ⬆️  ⬇️  Explore transactions          0️⃣  Genesis Reset";
     let help = format!(" ⬅️  ➡️  Explore blocks          Path: {}", app.devnet_path);
-    let paragraph = Paragraph::new(help.clone())
+    let paragraph = Paragraph::new(help)
         .style(Style::default().fg(Color::White))
         .block(Block::default().borders(Borders::NONE));
 

--- a/components/stacks-rpc-client/src/crypto.rs
+++ b/components/stacks-rpc-client/src/crypto.rs
@@ -117,8 +117,8 @@ pub fn encode_contract_call(
     let payload = TransactionContractCall {
         contract_name: contract_id.name.clone(),
         address: StacksAddress::from(contract_id.issuer.clone()),
-        function_name: function_name.clone(),
-        function_args: function_args.clone(),
+        function_name,
+        function_args,
     };
     sign_transaction_payload(
         wallet,


### PR DESCRIPTION
### Description

I've been doing some code cleanup on stacks-core, so I thought I'd try it on this repo also. This repo is already configured to use Clippy, which is great, but by default Clippy does not apply it's "nursery" (experimental) lints. Some of these can be useful and are worth applying. Specifically, I checked the following:

```
clear_with_drain
collection_is_never_read
needless_collect
iter_with_drain
mutex_integer
set_contains_or_insert
trivial_regex
useless_let_if_seq
unused_rounding
unnecessary_struct_initialization
tuple_array_conversions
```

Only `redundant_clone` and `clear_with_drain` resulted in any changes

#### Breaking change?

No

### Example

This can make the code more clear and improve performance by removing unnecessary function calls. For example, one change I made was:

```rust
fn level_to_string(level: &Level) -> String {
    match level {
        Level::Note => blue!("note:").to_string(),
        Level::Warning => yellow!("warning:").to_string(),
        Level::Error => red!("error:").to_string(),
    }
}
```

to

```rust
fn level_to_string(level: &Level) -> String {
    match level {
        Level::Note => blue!("note:"),
        Level::Warning => yellow!("warning:"),
        Level::Error => red!("error:"),
    }
}
```

### Checklist

- [ ] Tests added in this PR (if applicable)

