### PR TITLE
ci: run sdk tests in node 20 and 22

### DIFF
--- a/.github/workflows/ci-sdk.yaml
+++ b/.github/workflows/ci-sdk.yaml
@@ -71,6 +71,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        node-version: [20.x, 22.x]
     needs: build_wasm
     steps:
       - name: Checkout
@@ -79,7 +80,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: ${{ matrix.node-version }}
 
       - name: Download Wasm artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/ci-sdk.yaml
+++ b/.github/workflows/ci-sdk.yaml
@@ -71,7 +71,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: [20.x, 22.x]
+        node-version: [22.x]
     needs: build_wasm
     steps:
       - name: Checkout


### PR DESCRIPTION
### Description

Run clarinet-sdk tests in node 20 and 22