### PR TITLE
fix: avoid empty deployment batches

### DIFF
--- a/components/clarinet-deployments/src/lib.rs
+++ b/components/clarinet-deployments/src/lib.rs
@@ -792,12 +792,14 @@ pub async fn generate_default_deployment(
     let mut batch_count = 0;
     for (epoch, epoch_transactions) in transactions {
         for txs in epoch_transactions.chunks(tx_chain_limit) {
-            batches.push(TransactionsBatchSpecification {
-                id: batch_count,
-                transactions: txs.to_vec(),
-                epoch: Some(epoch),
-            });
-            batch_count += 1;
+            if !txs.is_empty() {
+                batches.push(TransactionsBatchSpecification {
+                    id: batch_count,
+                    transactions: txs.to_vec(),
+                    epoch: Some(epoch),
+                });
+                batch_count += 1;
+            }
         }
     }
 


### PR DESCRIPTION
### Description

When automatically updating a deployments plan, if contracts where removed from a batch leaving it empty, we still keep the empty batch in the deployment plan

