### PR TITLE
chore: move golden tests alongside relevant data

### DIFF
--- a/components/clarinet-format/src/formatter/mod.rs
+++ b/components/clarinet-format/src/formatter/mod.rs
@@ -917,9 +917,6 @@ mod tests_formatter {
             pretty_assertions::assert_eq!($($arg)*)
         }
     }
-    use std::collections::HashMap;
-    use std::fs;
-    use std::path::Path;
 
     fn format_with_default(source: &str) -> String {
         let formatter = ClarityFormatter::new(Settings::default());
@@ -931,49 +928,6 @@ mod tests_formatter {
         formatter.format_section(source)
     }
 
-    /// This is strictly for reading top metadata from golden tests
-    fn from_metadata(metadata: &str) -> Settings {
-        let mut max_line_length = 80;
-        let mut indent = Indentation::Space(2);
-
-        let metadata_map: HashMap<&str, &str> = metadata
-            .split(',')
-            .map(|pair| pair.trim())
-            .filter_map(|kv| kv.split_once(':'))
-            .map(|(k, v)| (k.trim(), v.trim()))
-            .collect();
-
-        if let Some(length) = metadata_map.get("max_line_length") {
-            max_line_length = length.parse().unwrap_or(max_line_length);
-        }
-
-        if let Some(&indentation) = metadata_map.get("indentation") {
-            indent = match indentation {
-                "tab" => Indentation::Tab,
-                value => {
-                    if let Ok(spaces) = value.parse::<usize>() {
-                        Indentation::Space(spaces)
-                    } else {
-                        Indentation::Space(2) // Fallback to default
-                    }
-                }
-            };
-        }
-
-        Settings {
-            max_line_length,
-            indentation: indent,
-        }
-    }
-    fn format_file_with_metadata(source: &str) -> String {
-        let mut lines = source.lines();
-        let metadata_line = lines.next().unwrap_or_default();
-        let settings = from_metadata(metadata_line);
-
-        let real_source = lines.collect::<Vec<&str>>().join("\n");
-        let formatter = ClarityFormatter::new(settings);
-        formatter.format_file(&real_source)
-    }
     #[test]
     fn test_simplest_formatter() {
         let result = format_with_default(&String::from("(  ok    true )"));
@@ -1168,7 +1122,7 @@ mod tests_formatter {
     c: d,
   },
 })"#;
-        std::assert_eq!(expected, result);
+        assert_eq!(expected, result);
         let src = r#"(ok
   {
     varslice: (unwrap! (slice? txbuff slice-start target-index) (err ERR-OUT-OF-BOUNDS)),
@@ -1359,7 +1313,7 @@ mod tests_formatter {
   (list)
 )"#;
         let result = format_with_default(src);
-        std::assert_eq!(src, result);
+        assert_eq!(src, result);
     }
 
     #[test]
@@ -1385,36 +1339,5 @@ mod tests_formatter {
   ))"#;
         let result = format_with_default(src);
         assert_eq!(src, result);
-    }
-
-    #[test]
-    fn test_irl_contracts() {
-        let golden_dir = "./tests/golden";
-        let intended_dir = "./tests/golden-intended";
-
-        // Iterate over files in the golden directory
-        for entry in fs::read_dir(golden_dir).expect("Failed to read golden directory") {
-            let entry = entry.expect("Failed to read directory entry");
-            let path = entry.path();
-
-            if path.is_file() {
-                let src = fs::read_to_string(&path).expect("Failed to read source file");
-
-                let file_name = path.file_name().expect("Failed to get file name");
-                let intended_path = Path::new(intended_dir).join(file_name);
-
-                let intended =
-                    fs::read_to_string(&intended_path).expect("Failed to read intended file");
-
-                // Apply formatting and compare
-                let result = format_file_with_metadata(&src);
-                pretty_assertions::assert_eq!(
-                    result,
-                    intended,
-                    "Mismatch in file: {:?}",
-                    file_name
-                );
-            }
-        }
     }
 }

--- a/components/clarinet-format/tests/golden.rs
+++ b/components/clarinet-format/tests/golden.rs
@@ -1,0 +1,73 @@
+use clarinet_format::formatter::{ClarityFormatter, Indentation, Settings};
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+
+/// This is strictly for reading top metadata from golden tests
+fn from_metadata(metadata: &str) -> Settings {
+    let mut max_line_length = 80;
+    let mut indent = Indentation::Space(2);
+
+    let metadata_map: HashMap<&str, &str> = metadata
+        .split(',')
+        .map(|pair| pair.trim())
+        .filter_map(|kv| kv.split_once(':'))
+        .map(|(k, v)| (k.trim(), v.trim()))
+        .collect();
+
+    if let Some(length) = metadata_map.get("max_line_length") {
+        max_line_length = length.parse().unwrap_or(max_line_length);
+    }
+
+    if let Some(&indentation) = metadata_map.get("indentation") {
+        indent = match indentation {
+            "tab" => Indentation::Tab,
+            value => {
+                if let Ok(spaces) = value.parse::<usize>() {
+                    Indentation::Space(spaces)
+                } else {
+                    Indentation::Space(2) // Fallback to default
+                }
+            }
+        };
+    }
+
+    Settings {
+        max_line_length,
+        indentation: indent,
+    }
+}
+fn format_file_with_metadata(source: &str) -> String {
+    let mut lines = source.lines();
+    let metadata_line = lines.next().unwrap_or_default();
+    let settings = from_metadata(metadata_line);
+
+    let real_source = lines.collect::<Vec<&str>>().join("\n");
+    let formatter = ClarityFormatter::new(settings);
+    formatter.format_file(&real_source)
+}
+#[test]
+fn test_irl_contracts() {
+    let golden_dir = "./tests/golden";
+    let intended_dir = "./tests/golden-intended";
+
+    // Iterate over files in the golden directory
+    for entry in fs::read_dir(golden_dir).expect("Failed to read golden directory") {
+        let entry = entry.expect("Failed to read directory entry");
+        let path = entry.path();
+
+        if path.is_file() {
+            let src = fs::read_to_string(&path).expect("Failed to read source file");
+
+            let file_name = path.file_name().expect("Failed to get file name");
+            let intended_path = Path::new(intended_dir).join(file_name);
+
+            let intended =
+                fs::read_to_string(&intended_path).expect("Failed to read intended file");
+
+            // Apply formatting and compare
+            let result = format_file_with_metadata(&src);
+            pretty_assertions::assert_eq!(result, intended, "Mismatch in file: {:?}", file_name);
+        }
+    }
+}


### PR DESCRIPTION
Simply moves the golden tests to appropriate place for integrations, separating from unit tests

