### PR TITLE
refactor: use colored

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,15 +69,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "anstream"
 version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -222,17 +213,6 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi 0.3.9",
-]
 
 [[package]]
 name = "auto_impl"
@@ -589,7 +569,7 @@ dependencies = [
  "futures",
  "fxhash",
  "hex",
- "hiro-system-kit 0.3.4",
+ "hiro-system-kit",
  "hyper 0.14.27",
  "lazy_static",
  "miniscript",
@@ -708,18 +688,17 @@ dependencies = [
 name = "clarinet-cli"
 version = "2.13.0"
 dependencies = [
- "ansi_term",
- "atty",
  "clap",
  "clap_complete",
  "clarinet-deployments",
  "clarinet-files",
  "clarity-lsp",
  "clarity-repl",
+ "colored",
  "crossbeam-channel",
  "crossterm",
  "fwdansi",
- "hiro-system-kit 0.1.0",
+ "hiro-system-kit",
  "mac_address",
  "nix 0.24.2",
  "ratatui",
@@ -789,7 +768,6 @@ dependencies = [
  "clarinet-files",
  "clarity",
  "clarity-repl",
- "colored",
  "console_error_panic_hook",
  "gloo-utils",
  "js-sys",
@@ -869,8 +847,6 @@ dependencies = [
 name = "clarity-repl"
 version = "2.13.0"
 dependencies = [
- "ansi_term",
- "atty",
  "bytes",
  "chrono",
  "clar2wasm",
@@ -880,7 +856,7 @@ dependencies = [
  "divan",
  "futures",
  "getrandom 0.2.8",
- "hiro-system-kit 0.1.0",
+ "hiro-system-kit",
  "httparse",
  "js-sys",
  "log",
@@ -2111,15 +2087,6 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
@@ -2144,29 +2111,9 @@ checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
 
 [[package]]
 name = "hiro-system-kit"
-version = "0.1.0"
+version = "0.3.5"
 dependencies = [
- "ansi_term",
- "atty",
- "slog",
- "slog-async",
- "slog-atomic",
- "slog-json",
- "slog-scope",
- "slog-term",
- "time",
- "tokio",
-]
-
-[[package]]
-name = "hiro-system-kit"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d3bf5cf007a9973ef9b7dffe8d63fa5228e9bb1aa012e89da2b9f1e7119ce6e"
-dependencies = [
- "ansi_term",
- "atty",
- "lazy_static",
+ "colored",
  "slog",
  "slog-async",
  "slog-atomic",
@@ -2623,7 +2570,7 @@ version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "libc",
  "windows-sys 0.52.0",
 ]
@@ -3121,7 +3068,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
@@ -3372,16 +3319,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.9",
- "libc",
-]
-
-[[package]]
-name = "num_threads"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
-dependencies = [
+ "hermit-abi",
  "libc",
 ]
 
@@ -4769,11 +4707,11 @@ dependencies = [
 
 [[package]]
 name = "slog-term"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87d29185c55b7b258b4f120eab00f48557d4d9bc814f41713f449d35b0f8977c"
+checksum = "b6e022d0b998abfe5c3782c1f03551a596269450ccd677ea51c56f8b214610e8"
 dependencies = [
- "atty",
+ "is-terminal",
  "slog",
  "term",
  "thread_local",
@@ -4923,7 +4861,7 @@ dependencies = [
  "clarinet-files",
  "clarinet-utils",
  "error-chain",
- "hiro-system-kit 0.1.0",
+ "hiro-system-kit",
  "neon",
  "num",
  "serde",
@@ -4934,8 +4872,6 @@ dependencies = [
 name = "stacks-network"
 version = "2.13.0"
 dependencies = [
- "ansi_term",
- "atty",
  "base58",
  "bitcoincore-rpc",
  "bollard",
@@ -4946,12 +4882,13 @@ dependencies = [
  "clarinet-deployments",
  "clarinet-files",
  "clarity",
+ "colored",
  "crossbeam-channel",
  "crossterm",
  "ctrlc",
  "dirs",
  "futures",
- "hiro-system-kit 0.1.0",
+ "hiro-system-kit",
  "ratatui",
  "reqwest",
  "serde",
@@ -5311,9 +5248,7 @@ checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
- "libc",
  "num-conv",
- "num_threads",
  "powerfmt",
  "serde",
  "time-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ reqwest = { version = "0.12", default-features = false, features = [
     "json",
     "rustls-tls",
 ] }
-colored = { version = "3.0.0" }
+colored = { version = "3" }
 wasm-bindgen = { version = "=0.2.100" }
 wasm-bindgen-futures = { version = "=0.4.50" }
 web-sys = { version = "=0.3.77" }
@@ -35,6 +35,7 @@ web-sys = { version = "=0.3.77" }
 chainhook-sdk = { git = "https://github.com/hirosystems/chainhook.git" }
 chainhook-types = { git = "https://github.com/hirosystems/chainhook.git" }
 stacks-codec = { path = "./components/stacks-codec" }
+hiro-system-kit = { path = "./components/hiro-system-kit" }
 
 # [patch.'https://github.com/stacks-network/stacks-core.git']
 # clarity = { path = "../stacks-core/clarity" }

--- a/components/clarinet-cli/Cargo.toml
+++ b/components/clarinet-cli/Cargo.toml
@@ -16,7 +16,7 @@ categories = [
 ]
 
 [dependencies]
-ansi_term = "0.12.1"
+colored = { workspace = true }
 clap = { version = "4.4.8", features = ["derive"], optional = true }
 clap_complete = { version = "4.4.4", optional = true }
 toml = { version = "0.5.6", features = ["preserve_order"] }
@@ -24,7 +24,6 @@ serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1.0.79", features = ["preserve_order"] }
 serde_derive = "1"
 tokio = { version = "1.35.1", features = ["full"] }
-atty = "0.2.14"
 crossterm = "0.27.0"
 ratatui = { version = "0.27.0", default-features = false, features = ["crossterm"] }
 segment = { version = "0.2.4", optional = true }

--- a/components/clarinet-deployments/src/diagnostic_digest.rs
+++ b/components/clarinet-deployments/src/diagnostic_digest.rs
@@ -7,7 +7,7 @@ use clarity_repl::{
     },
     repl::diagnostic::output_code,
 };
-use colored::*;
+use colored::Colorize;
 
 use crate::types::DeploymentSpecification;
 

--- a/components/clarinet-sdk-wasm/Cargo.toml
+++ b/components/clarinet-sdk-wasm/Cargo.toml
@@ -21,7 +21,6 @@ serde-wasm-bindgen = { version = "0.6.4", optional = true }
 wasm-bindgen = { workspace = true, optional = true }
 wasm-bindgen-futures = { workspace = true, optional = true }
 web-sys = { workspace = true, features = ["console"], optional = true }
-colored = { workspace = true }
 
 clarinet-files = { path = "../clarinet-files", default-features = false }
 clarity-repl = { path = "../clarity-repl", default-features = false, optional = true }

--- a/components/clarinet-sdk/node/tests/simnet-usage.test.ts
+++ b/components/clarinet-sdk/node/tests/simnet-usage.test.ts
@@ -43,6 +43,11 @@ describe("basic simnet interactions", () => {
     expect(simnet.blockHeight).toBe(1);
   });
 
+  it("can run command", () => {
+    const r = simnet.executeCommand("::set_epoch 3.1");
+    expect(r).toBe("Epoch updated to: 3.1");
+  });
+
   it("can mine empty blocks", () => {
     const blockHeight = simnet.blockHeight;
     simnet.mineEmptyBlock();

--- a/components/clarity-jupyter-kernel/src/jupyter/core.rs
+++ b/components/clarity-jupyter-kernel/src/jupyter/core.rs
@@ -5,7 +5,7 @@ use super::control_file;
 use super::jupyter_message::JupyterMessage;
 use super::CommandContext;
 
-use colored::*;
+use colored::Colorize;
 use failure::Error;
 use json;
 use json::JsonValue;

--- a/components/clarity-repl/Cargo.toml
+++ b/components/clarity-repl/Cargo.toml
@@ -22,15 +22,13 @@ categories = [
 ]
 
 [dependencies]
-ansi_term = "0.12.1" # to be replaced with colored in the future
-chrono = "0.4.31"
 colored = { workspace = true }
+chrono = "0.4.31"
 regex = "1.7"
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1.0.47", features = ["unbounded_depth"] }
 sha2 = "0.10"
 serde_derive = "1.0"
-atty = "0.2.14"
 clarity = { workspace = true }
 clar2wasm = { git = "https://github.com/stacks-network/clarity-wasm.git", branch = "main", optional = true }
 pox-locking = { git = "https://github.com/stacks-network/stacks-core.git", branch="feat/clarity-wasm-develop", optional = true, default-features = false }
@@ -56,7 +54,7 @@ memchr = { version = "2.4.1", optional = true }
 # CLI
 pico-args = { version = "0.5.0", optional = true }
 rustyline = { version = "14.0.0", optional = true }
-hiro_system_kit = { version = "0.1.0", package = "hiro-system-kit", path = "../hiro-system-kit", default-features = false }
+hiro-system-kit = { path = "../hiro-system-kit", default-features = false }
 reqwest = { workspace = true, features = ["blocking"] }
 
 [dev-dependencies]
@@ -83,7 +81,7 @@ sdk = [
     "clarity/developer-mode",
     "clarity/devtools",
     "clarity/log",
-    "hiro_system_kit/tokio_helpers",
+    "hiro-system-kit/tokio_helpers",
     "pox-locking/default",
 ]
 cli = [

--- a/components/clarity-repl/src/repl/session.rs
+++ b/components/clarity-repl/src/repl/session.rs
@@ -5,7 +5,8 @@ use super::diagnostic::output_diagnostic;
 use super::{ClarityCodeSource, ClarityContract, ClarityInterpreter, ContractDeployer};
 use crate::analysis::coverage::CoverageHook;
 use crate::repl::clarity_values::value_to_string;
-use crate::utils;
+use crate::utils::serialize_event;
+
 use clarity::codec::StacksMessageCodec;
 use clarity::types::chainstate::StacksAddress;
 use clarity::types::StacksEpochId;
@@ -20,8 +21,9 @@ use clarity::vm::{
     ClarityVersion, CostSynthesis, EvalHook, EvaluationResult, ExecutionResult, ParsedContract,
     SymbolicExpression,
 };
-use colored::*;
+use colored::Colorize;
 use prettytable::{Cell, Row, Table};
+
 use std::collections::{BTreeMap, HashMap};
 use std::fmt;
 use std::num::ParseIntError;
@@ -349,7 +351,7 @@ impl Session {
                 if !result.events.is_empty() {
                     output.push(black!("Events emitted"));
                     for event in result.events.iter() {
-                        output.push(black!(format!("{}", utils::serialize_event(event))));
+                        output.push(black!(format!("{}", serialize_event(event))));
                     }
                 }
                 match &result.result {
@@ -1477,7 +1479,7 @@ mod tests {
             result.split('\n').next().unwrap(),
             format!(
                 "encode:1:1: {} use of unresolved function 'foo'",
-                "error:".bold().red()
+                "error:".red().bold()
             )
         );
     }

--- a/components/hiro-system-kit/Cargo.toml
+++ b/components/hiro-system-kit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hiro-system-kit"
-version = "0.1.0"
+version = "0.3.5"
 description = "Hiro system kit library"
 license = "MIT"
 edition = "2021"
@@ -8,13 +8,12 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+colored = { workspace = true }
 tokio = { version = "1.35.1", optional = true }
-ansi_term = "0.12.1"
-atty = "0.2.14"
 slog = { version = "2.7.0", optional = true }
 slog-json = { version = "2.6.1", optional = true }
 slog-scope = { version = "4.4.0", optional = true }
-slog-term = { version = "2.9.0", optional = true }
+slog-term = { version = "2.9.1", optional = true }
 slog-async = { version = "2.7.0", optional = true }
 slog-atomic = { version = "3.1.0", optional = true }
 time = "0.3.36"

--- a/components/hiro-system-kit/src/macros.rs
+++ b/components/hiro-system-kit/src/macros.rs
@@ -1,139 +1,49 @@
-#[allow(unused_macros)]
 #[macro_export]
 macro_rules! green {
-    ($($arg:tt)*) => (
-        {
-            use atty::Stream;
-            use ansi_term::{Colour, Style};
-            if atty::is(Stream::Stdout) {
-                let colour = Colour::Green.bold();
-                format!(
-                    "{}",
-                    colour.paint($($arg)*)
-                )
-            } else {
-                format!(
-                    "{}",
-                    $($arg)*
-                )
-            }
-        }
-    )
+    ($($arg:tt)*) => ({
+        use colored::Colorize;
+        format!("{}", format!("{}", $($arg)*).green().bold())
+    })
 }
 
-#[allow(unused_macros)]
 #[macro_export]
 macro_rules! red {
-    ($($arg:tt)*) => (
-        {
-            use atty::Stream;
-            use ansi_term::{Colour, Style};
-            if atty::is(Stream::Stdout) {
-                let colour = Colour::Red.bold();
-                format!(
-                    "{}",
-                    colour.paint($($arg)*)
-                )
-            } else {
-                format!(
-                    "{}",
-                    $($arg)*
-                )
-            }
-        }
-    )
+    ($($arg:tt)*) => ({
+        use colored::Colorize;
+        format!("{}", format!("{}", $($arg)*).red().bold())
+    })
 }
 
-#[allow(unused_macros)]
 #[macro_export]
 macro_rules! yellow {
-    ($($arg:tt)*) => (
-        {
-            use atty::Stream;
-            use ansi_term::{Colour, Style};
-            if atty::is(Stream::Stdout) {
-                let colour = Colour::Yellow.bold();
-                format!(
-                    "{}",
-                    colour.paint($($arg)*)
-                )
-            } else {
-                format!(
-                    "{}",
-                    $($arg)*
-                )
-            }
-        }
-    )
+    ($($arg:tt)*) => ({
+        use colored::Colorize;
+        format!("{}", format!("{}", $($arg)*).yellow().bold())
+    })
 }
 
-#[allow(unused_macros)]
 #[macro_export]
 macro_rules! blue {
-    ($($arg:tt)*) => (
-        {
-            use atty::Stream;
-            use ansi_term::{Colour, Style};
-            if atty::is(Stream::Stdout) {
-                let colour = Colour::Cyan.bold();
-                format!(
-                    "{}",
-                    colour.paint($($arg)*)
-                )
-            } else {
-                format!(
-                    "{}",
-                    $($arg)*
-                )
-            }
-        }
-    )
+    ($($arg:tt)*) => ({
+        use colored::Colorize;
+        format!("{}", format!("{}", $($arg)*).blue().bold())
+    })
 }
 
-#[allow(unused_macros)]
 #[macro_export]
 macro_rules! purple {
-    ($($arg:tt)*) => (
-        {
-            use atty::Stream;
-            use ansi_term::{Colour, Style};
-            if atty::is(Stream::Stdout) {
-                let colour = Colour::Purple.bold();
-                format!(
-                    "{}",
-                    colour.paint($($arg)*)
-                )
-            } else {
-                format!(
-                    "{}",
-                    $($arg)*
-                )
-            }
-        }
-    )
+    ($($arg:tt)*) => ({
+        use colored::Colorize;
+        format!("{}", format!("{}", $($arg)*).purple().bold())
+    })
 }
 
-#[allow(unused_macros)]
 #[macro_export]
 macro_rules! black {
-    ($($arg:tt)*) => (
-        {
-            use atty::Stream;
-            use ansi_term::{Colour, Style};
-            if atty::is(Stream::Stdout) {
-                let colour = Colour::Fixed(244);
-                format!(
-                    "{}",
-                    colour.paint($($arg)*)
-                )
-            } else {
-                format!(
-                    "{}",
-                    $($arg)*
-                )
-            }
-        }
-    )
+    ($($arg:tt)*) => ({
+        use colored::Colorize;
+        format!("{}", format!("{}", $($arg)*).black().bold())
+    })
 }
 
 #[macro_export]
@@ -147,7 +57,6 @@ macro_rules! pluralize {
     };
 }
 
-#[allow(unused_macros)]
 #[macro_export]
 macro_rules! format_err {
     ($($arg:tt)*) => (
@@ -157,7 +66,6 @@ macro_rules! format_err {
     )
 }
 
-#[allow(unused_macros)]
 #[macro_export]
 macro_rules! format_warn {
     ($($arg:tt)*) => (
@@ -167,7 +75,6 @@ macro_rules! format_warn {
     )
 }
 
-#[allow(unused_macros)]
 #[macro_export]
 macro_rules! format_note {
     ($($arg:tt)*) => (

--- a/components/stacks-network/Cargo.toml
+++ b/components/stacks-network/Cargo.toml
@@ -6,8 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atty = "0.2.14"
-ansi_term = "0.12.1"
+colored = { workspace = true }
 bollard = "0.17"
 bitcoincore-rpc = "0.18.0"
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
### Description

We were using 2 crates to colorize text in terminal "colored" and "ansi_term"
- colored is maintained and automatically handle wasm build (by not colorizing text in non-terminal build, removing the need for atty)
- ansi is unmaintained

