### PR TITLE
refactor: remove tiny hderive

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -85,7 +85,7 @@ jobs:
         run: cargo install cargo-audit
 
       - name: Run audit
-        run: cargo audit --ignore RUSTSEC-2022-0093 --ignore RUSTSEC-2021-0076 --ignore RUSTSEC-2022-0090 --ignore RUSTSEC-2022-002 --ignore RUSTSEC-2022-0028 --ignore RUSTSEC-2024-0344 --ignore RUSTSEC-2024-0399
+        run: cargo audit --ignore RUSTSEC-2024-0344 --ignore RUSTSEC-2022-0028 --ignore RUSTSEC-2024-0399
 
       - name: Run rustfmt
         run: cargo fmt --all -- --check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,10 +252,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "base58"
-version = "0.1.0"
+name = "base16ct"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5024ee8015f02155eee35c711107ddd9a9bf3cb689cf2a9089c97e79b6e1ae83"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base58"
@@ -315,13 +315,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "bip39"
-version = "1.0.1"
+name = "bip32"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e89470017230c38e52b82b3ee3f530db1856ba1d434e3a67a3456a8a8dec5f"
+checksum = "db40d3dfbeab4e031d78c844642fa0caa0b0db11ce1607ac9d2986dff1405c69"
 dependencies = [
- "bitcoin_hashes 0.9.7",
- "rand_core 0.4.2",
+ "bs58",
+ "hmac 0.12.1",
+ "k256",
+ "once_cell",
+ "pbkdf2",
+ "rand_core 0.6.4",
+ "ripemd",
+ "secp256k1 0.27.0",
+ "sha2 0.10.8",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -332,7 +341,7 @@ checksum = "6c85783c2fe40083ea54a33aa2f0ba58831d90fcd190f5bdc47e74e84d2a96ae"
 dependencies = [
  "bech32",
  "bitcoin-internals",
- "bitcoin_hashes 0.13.0",
+ "bitcoin_hashes",
  "hex-conservative",
  "hex_lit",
  "secp256k1 0.28.2",
@@ -347,12 +356,6 @@ checksum = "9425c3bf7089c983facbae04de54513cce73b41c7f9ff8c845b54e7bc64ebbfb"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "bitcoin_hashes"
-version = "0.9.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ce18265ec2324ad075345d5814fbeed4f41f0a660055dc78840b74d19b874b1"
 
 [[package]]
 name = "bitcoin_hashes"
@@ -403,18 +406,6 @@ checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
 name = "block-buffer"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
-dependencies = [
- "block-padding",
- "byte-tools",
- "byteorder",
- "generic-array 0.12.4",
-]
-
-[[package]]
-name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
@@ -429,15 +420,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
 dependencies = [
  "generic-array 0.14.6",
-]
-
-[[package]]
-name = "block-padding"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
-dependencies = [
- "byte-tools",
 ]
 
 [[package]]
@@ -485,16 +467,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "sha2 0.10.8",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
-
-[[package]]
-name = "byte-tools"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "bytemuck"
@@ -561,7 +546,7 @@ name = "chainhook-sdk"
 version = "0.12.11"
 source = "git+https://github.com/hirosystems/chainhook.git#c9675894655293167be51d29d3c935eb10c3e195"
 dependencies = [
- "base58 0.2.0",
+ "base58",
  "base64 0.21.7",
  "bitcoincore-rpc",
  "bitcoincore-rpc-json",
@@ -724,7 +709,7 @@ dependencies = [
 name = "clarinet-deployments"
 version = "2.12.0"
 dependencies = [
- "base58 0.2.0",
+ "base58",
  "base64 0.21.7",
  "bitcoin",
  "bitcoincore-rpc",
@@ -742,14 +727,12 @@ dependencies = [
  "serde_yaml",
  "stacks-codec",
  "stacks-rpc-client",
- "tiny-hderive",
 ]
 
 [[package]]
 name = "clarinet-files"
 version = "2.12.0"
 dependencies = [
- "bip39",
  "bitcoin",
  "clarinet-utils",
  "clarity",
@@ -761,7 +744,6 @@ dependencies = [
  "serde-wasm-bindgen",
  "serde_derive",
  "serde_json",
- "tiny-hderive",
  "toml 0.5.11",
  "url",
  "wasm-bindgen",
@@ -794,9 +776,8 @@ dependencies = [
 name = "clarinet-utils"
 version = "1.0.0"
 dependencies = [
- "hmac 0.12.1",
- "pbkdf2",
- "sha2 0.10.8",
+ "bip32",
+ "libsecp256k1 0.7.1",
 ]
 
 [[package]]
@@ -1184,6 +1165,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array 0.14.6",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1195,22 +1188,12 @@ dependencies = [
 
 [[package]]
 name = "crypto-mac"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
-dependencies = [
- "generic-array 0.12.4",
- "subtle 1.0.0",
-]
-
-[[package]]
-name = "crypto-mac"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
  "generic-array 0.14.6",
- "subtle 2.6.1",
+ "subtle",
 ]
 
 [[package]]
@@ -1260,7 +1243,7 @@ dependencies = [
  "digest 0.8.1",
  "rand_core 0.5.1",
  "serde",
- "subtle 2.6.1",
+ "subtle",
  "zeroize",
 ]
 
@@ -1277,7 +1260,7 @@ dependencies = [
  "fiat-crypto",
  "platforms",
  "rustc_version",
- "subtle 2.6.1",
+ "subtle",
  "zeroize",
 ]
 
@@ -1447,8 +1430,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.3",
+ "const-oid",
  "crypto-common",
- "subtle 2.6.1",
+ "subtle",
 ]
 
 [[package]]
@@ -1545,6 +1529,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9b0705efd4599c15a38151f4721f7bc388306f61084d3bfd50bd07fbca5cb60"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest 0.10.7",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+]
+
+[[package]]
 name = "ed25519"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1566,7 +1563,7 @@ dependencies = [
  "rand_core 0.6.4",
  "serde",
  "sha2 0.10.8",
- "subtle 2.6.1",
+ "subtle",
  "zeroize",
 ]
 
@@ -1575,6 +1572,24 @@ name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest 0.10.7",
+ "ff",
+ "generic-array 0.14.6",
+ "group",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "encode_unicode"
@@ -1630,12 +1645,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0474425d51df81997e2f90a21591180b38eccf27292d755f3e30750225c175b"
 
 [[package]]
-name = "fake-simd"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
-
-[[package]]
 name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1668,6 +1677,16 @@ dependencies = [
  "cfg-if 1.0.0",
  "rustix",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "ff"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -1878,6 +1897,7 @@ checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -1949,6 +1969,17 @@ dependencies = [
  "serde_json",
  "wasm-bindgen",
  "web-sys",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -2096,21 +2127,11 @@ dependencies = [
 
 [[package]]
 name = "hmac"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dcb5e64cda4c23119ab41ba960d1e170a774c8e4b9d9e6a9bc18aabf5e59695"
-dependencies = [
- "crypto-mac 0.7.0",
- "digest 0.8.1",
-]
-
-[[package]]
-name = "hmac"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
 dependencies = [
- "crypto-mac 0.8.0",
+ "crypto-mac",
  "digest 0.9.0",
 ]
 
@@ -2121,17 +2142,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
-]
-
-[[package]]
-name = "hmac-drbg"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6e570451493f10f6581b48cdd530413b63ea9e780f544bfd3bdcaa0d89d1a7b"
-dependencies = [
- "digest 0.8.1",
- "generic-array 0.12.4",
- "hmac 0.7.1",
 ]
 
 [[package]]
@@ -2301,9 +2311,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.8"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da62f120a8a37763efb0cf8fdf264b884c7b8b9ac8660b900c8661030c00e6ba"
+checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2314,7 +2324,6 @@ dependencies = [
  "pin-project-lite",
  "socket2 0.5.5",
  "tokio",
- "tower",
  "tower-service",
  "tracing",
 ]
@@ -2646,6 +2655,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "k256"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
+dependencies = [
+ "cfg-if 1.0.0",
+ "ecdsa",
+ "elliptic-curve",
+ "sha2 0.10.8",
+]
+
+[[package]]
 name = "keccak"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2694,22 +2715,6 @@ dependencies = [
 
 [[package]]
 name = "libsecp256k1"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc1e2c808481a63dc6da2074752fdd4336a3c8fcc68b83db6f1fd5224ae7962"
-dependencies = [
- "arrayref",
- "crunchy",
- "digest 0.8.1",
- "hmac-drbg 0.2.0",
- "rand 0.7.3",
- "sha2 0.8.2",
- "subtle 2.6.1",
- "typenum",
-]
-
-[[package]]
-name = "libsecp256k1"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd1137239ab33b41aa9637a88a28249e5e70c40a42ccc92db7f12cc356c1fcd7"
@@ -2717,7 +2722,7 @@ dependencies = [
  "arrayref",
  "base64 0.12.3",
  "digest 0.9.0",
- "hmac-drbg 0.3.0",
+ "hmac-drbg",
  "libsecp256k1-core 0.2.2",
  "libsecp256k1-gen-ecmult 0.2.1",
  "libsecp256k1-gen-genmult 0.2.1",
@@ -2736,7 +2741,7 @@ dependencies = [
  "arrayref",
  "base64 0.13.1",
  "digest 0.9.0",
- "hmac-drbg 0.3.0",
+ "hmac-drbg",
  "libsecp256k1-core 0.3.0",
  "libsecp256k1-gen-ecmult 0.3.0",
  "libsecp256k1-gen-genmult 0.3.0",
@@ -2754,7 +2759,7 @@ checksum = "d0f6ab710cec28cef759c5f18671a27dae2a5f952cdaaee1d8e2908cb2478a80"
 dependencies = [
  "crunchy",
  "digest 0.9.0",
- "subtle 2.6.1",
+ "subtle",
 ]
 
 [[package]]
@@ -2765,7 +2770,7 @@ checksum = "5be9b9bb642d8522a44d533eab56c16c738301965504753b03ad1de3425d5451"
 dependencies = [
  "crunchy",
  "digest 0.9.0",
- "subtle 2.6.1",
+ "subtle",
 ]
 
 [[package]]
@@ -2978,12 +2983,6 @@ checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
  "autocfg",
 ]
-
-[[package]]
-name = "memzero"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93c0d11ac30a033511ae414355d80f70d9f29a44a49140face477117a1ee90db"
 
 [[package]]
 name = "mime"
@@ -3328,12 +3327,6 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "opaque-debug"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
-
-[[package]]
-name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
@@ -3368,17 +3361,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "password-hash"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
-dependencies = [
- "base64ct",
- "rand_core 0.6.4",
- "subtle 2.6.1",
-]
-
-[[package]]
 name = "paste"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3392,8 +3374,6 @@ checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest 0.10.7",
  "hmac 0.12.1",
- "password-hash",
- "sha2 0.10.8",
 ]
 
 [[package]]
@@ -3710,12 +3690,6 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
-
-[[package]]
-name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
@@ -3896,9 +3870,9 @@ checksum = "56d84fdd47036b038fc80dd333d10b6aab10d5d31f4a366e20014def75328d33"
 
 [[package]]
 name = "reqwest"
-version = "0.12.9"
+version = "0.12.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77c62af46e79de0a562e1a9849205ffcb7fc1238876e9bd743357570e04046f"
+checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3928,6 +3902,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tower 0.5.2",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -3935,6 +3910,16 @@ dependencies = [
  "web-sys",
  "webpki-roots",
  "windows-registry",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac 0.12.1",
+ "subtle",
 ]
 
 [[package]]
@@ -4145,7 +4130,7 @@ dependencies = [
  "ring",
  "rustls-pki-types",
  "rustls-webpki",
- "subtle 2.6.1",
+ "subtle",
  "zeroize",
 ]
 
@@ -4260,6 +4245,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
 
 [[package]]
+name = "sec1"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48518a2b5775ba8ca5b46596aae011caa431e6ce7e4a67ead66d92f08884220e"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array 0.14.6",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "secp256k1"
 version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4271,11 +4269,20 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
+dependencies = [
+ "secp256k1-sys 0.8.1",
+]
+
+[[package]]
+name = "secp256k1"
 version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d24b59d129cdadea20aea4fb2352fa053712e5d713eee47d700cd4b2bc002f10"
 dependencies = [
- "bitcoin_hashes 0.13.0",
+ "bitcoin_hashes",
  "rand 0.8.5",
  "secp256k1-sys 0.9.2",
  "serde",
@@ -4286,6 +4293,15 @@ name = "secp256k1-sys"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83080e2c2fc1006e625be82e5d1eb6a43b7fd9578b617fcc55814daf286bba4b"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70a129b9e9efbfb223753b9163c4ab3b13cff7fd9c7f010fbac25ab4099fa07e"
 dependencies = [
  "cc",
 ]
@@ -4472,18 +4488,6 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a256f46ea78a0c0d9ff00077504903ac881a1dafdc20da66545699e7776b3e69"
-dependencies = [
- "block-buffer 0.7.3",
- "digest 0.8.1",
- "fake-simd",
- "opaque-debug 0.2.3",
-]
-
-[[package]]
-name = "sha2"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
@@ -4492,7 +4496,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.9.0",
- "opaque-debug 0.3.0",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -4571,6 +4575,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -4805,6 +4810,7 @@ version = "2.12.0"
 dependencies = [
  "clarinet-deployments",
  "clarinet-files",
+ "clarinet-utils",
  "error-chain",
  "hiro-system-kit 0.1.0",
  "neon",
@@ -4819,7 +4825,7 @@ version = "2.12.0"
 dependencies = [
  "ansi_term",
  "atty",
- "base58 0.2.0",
+ "base58",
  "bitcoincore-rpc",
  "bollard",
  "chainhook-sdk",
@@ -4854,17 +4860,14 @@ dependencies = [
 name = "stacks-rpc-client"
 version = "2.12.0"
 dependencies = [
+ "clarinet-utils",
  "clarity",
- "hmac 0.12.1",
  "libsecp256k1 0.7.1",
- "pbkdf2",
  "reqwest",
  "serde",
  "serde_derive",
  "serde_json",
- "sha2 0.10.8",
  "stacks-codec",
- "tiny-hderive",
 ]
 
 [[package]]
@@ -4973,12 +4976,6 @@ dependencies = [
  "rustversion",
  "syn 2.0.82",
 ]
-
-[[package]]
-name = "subtle"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 
 [[package]]
 name = "subtle"
@@ -5209,19 +5206,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tiny-hderive"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01b874a4992538d4b2f4fbbac11b9419d685f4b39bdc3fed95b04e07bfd76040"
-dependencies = [
- "base58 0.1.0",
- "hmac 0.7.1",
- "libsecp256k1 0.3.5",
- "memzero",
- "sha2 0.8.2",
-]
-
-[[package]]
 name = "tinystr"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5364,6 +5348,20 @@ dependencies = [
  "futures-util",
  "pin-project",
  "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -5371,9 +5369,9 @@ dependencies = [
 
 [[package]]
 name = "tower-layer"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-lsp"
@@ -5393,7 +5391,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-util",
- "tower",
+ "tower 0.4.13",
  "tower-lsp-macros",
  "tracing",
 ]
@@ -5411,9 +5409,9 @@ dependencies = [
 
 [[package]]
 name = "tower-service"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"

--- a/components/clarinet-deployments/Cargo.toml
+++ b/components/clarinet-deployments/Cargo.toml
@@ -23,7 +23,6 @@ bitcoincore-rpc = { version = "0.18.0", optional = true }
 bitcoincore-rpc-json = { version = "0.18.0", optional = true }
 base58 = { version = "0.2.0", optional = true }
 base64 = "0.21.3"
-tiny-hderive = { version = "0.3.0", optional = true }
 libsecp256k1 = { version = "0.7.0", optional = true }
 
 clarity = { workspace = true }
@@ -38,7 +37,6 @@ onchain = [
     "bitcoincore-rpc",
     "bitcoincore-rpc-json",
     "base58",
-    "tiny-hderive",
     "libsecp256k1",
     "clarinet-utils",
 ]

--- a/components/clarinet-files/Cargo.toml
+++ b/components/clarinet-files/Cargo.toml
@@ -11,7 +11,7 @@ serde_derive = "1"
 toml = { version = "0.5.6", features = ["preserve_order"] }
 url = { version = "2.2.2", features = ["serde"] }
 bitcoin = { version = "0.31.2", optional = true }
-libsecp256k1 = { version = "0.7.0", optional = true }
+libsecp256k1 = "0.7.0"
 lazy_static = { workspace = true}
 
 clarity = { workspace = true }
@@ -30,11 +30,7 @@ web-sys = { workspace = true, features = ["console"], optional = true }
 
 [features]
 default = ["cli"]
-cli = [
-  "bitcoin",
-  "clarity-repl/sdk",
-  "libsecp256k1"
-]
+cli = ["bitcoin", "clarity-repl/sdk"]
 wasm = [
   "js-sys",
   "web-sys",

--- a/components/clarinet-files/Cargo.toml
+++ b/components/clarinet-files/Cargo.toml
@@ -8,12 +8,10 @@ license = "GPL-3.0"
 [dependencies]
 serde = "1"
 serde_derive = "1"
-bip39 = { version = "1.0.1", default-features = false }
-libsecp256k1 = "0.7.0"
 toml = { version = "0.5.6", features = ["preserve_order"] }
 url = { version = "2.2.2", features = ["serde"] }
-tiny-hderive = "0.3.0"
 bitcoin = { version = "0.31.2", optional = true }
+libsecp256k1 = { version = "0.7.0", optional = true }
 lazy_static = { workspace = true}
 
 clarity = { workspace = true }
@@ -32,7 +30,11 @@ web-sys = { workspace = true, features = ["console"], optional = true }
 
 [features]
 default = ["cli"]
-cli = ["bitcoin", "clarity-repl/sdk"]
+cli = [
+  "bitcoin",
+  "clarity-repl/sdk",
+  "libsecp256k1"
+]
 wasm = [
   "js-sys",
   "web-sys",

--- a/components/clarinet-files/src/lib.rs
+++ b/components/clarinet-files/src/lib.rs
@@ -3,7 +3,6 @@ extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 
-pub extern crate bip39;
 pub extern crate url;
 
 mod network_manifest;

--- a/components/clarinet-files/src/lib.rs
+++ b/components/clarinet-files/src/lib.rs
@@ -3,8 +3,6 @@ extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 
-pub extern crate url;
-
 pub mod clarinetrc;
 
 mod network_manifest;

--- a/components/clarinet-files/src/network_manifest.rs
+++ b/components/clarinet-files/src/network_manifest.rs
@@ -1,14 +1,16 @@
 use std::collections::BTreeMap;
 
-use super::{FileAccessor, FileLocation};
 use clarinet_utils::{get_bip32_keys_from_mnemonic, mnemonic_from_phrase, random_mnemonic};
 use clarity::address::AddressHashMode;
 use clarity::types::chainstate::{StacksAddress, StacksPrivateKey};
 use clarity::util::{hash::bytes_to_hex, secp256k1::Secp256k1PublicKey};
 use clarity::vm::types::QualifiedContractIdentifier;
 use lazy_static::lazy_static;
+use libsecp256k1::PublicKey;
 use serde::Serialize;
 use toml::value::Value;
+
+use super::{FileAccessor, FileLocation};
 
 pub const DEFAULT_DERIVATION_PATH: &str = "m/44'/5757'/0'/0/0";
 
@@ -1141,7 +1143,7 @@ pub fn compute_addresses(
 }
 
 #[cfg(not(feature = "wasm"))]
-fn compute_btc_address(public_key: &libsecp256k1::PublicKey, network: &BitcoinNetwork) -> String {
+fn compute_btc_address(public_key: &PublicKey, network: &BitcoinNetwork) -> String {
     let public_key = bitcoin::PublicKey::from_slice(&public_key.serialize_compressed())
         .expect("Unable to recreate public key");
     let btc_address = bitcoin::Address::p2pkh(

--- a/components/clarinet-utils/Cargo.toml
+++ b/components/clarinet-utils/Cargo.toml
@@ -6,9 +6,8 @@ license = "MIT"
 edition = "2021"
 
 [dependencies]
-hmac = "0.12.0"
-pbkdf2 = { version = "0.12.2", features = ["simple"], default-features = false }
-sha2 = "0.10.0"
+bip32 =  { version = "0.5.3", features = ["mnemonic"] }
+libsecp256k1 = "0.7.0"
 
 [lib]
 name = "clarinet_utils"

--- a/components/stacks-devnet-js/Cargo.toml
+++ b/components/stacks-devnet-js/Cargo.toml
@@ -13,6 +13,7 @@ serde = "1"
 error-chain = "0.12"
 clarinet-files = { path = "../clarinet-files" }
 clarinet-deployments = { path = "../clarinet-deployments" }
+clarinet-utils = { path = "../clarinet-utils" }
 stacks-network = { path = "../stacks-network" }
 hiro-system-kit = { path = "../hiro-system-kit" }
 

--- a/components/stacks-devnet-js/src/lib.rs
+++ b/components/stacks-devnet-js/src/lib.rs
@@ -5,11 +5,11 @@ extern crate error_chain;
 mod serde;
 
 use clarinet_deployments::{get_default_deployment_path, load_deployment};
-use clarinet_files::bip39::{Language, Mnemonic};
 use clarinet_files::{
     compute_addresses, AccountConfig, DevnetConfigFile, FileLocation, PoxStackingOrder,
     ProjectManifest, StacksNetwork, DEFAULT_DERIVATION_PATH,
 };
+use clarinet_utils::mnemonic_from_phrase;
 use hiro_system_kit::{o, slog, slog_async, slog_term, Drain};
 use neon::context::Context as NeonContext;
 use stacks_network::chainhook_sdk::types::{
@@ -397,14 +397,12 @@ impl StacksDevnet {
                 .downcast_or_throw::<JsString, _>(&mut cx)?
                 .value(&mut cx);
 
-            let words = account_settings
+            let phrase = account_settings
                 .get(&mut cx, "mnemonic")?
                 .downcast_or_throw::<JsString, _>(&mut cx)?
                 .value(&mut cx);
 
-            let mnemonic = Mnemonic::parse_in_normalized(Language::English, &words)
-                .unwrap()
-                .to_string();
+            let mnemonic = mnemonic_from_phrase(&phrase).unwrap().phrase().to_string();
 
             let balance = match account_settings
                 .get(&mut cx, "balance")?

--- a/components/stacks-devnet-js/src/lib.rs
+++ b/components/stacks-devnet-js/src/lib.rs
@@ -4,7 +4,6 @@ extern crate error_chain;
 
 mod serde;
 
-use bip39::{Language, Mnemonic};
 use clarinet_deployments::{get_default_deployment_path, load_deployment};
 use clarinet_files::{
     compute_addresses, AccountConfig, DevnetConfigFile, FileLocation, PoxStackingOrder,

--- a/components/stacks-rpc-client/Cargo.toml
+++ b/components/stacks-rpc-client/Cargo.toml
@@ -10,11 +10,8 @@ serde = "1"
 serde_json = "1"
 serde_derive = "1"
 reqwest = { workspace = true, features = ["blocking"] }
-hmac = "0.12.0"
-pbkdf2 = { version = "0.12.2", features = ["simple"], default-features = false }
-sha2 = "0.10.0"
-tiny-hderive = { version = "0.3.0" }
 libsecp256k1 = { version = "0.7.0" }
 
 clarity = { workspace = true }
+clarinet-utils = { version = "1", path = "../clarinet-utils" }
 stacks-codec = { version = "2", package = "stacks-codec", path = "../stacks-codec" }

--- a/components/stacks-rpc-client/src/crypto.rs
+++ b/components/stacks-rpc-client/src/crypto.rs
@@ -1,5 +1,6 @@
 use std::str::FromStr;
 
+use clarinet_utils::get_bip32_keys_from_mnemonic;
 use stacks_codec::codec::*;
 
 use clarity::address::{
@@ -10,11 +11,7 @@ use clarity::types::chainstate::StacksAddress;
 use clarity::util::secp256k1::{MessageSignature, Secp256k1PrivateKey, Secp256k1PublicKey};
 use clarity::vm::types::{PrincipalData, QualifiedContractIdentifier};
 use clarity::vm::{ClarityName, ClarityVersion, ContractName, Value as ClarityValue};
-use hmac::Hmac;
-use libsecp256k1::{PublicKey, SecretKey};
-use pbkdf2::pbkdf2;
-use sha2::Sha512;
-use tiny_hderive::bip32::ExtendedPrivKey;
+use libsecp256k1::PublicKey;
 
 #[derive(Clone, Debug)]
 pub struct Wallet {
@@ -52,14 +49,9 @@ pub fn compute_stacks_address(public_key: &PublicKey, mainnet: bool) -> StacksAd
 }
 
 pub fn compute_keypair(wallet: &Wallet) -> Keypair {
-    let bip39_seed = match get_bip39_seed_from_mnemonic(&wallet.mnemonic, "") {
-        Ok(bip39_seed) => bip39_seed,
-        Err(_) => panic!(),
-    };
-    let ext = ExtendedPrivKey::derive(&bip39_seed[..], wallet.derivation.as_str()).unwrap();
-    let wrapped_secret_key = Secp256k1PrivateKey::from_slice(&ext.secret()).unwrap();
-    let secret_key = SecretKey::parse_slice(&ext.secret()).unwrap();
-    let public_key = PublicKey::from_secret_key(&secret_key);
+    let (secret_bytes, public_key) =
+        get_bip32_keys_from_mnemonic(&wallet.mnemonic, "", &wallet.derivation).unwrap();
+    let wrapped_secret_key = Secp256k1PrivateKey::from_slice(&secret_bytes).unwrap();
     Keypair {
         secret_key: wrapped_secret_key,
         public_key,
@@ -170,20 +162,4 @@ pub fn encode_contract_publish(
         tx_fee,
         anchor_mode,
     )
-}
-
-pub fn get_bip39_seed_from_mnemonic(mnemonic: &str, password: &str) -> Result<Vec<u8>, String> {
-    const PBKDF2_ROUNDS: u32 = 2048;
-    const PBKDF2_BYTES: usize = 64;
-    let salt = format!("mnemonic{}", password);
-    let mut seed = vec![0u8; PBKDF2_BYTES];
-
-    pbkdf2::<Hmac<Sha512>>(
-        mnemonic.as_bytes(),
-        salt.as_bytes(),
-        PBKDF2_ROUNDS,
-        &mut seed,
-    )
-    .map_err(|e| e.to_string())?;
-    Ok(seed)
 }

--- a/components/stacks-rpc-client/src/lib.rs
+++ b/components/stacks-rpc-client/src/lib.rs
@@ -1,5 +1,3 @@
-#![allow(unused_imports)]
-
 extern crate serde;
 
 #[macro_use]

--- a/components/stacks-rpc-client/src/rpc_client.rs
+++ b/components/stacks-rpc-client/src/rpc_client.rs
@@ -1,5 +1,3 @@
-use std::fs::File;
-use std::io::prelude::*;
 use std::io::Cursor;
 
 use clarity::codec::StacksMessageCodec;


### PR DESCRIPTION
### Description

Just some maintenance work.

- remove `tiny-hderive` - it's old and unmaintained and brought a lot of old version of [other dependencies](https://crates.io/crates/tiny-hderive/0.3.0/dependencies)
- also update reqwest