### PR TITLE
chore: update project template npm dependencies

### DIFF
--- a/components/clarinet-cli/src/generate/project.rs
+++ b/components/clarinet-cli/src/generate/project.rs
@@ -425,13 +425,13 @@ btc_address = "mvZtbibDAAA3WLpY7zXXFqRa3T4XSknBX7"
   "author": "",
   "license": "ISC",
   "dependencies": {{
-    "@hirosystems/clarinet-sdk": "^2.3.2",
+    "@hirosystems/clarinet-sdk": "^2.14.0",
     "@stacks/transactions": "^6.12.0",
     "chokidar-cli": "^3.0.0",
-    "typescript": "^5.3.3",
-    "vite": "^5.1.4",
-    "vitest": "^1.3.1",
-    "vitest-environment-clarinet": "^2.0.0"
+    "typescript": "^5.6.0",
+    "vite": "^6.1.0",
+    "vitest": "^3.0.0",
+    "vitest-environment-clarinet": "^2.3.0"
   }}
 }}
 "#,


### PR DESCRIPTION
### Description

We can support vitest@3.x since vitest-environment-clarinet@2.3.0
https://github.com/hirosystems/vitest-environment-clarinet

Future projects should use it by default

