### PR TITLE
fix unit test: update error expected format

### DIFF
--- a/components/clarity-repl/src/repl/session.rs
+++ b/components/clarity-repl/src/repl/session.rs
@@ -1522,7 +1522,7 @@ mod tests {
             result.split('\n').next().unwrap(),
             format!(
                 "encode:1:1: {} use of unresolved function 'foo'",
-                "error:".red()
+                "error:".bold().red()
             )
         );
     }


### PR DESCRIPTION
### Description

The error has `bold` as format, but that wasn't expected on the assert. I've updated the assert.