### PR TITLE
fix: vscode extension

### DIFF
--- a/components/clarinet-cli/Cargo.toml
+++ b/components/clarinet-cli/Cargo.toml
@@ -34,7 +34,7 @@ tower-lsp = { version = "0.19.0", optional = true }
 similar = "2.1.0"
 crossbeam-channel = "0.5.6"
 
-clarity_repl = { package = "clarity-repl", path = "../clarity-repl", features = [
+clarity-repl = { package = "clarity-repl", path = "../clarity-repl", features = [
     "cli",
 ] }
 clarinet-files = { path = "../clarinet-files", features = ["cli"] }

--- a/components/clarinet-cli/src/frontend/dap.rs
+++ b/components/clarinet-cli/src/frontend/dap.rs
@@ -13,7 +13,7 @@ pub fn run_dap() -> Result<(), String> {
     match dap.init() {
         Ok((manifest_location_str, expression)) => {
             let manifest_location = FileLocation::from_path_string(&manifest_location_str)?;
-            let project_manifest = ProjectManifest::from_location(&manifest_location)?;
+            let project_manifest = ProjectManifest::from_location(&manifest_location, false)?;
             let (deployment, artifacts) =
                 generate_default_deployment(&project_manifest, &StacksNetwork::Simnet, false)?;
             let mut session = setup_session_with_deployment(

--- a/components/clarinet-files/src/lib.rs
+++ b/components/clarinet-files/src/lib.rs
@@ -128,9 +128,6 @@ impl FileLocation {
                 path.extend(&path_to_append);
             }
             FileLocation::Url { url } => {
-                #[cfg(target_arch = "wasm32")]
-                web_sys::console::log_1(&format!("url: {}", url).into());
-
                 let mut paths_segments = url
                     .path_segments_mut()
                     .map_err(|_| "unable to mutate url")?;
@@ -266,9 +263,6 @@ impl FileLocation {
                 path.pop();
             }
             FileLocation::Url { url } => {
-                #[cfg(target_arch = "wasm32")]
-                web_sys::console::log_1(&format!("url: {}", url).into());
-
                 let mut segments = url
                     .path_segments_mut()
                     .map_err(|_| "unable to mutate url".to_string())?;

--- a/components/clarinet-sdk-wasm/Cargo.toml
+++ b/components/clarinet-sdk-wasm/Cargo.toml
@@ -42,6 +42,7 @@ wasm = [
   "console_error_panic_hook",
   "clarinet-deployments/wasm",
   "clarity-repl/wasm",
+  "clarity-repl/remote-data-fetching",
   "clarinet-files/wasm",
 ]
 

--- a/components/clarinet-sdk-wasm/src/core.rs
+++ b/components/clarinet-sdk-wasm/src/core.rs
@@ -396,7 +396,8 @@ impl SDK {
         manifest_location: &FileLocation,
     ) -> Result<ProjectCache, String> {
         let manifest =
-            ProjectManifest::from_file_accessor(manifest_location, &*self.file_accessor).await?;
+            ProjectManifest::from_file_accessor(manifest_location, true, &*self.file_accessor)
+                .await?;
         let project_root = manifest_location.get_parent_location()?;
         let deployment_plan_location =
             FileLocation::try_parse("deployments/default.simnet-plan.yaml", Some(&project_root))

--- a/components/clarinet-sdk/clarinet-sdk.code-workspace
+++ b/components/clarinet-sdk/clarinet-sdk.code-workspace
@@ -9,16 +9,5 @@
       "--tests",
       "--message-format=json",
     ],
-    "rust-analyzer.cargo.allTargets": false,
-    "rust-analyzer.cargo.target": "wasm32-unknown-unknown",
-    "rust-analyzer.check.workspace": false,
-    "rust-analyzer.cargo.buildScripts.overrideCommand": [
-      "cargo",
-      "build",
-      "--package=clarinet-sdk-wasm",
-      "--target=wasm32-unknown-unknown",
-      "--tests",
-      "--message-format=json",
-    ],
   },
 }

--- a/components/clarity-lsp/src/common/backend.rs
+++ b/components/clarity-lsp/src/common/backend.rs
@@ -145,10 +145,11 @@ pub async fn process_notification(
                     Some((clarity_version, _)) => clarity_version,
                     None => {
                         match file_accessor {
-                            None => ProjectManifest::from_location(&manifest_location),
+                            None => ProjectManifest::from_location(&manifest_location, false),
                             Some(file_accessor) => {
                                 ProjectManifest::from_file_accessor(
                                     &manifest_location,
+                                    false,
                                     file_accessor,
                                 )
                                 .await

--- a/components/clarity-lsp/src/common/state.rs
+++ b/components/clarity-lsp/src/common/state.rs
@@ -634,9 +634,9 @@ pub async fn build_state(
     // A on-disk deployment could quickly lead to an outdated
     // view of the repo.
     let manifest = match file_accessor {
-        None => ProjectManifest::from_location(manifest_location)?,
+        None => ProjectManifest::from_location(manifest_location, false)?,
         Some(file_accessor) => {
-            ProjectManifest::from_file_accessor(manifest_location, file_accessor).await?
+            ProjectManifest::from_file_accessor(manifest_location, false, file_accessor).await?
         }
     };
 

--- a/components/clarity-repl/Cargo.toml
+++ b/components/clarity-repl/Cargo.toml
@@ -78,7 +78,8 @@ name = "simnet"
 harness = false
 
 [features]
-default = ["cli", "dap"]
+default = ["cli", "dap", "remote-data-fetching"]
+remote-data-fetching = []
 sdk = [
     "clarity/canonical",
     "clarity/developer-mode",

--- a/components/clarity-repl/src/repl/remote_data.rs
+++ b/components/clarity-repl/src/repl/remote_data.rs
@@ -8,11 +8,11 @@ use clarity::vm::errors::InterpreterResult;
 use serde::de::Error as SerdeError;
 use serde::{de::DeserializeOwned, Deserialize, Deserializer};
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", feature = "remote-data-fetching"))]
 use js_sys::JsString;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", feature = "remote-data-fetching"))]
 use wasm_bindgen::prelude::*;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", feature = "remote-data-fetching"))]
 #[wasm_bindgen]
 #[derive(Deserialize)]
 struct JsHttpClientResponse {
@@ -20,7 +20,7 @@ struct JsHttpClientResponse {
     body: Vec<u8>,
 }
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", feature = "remote-data-fetching"))]
 #[wasm_bindgen(module = "/js/index.mjs")]
 extern "C" {
     #[wasm_bindgen(js_name = httpClient)]
@@ -236,7 +236,7 @@ impl HttpClient {
         response.json::<T>().map_err(|e| e.to_string())
     }
 
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(all(target_arch = "wasm32", feature = "remote-data-fetching"))]
     fn get<T: DeserializeOwned>(&self, path: &str) -> Result<T, String> {
         let url = JsString::from(format!("{}{}", self.url, path));
         let raw_response = http_client(&JsString::from("GET"), &url);
@@ -250,6 +250,11 @@ impl HttpClient {
             ));
         }
         serde_json::from_str::<T>(body).map_err(|e| e.to_string())
+    }
+
+    #[cfg(not(feature = "remote-data-fetching"))]
+    fn get<T: DeserializeOwned>(&self, _path: &str) -> Result<T, String> {
+        unreachable!()
     }
 
     pub fn fetch_info(&self) -> Info {

--- a/components/clarity-repl/src/repl/remote_data.rs
+++ b/components/clarity-repl/src/repl/remote_data.rs
@@ -252,7 +252,7 @@ impl HttpClient {
         serde_json::from_str::<T>(body).map_err(|e| e.to_string())
     }
 
-    #[cfg(not(feature = "remote-data-fetching"))]
+    #[cfg(all(target_arch = "wasm32", not(feature = "remote-data-fetching")))]
     fn get<T: DeserializeOwned>(&self, _path: &str) -> Result<T, String> {
         unreachable!()
     }

--- a/components/clarity-repl/src/repl/settings.rs
+++ b/components/clarity-repl/src/repl/settings.rs
@@ -79,7 +79,7 @@ impl fmt::Display for ApiUrl {
 #[derive(Debug, Default, Clone, Deserialize, Serialize)]
 pub struct Settings {
     pub analysis: analysis::Settings,
-    #[serde(skip_serializing)]
+    #[serde(skip_serializing_if = "RemoteDataSettings::is_disabled")]
     pub remote_data: RemoteDataSettings,
     #[serde(skip_serializing, skip_deserializing)]
     pub clarity_wasm_mode: bool,
@@ -171,5 +171,9 @@ impl RemoteDataSettings {
             stacks_tip_height: info.stacks_tip_height,
             is_mainnet: info.network_id == 1,
         })
+    }
+
+    pub fn is_disabled(&self) -> bool {
+        !self.enabled
     }
 }

--- a/components/clarity-vscode/web-extension.code-workspace
+++ b/components/clarity-vscode/web-extension.code-workspace
@@ -1,11 +1,11 @@
 {
   "folders": [
     {
-      "path": "./"
+      "path": "./",
     },
     {
-      "path": "../../"
-    }
+      "path": "../../",
+    },
   ],
   "settings": {
     "rust-analyzer.cargo.noDefaultFeatures": true,
@@ -13,10 +13,11 @@
     "rust-analyzer.check.overrideCommand": [
       "cargo",
       "clippy",
+      "--target=wasm32-unknown-unknown",
       "--no-default-features",
       "--package=clarity-lsp",
       "--features=wasm",
-      "--message-format=json"
-    ]
-  }
+      "--message-format=json",
+    ],
+  },
 }

--- a/components/stacks-devnet-js/src/lib.rs
+++ b/components/stacks-devnet-js/src/lib.rs
@@ -109,7 +109,7 @@ impl StacksDevnet {
         let channel = cx.channel();
 
         let manifest_location = get_manifest_location_or_exit(Some(manifest_location));
-        let manifest = ProjectManifest::from_location(&manifest_location)
+        let manifest = ProjectManifest::from_location(&manifest_location, false)
             .expect("Syntax error in Clarinet.toml.");
         let (deployment, _) =
             read_deployment_or_generate_default(&manifest, &StacksNetwork::Devnet)

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,18 +27,12 @@
     "components/clarinet-sdk-wasm/pkg-browser": {
       "name": "@hirosystems/clarinet-sdk-wasm-browser",
       "version": "2.12.0",
-      "license": "GPL-3.0",
-      "dependencies": {
-        "sync-request": "6.1.0"
-      }
+      "license": "GPL-3.0"
     },
     "components/clarinet-sdk-wasm/pkg-node": {
       "name": "@hirosystems/clarinet-sdk-wasm",
       "version": "2.12.0",
-      "license": "GPL-3.0",
-      "dependencies": {
-        "sync-request": "6.1.0"
-      }
+      "license": "GPL-3.0"
     },
     "components/clarinet-sdk/browser": {
       "name": "@hirosystems/clarinet-sdk-browser",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,12 +27,18 @@
     "components/clarinet-sdk-wasm/pkg-browser": {
       "name": "@hirosystems/clarinet-sdk-wasm-browser",
       "version": "2.12.0",
-      "license": "GPL-3.0"
+      "license": "GPL-3.0",
+      "dependencies": {
+        "sync-request": "6.1.0"
+      }
     },
     "components/clarinet-sdk-wasm/pkg-node": {
       "name": "@hirosystems/clarinet-sdk-wasm",
       "version": "2.12.0",
-      "license": "GPL-3.0"
+      "license": "GPL-3.0",
+      "dependencies": {
+        "sync-request": "6.1.0"
+      }
     },
     "components/clarinet-sdk/browser": {
       "name": "@hirosystems/clarinet-sdk-browser",


### PR DESCRIPTION
### Description

The VSCode was partially broken due to #1503 
The root cause it due to bundling issue: the [JS snippet](https://github.com/hirosystems/clarinet/blob/59e015b497b4b5d67463633b962079aa41506880/components/clarity-repl/js/index.mjs) that is needed to make synchronous http calls in the clarity-repl could not be loaded in the VScode JS environment.

Hopefully, the LSP doesn't need this feature, so let's just disable it with a cargo feature flag