### PR TITLE
fix: burn-block-height in at-block at epoch 3.x

### DIFF
--- a/components/clarity-repl/src/repl/datastore.rs
+++ b/components/clarity-repl/src/repl/datastore.rs
@@ -989,6 +989,15 @@ impl BurnStateDB for Datastore {
     }
 
     fn get_tip_burn_block_height(&self) -> Option<u32> {
+        // preserve the 3.0 and 3.1 special behavior of burn-block-height
+        // https://github.com/stacks-network/stacks-core/pull/5524
+        if matches!(
+            self.current_epoch,
+            StacksEpochId::Epoch30 | StacksEpochId::Epoch31
+        ) {
+            return Some(self.burn_chain_height);
+        }
+
         let current_chain_tip = self.current_chain_tip.borrow();
         if let Some(height) = self.get_burn_block_height_for_block(&current_chain_tip) {
             return Some(height);

--- a/components/clarity-repl/src/repl/datastore.rs
+++ b/components/clarity-repl/src/repl/datastore.rs
@@ -805,6 +805,7 @@ impl Datastore {
         if epoch == self.current_epoch {
             return;
         }
+        clarity_datastore.put("vm-epoch::epoch-version", &format!("{:08x}", epoch as u32));
         self.current_epoch = epoch;
         self.current_epoch_start_height = self.stacks_chain_height;
         if epoch >= StacksEpochId::Epoch30 {

--- a/components/clarity-repl/src/repl/session.rs
+++ b/components/clarity-repl/src/repl/session.rs
@@ -1885,7 +1885,7 @@ mod tests {
     }
 
     #[test]
-    fn burn_block_height_behavior_epoch3_0_edge() {
+    fn burn_block_height_behavior_epoch3_0_contract_in_2_5() {
         let settings = SessionSettings::default();
         let mut session = Session::new(settings);
         session.start().expect("session could not start");
@@ -1899,7 +1899,8 @@ mod tests {
         .join("\n");
 
         let contract = ClarityContractBuilder::new()
-            .code_source(snippet)
+            .name("contract-2-5")
+            .code_source(snippet.clone())
             .clarity_version(ClarityVersion::Clarity2)
             .epoch(StacksEpochId::Epoch25)
             .build();
@@ -1910,6 +1911,9 @@ mod tests {
         session.update_epoch(StacksEpochId::Epoch30);
 
         session.advance_burn_chain_tip(10);
+
+        let result = run_session_snippet(&mut session, "stacks-block-height");
+        assert_eq!(result, Value::UInt(21));
 
         // calling a 2.5 contract in epoch 3.0 has the same behavior as epoch 2.5
 
@@ -1923,6 +1927,6 @@ mod tests {
             &mut session,
             format!("(contract-call? .{} get-burn u18)", contract.name).as_str(),
         );
-        assert_eq!(result, Value::UInt(17));
+        assert_eq!(result, Value::UInt(21));
     }
 }

--- a/components/clarity-repl/src/repl/session.rs
+++ b/components/clarity-repl/src/repl/session.rs
@@ -1693,8 +1693,7 @@ mod tests {
 
         let _ = session.advance_burn_chain_tip(10000);
 
-        assert_eq!(session.process_console_input("(at-block (unwrap-panic (get-stacks-block-info? id-header-hash u19000)) burn-block-height)").1[0], "u18999".green().to_string());
-        assert_eq!(session.process_console_input("(at-block (unwrap-panic (get-stacks-block-info? id-header-hash u20000)) burn-block-height)").1[0], "u19999".green().to_string());
+        assert_eq!(session.process_console_input("(at-block (unwrap-panic (get-stacks-block-info? id-header-hash u19000)) burn-block-height)").1[0], "u20021".green().to_string());
     }
 
     #[test]

--- a/components/clarity-repl/tests/session_with_remote_data.rs
+++ b/components/clarity-repl/tests/session_with_remote_data.rs
@@ -154,7 +154,7 @@ fn it_can_get_heights() {
     assert_eq!(result, Value::UInt(42000));
     let snippet = format!("(at-block {hash} burn-block-height)");
     let result = eval_snippet(&mut session, &snippet);
-    assert_eq!(result, Value::UInt(5560));
+    assert_eq!(result, Value::UInt(6603));
     let snippet = format!("(at-block {hash} tenure-height)");
     let result = eval_snippet(&mut session, &snippet);
     assert_eq!(result, Value::UInt(3302));


### PR DESCRIPTION
### Description

Preserve burn-block-height behavior in 3.x
https://github.com/stacks-network/stacks-core/pull/5524

