### PR TITLE
refactor: rework wasm conditional compilation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ version = "2.15.1"
 
 [workspace.dependencies]
 clarity = { git = "https://github.com/stacks-network/stacks-core.git", branch="feat/clarity-wasm-develop", package = "clarity", default-features = false }
+pox-locking = { git = "https://github.com/stacks-network/stacks-core.git", branch="feat/clarity-wasm-develop", package = "pox-locking", default-features = false }
 reqwest = { version = "0.12", default-features = false, features = [
     "json",
     "rustls-tls",

--- a/components/clarinet-cli/Cargo.toml
+++ b/components/clarinet-cli/Cargo.toml
@@ -17,8 +17,6 @@ categories = [
 
 [dependencies]
 colored = { workspace = true }
-clap = { version = "4.4.8", features = ["derive"], optional = true }
-clap_complete = { version = "4.4.4", optional = true }
 toml = { version = "0.5.6", features = ["preserve_order"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1.0.79", features = ["preserve_order"] }
@@ -26,24 +24,26 @@ serde_derive = "1"
 tokio = { version = "1.35.1", features = ["full"] }
 crossterm = "0.27.0"
 ratatui = { version = "0.27.0", default-features = false, features = ["crossterm"] }
-segment = { version = "0.2.4", optional = true }
-mac_address = { version = "1.1.2", optional = true }
-tower-lsp = { version = "0.19.0", optional = true }
 similar = "2.1.0"
 crossbeam-channel = "0.5.6"
 
-clarity-repl = { package = "clarity-repl", path = "../clarity-repl", features = [
-    "cli",
-] }
-clarinet-files = { path = "../clarinet-files", features = ["cli"] }
-clarity-lsp = { path = "../clarity-lsp", features = ["cli"] }
+clarity-repl = { package = "clarity-repl", path = "../clarity-repl" }
+clarinet-files = { path = "../clarinet-files" }
+clarity-lsp = { path = "../clarity-lsp" }
 clarinet-format = { path = "../clarinet-format" }
-clarinet-deployments = { path = "../clarinet-deployments", features = ["cli"] }
+clarinet-deployments = { path = "../clarinet-deployments" }
 hiro-system-kit = { path = "../hiro-system-kit" }
 stacks-network = { path = "../stacks-network" }
 
 [target.'cfg(unix)'.dependencies]
 nix = "=0.24.2"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+clap = { version = "4.4.8", features = ["derive"] }
+clap_complete = { version = "4.4.4" }
+tower-lsp = { version = "0.19.0" }
+segment = { version = "0.2.4", optional = true }
+mac_address = { version = "1.1.2", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 fwdansi = "1.1.0"
@@ -78,6 +78,5 @@ name = "clarinet"
 path = "src/bin.rs"
 
 [features]
-default = ["cli", "telemetry"]
-cli = ["clap", "clap_complete", "tower-lsp"]
+default = ["telemetry"]
 telemetry = ["segment", "mac_address"]

--- a/components/clarinet-cli/src/lib.rs
+++ b/components/clarinet-cli/src/lib.rs
@@ -12,7 +12,7 @@ pub mod deployments;
 pub mod generate;
 
 pub mod devnet;
-#[cfg(feature = "cli")]
+#[cfg(not(target_arch = "wasm32"))]
 pub mod frontend;
-#[cfg(feature = "cli")]
+#[cfg(not(target_arch = "wasm32"))]
 pub mod lsp;

--- a/components/clarinet-deployments/Cargo.toml
+++ b/components/clarinet-deployments/Cargo.toml
@@ -5,42 +5,27 @@ edition = "2021"
 
 [dependencies]
 colored = { workspace = true }
+base64 = "0.21.3"
 serde = "1"
 serde_json = "1.0.123"
 serde_derive = "1"
 serde_yaml = "0.8.23"
 rand = "0.8.5"
-
-clarity-repl = { path = "../clarity-repl", default-features = false, optional = true }
-clarinet-files = { path = "../clarinet-files", default-features = false }
-stacks-rpc-client = { path = "../stacks-rpc-client", optional = true }
-clarinet-utils = { path = "../clarinet-utils", optional = true }
-stacks-codec = { path = "../stacks-codec", optional = true }
-
-# CLI
 reqwest = { workspace = true }
-bitcoin = { version = "0.31.2", optional = true }
-bitcoincore-rpc = { version = "0.18.0", optional = true }
-bitcoincore-rpc-json = { version = "0.18.0", optional = true }
-base58 = { version = "0.2.0", optional = true }
-base64 = "0.21.3"
-libsecp256k1 = { version = "0.7.0", optional = true }
-
 clarity = { workspace = true }
 
-[features]
-default = ["cli"]
-cli = ["clarity-repl/sdk", "clarinet-files/cli", "stacks-codec", "onchain"]
-wasm = ["clarity-repl/wasm", "clarinet-files/wasm"]
-onchain = [
-    "stacks-rpc-client",
-    "bitcoin",
-    "bitcoincore-rpc",
-    "bitcoincore-rpc-json",
-    "base58",
-    "libsecp256k1",
-    "clarinet-utils",
-]
+clarity-repl = { path = "../clarity-repl", default-features = false }
+clarinet-files = { path = "../clarinet-files" }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+bitcoin = "0.31.2"
+bitcoincore-rpc = "0.18.0"
+bitcoincore-rpc-json = "0.18.0"
+base58 = "0.2.0"
+libsecp256k1 = "0.7.0"
+clarinet-utils = { path = "../clarinet-utils" }
+stacks-codec = { path = "../stacks-codec" }
+stacks-rpc-client = { path = "../stacks-rpc-client" }
 
 [lib]
 name = "clarinet_deployments"

--- a/components/clarinet-deployments/src/lib.rs
+++ b/components/clarinet-deployments/src/lib.rs
@@ -7,7 +7,7 @@ extern crate serde;
 extern crate serde_derive;
 
 pub mod diagnostic_digest;
-#[cfg(feature = "onchain")]
+#[cfg(not(target_arch = "wasm32"))]
 pub mod onchain;
 pub mod requirements;
 pub mod types;

--- a/components/clarinet-files/Cargo.toml
+++ b/components/clarinet-files/Cargo.toml
@@ -6,39 +6,27 @@ description = "Clarinet manifests files helpers"
 license = "GPL-3.0"
 
 [dependencies]
+dirs = "6.0"
+libsecp256k1 = "0.7.0"
 serde = "1"
 serde_derive = "1"
+serde_json = "1.0.114"
 toml = { version = "0.5.6", features = ["preserve_order"] }
 url = { version = "2.2.2", features = ["serde"] }
-bitcoin = { version = "0.31.2", optional = true }
-libsecp256k1 = "0.7.0"
-dirs = "6.0"
 
 clarity = { workspace = true }
-
 clarinet-utils = { version = "1", path = "../clarinet-utils" }
-clarity-repl = { path = "../clarity-repl", default-features = false, optional = true }
+clarity-repl = { path = "../clarity-repl", default-features = false }
 
-# wasm
-js-sys = { version = "0.3", optional = true }
-serde-wasm-bindgen = { version = "0.6.4", optional = true }
-wasm-bindgen = { workspace = true, optional = true }
-wasm-bindgen-futures = { workspace = true, optional = true }
-serde_json = "1.0.114"
-web-sys = { workspace = true, features = ["console"], optional = true }
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+bitcoin = { version = "0.31.2" }
 
-
-[features]
-default = ["cli"]
-cli = ["bitcoin", "clarity-repl/sdk"]
-wasm = [
-  "js-sys",
-  "web-sys",
-  "serde-wasm-bindgen",
-  "wasm-bindgen",
-  "wasm-bindgen-futures",
-  "clarity-repl/wasm",
-]
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+js-sys = { version = "0.3" }
+serde-wasm-bindgen = { version = "0.6.4" }
+wasm-bindgen = { workspace = true }
+wasm-bindgen-futures = { workspace = true }
+web-sys = { workspace = true, features = ["console"] }
 
 [lib]
 name = "clarinet_files"

--- a/components/clarinet-files/src/lib.rs
+++ b/components/clarinet-files/src/lib.rs
@@ -10,9 +10,9 @@ mod project_manifest;
 
 pub use network_manifest::{BitcoinNetwork, StacksNetwork};
 
-#[cfg(feature = "wasm")]
+#[cfg(target_arch = "wasm32")]
 mod wasm_fs_accessor;
-#[cfg(feature = "wasm")]
+#[cfg(target_arch = "wasm32")]
 pub use wasm_fs_accessor::WASMFileSystemAccessor;
 
 pub use network_manifest::{
@@ -103,7 +103,7 @@ impl FileLocation {
         let url = Url::from_str(url_string)
             .map_err(|e| format!("unable to parse {} as a url\n{:?}", url_string, e))?;
 
-        #[cfg(not(feature = "wasm"))]
+        #[cfg(not(target_arch = "wasm32"))]
         if url.scheme() == "file" {
             let path = url
                 .to_file_path()
@@ -317,7 +317,7 @@ impl FileLocation {
         let bytes = match &self {
             FileLocation::FileSystem { path } => FileLocation::fs_read_content(path),
             FileLocation::Url { url } => match url.scheme() {
-                #[cfg(not(feature = "wasm"))]
+                #[cfg(not(target_arch = "wasm32"))]
                 "file" => {
                     let path = url
                         .to_file_path()
@@ -351,7 +351,7 @@ impl FileLocation {
 
     pub fn to_url_string(&self) -> Result<String, String> {
         match self {
-            #[cfg(not(feature = "wasm"))]
+            #[cfg(not(target_arch = "wasm32"))]
             FileLocation::FileSystem { path } => {
                 let file_path = self.to_string();
                 let url = Url::from_file_path(file_path)

--- a/components/clarinet-files/src/network_manifest.rs
+++ b/components/clarinet-files/src/network_manifest.rs
@@ -34,7 +34,7 @@ pub const DEFAULT_SUBNET_MNEMONIC: &str = "twice kind fence tip hidden tilt acti
 pub const DEFAULT_DOCKER_SOCKET: &str = "unix:///var/run/docker.sock";
 #[cfg(windows)]
 pub const DEFAULT_DOCKER_SOCKET: &str = "npipe:////./pipe/docker_engine";
-#[cfg(target_family = "wasm")]
+#[cfg(target_arch = "wasm32")]
 pub const DEFAULT_DOCKER_SOCKET: &str = "/var/run/docker.sock";
 pub const DEFAULT_DOCKER_PLATFORM: &str = "linux/amd64";
 
@@ -1149,7 +1149,7 @@ pub fn compute_addresses(
     (stx_address.to_string(), btc_address, miner_secret_key_hex)
 }
 
-#[cfg(not(feature = "wasm"))]
+#[cfg(not(target_arch = "wasm32"))]
 fn compute_btc_address(public_key: &PublicKey, network: &BitcoinNetwork) -> String {
     let public_key = bitcoin::PublicKey::from_slice(&public_key.serialize_compressed())
         .expect("Unable to recreate public key");
@@ -1186,7 +1186,7 @@ pub fn is_in_reward_phase(
     }
 }
 
-#[cfg(feature = "wasm")]
+#[cfg(target_arch = "wasm32")]
 fn compute_btc_address(_public_key: &PublicKey, _network: &BitcoinNetwork) -> String {
     "__not_implemented__".to_string()
 }

--- a/components/clarinet-format/Cargo.toml
+++ b/components/clarinet-format/Cargo.toml
@@ -3,8 +3,11 @@ name = "clarinet-format"
 version = "0.1.0"
 edition = "2021"
 
-[dependencies]
-clarity = { workspace = true}
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+clarity = { workspace = true, features = ["canonical", "developer-mode", "devtools", "log"] }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+clarity = { workspace = true, features = ["wasm", "developer-mode", "devtools"] }
 
 [dev-dependencies]
 pretty_assertions = "1.3"
@@ -13,21 +16,6 @@ divan = "0.1"
 [[bench]]
 name = "formatter"
 harness = false
-
-[features]
-default = ["cli"]
-cli = [
-    "clarity/canonical",
-    "clarity/developer-mode",
-    "clarity/devtools",
-    "clarity/log",
-]
-wasm = [
-    "clarity/wasm",
-    "clarity/developer-mode",
-    "clarity/devtools",
-]
-
 
 [lib]
 name = "clarinet_format"

--- a/components/clarinet-sdk-wasm/Cargo.toml
+++ b/components/clarinet-sdk-wasm/Cargo.toml
@@ -12,18 +12,18 @@ name = "clarinet_sdk"
 path = "src/lib.rs"
 
 [dependencies]
-console_error_panic_hook = { version = "0.1", optional = true }
+console_error_panic_hook = { version = "0.1" }
 gloo-utils = { version = "0.2.0", features = ["serde"] }
-js-sys = { version = "0.3", optional = true }
+js-sys = { version = "0.3" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
-serde-wasm-bindgen = { version = "0.6.4", optional = true }
-wasm-bindgen = { workspace = true, optional = true }
-wasm-bindgen-futures = { workspace = true, optional = true }
-web-sys = { workspace = true, features = ["console"], optional = true }
+serde-wasm-bindgen = { version = "0.6.4" }
+wasm-bindgen = { workspace = true }
+wasm-bindgen-futures = { workspace = true }
+web-sys = { workspace = true, features = ["console"] }
 
 clarinet-files = { path = "../clarinet-files", default-features = false }
-clarity-repl = { path = "../clarity-repl", default-features = false, optional = true }
+clarity-repl = { path = "../clarity-repl", default-features = false }
 clarinet-deployments = { path = "../clarinet-deployments", default-features = false }
 
 [dev-dependencies]
@@ -31,18 +31,6 @@ wasm-bindgen-test = "0.3.0"
 clarity = { workspace = true }
 
 [features]
-default = ["wasm"]
-wasm = [
-  "wasm-bindgen",
-  "wasm-bindgen-futures",
-  "serde-wasm-bindgen",
-  "js-sys",
-  "web-sys",
-  "console_error_panic_hook",
-  "clarinet-deployments/wasm",
-  "clarity-repl/wasm",
-  "clarinet-files/wasm",
-]
 web = [
   "clarity-repl/web",
 ]

--- a/components/clarity-events/Cargo.toml
+++ b/components/clarity-events/Cargo.toml
@@ -4,17 +4,14 @@ version.workspace = true
 edition = "2021"
 
 [dependencies]
-clarinet-files = { path = "../clarinet-files", default-features = false, optional = true }
+clarinet-files = { path = "../clarinet-files", default-features = false }
 clarity-repl = { path = "../clarity-repl", default-features = false }
-clap = { version = "4.4.8", features = ["derive"], optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1.0.79", features = ["preserve_order"] }
 serde_derive = "1"
 
-[features]
-default = ["cli"]
-cli = ["clarity-repl/cli", "clarinet-files/cli", "clap"]
-lib = ["clarity-repl/cli"]
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+clap = { version = "4.4.8", features = ["derive"] }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/components/clarity-lsp/Cargo.toml
+++ b/components/clarity-lsp/Cargo.toml
@@ -8,38 +8,18 @@ lsp-types = "0.94.0"
 regex = "1.7"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
-clarinet-files = { path = "../clarinet-files", default-features = false }
-clarity-repl = { path = "../clarity-repl", default-features = false, optional = true }
-clarinet-deployments = { path = "../clarinet-deployments", default-features = false }
+clarinet-files = { path = "../clarinet-files" }
+clarity-repl = { path = "../clarity-repl", default-features = false }
+clarinet-deployments = { path = "../clarinet-deployments" }
 
-# WASM
-console_error_panic_hook = { version = "0.1", optional = true }
-js-sys = { version = "0.3", optional = true }
-serde-wasm-bindgen = { version = "0.6.4", optional = true }
-wasm-bindgen = { workspace = true, optional = true }
-wasm-bindgen-futures = { workspace = true, optional = true }
-web-sys = { workspace = true, features = ["console"], optional = true }
-
-[features]
-default = ["cli"]
-cli = [
-  "clarinet-deployments/cli",
-  "clarinet-deployments/cli",
-  "clarity-repl/cli",
-  "clarinet-files/cli",
-]
-wasm = [
-  "wasm-bindgen",
-  "wasm-bindgen-futures",
-  "serde-wasm-bindgen",
-  "js-sys",
-  "web-sys",
-  "console_error_panic_hook",
-  "clarinet-deployments/wasm",
-  "clarity-repl/wasm",
-  "clarity-repl/web",
-  "clarinet-files/wasm",
-]
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+console_error_panic_hook = { version = "0.1" }
+js-sys = { version = "0.3" }
+serde-wasm-bindgen = { version = "0.6.4" }
+wasm-bindgen = { workspace = true }
+wasm-bindgen-futures = { workspace = true }
+web-sys = { workspace = true, features = ["console"] }
+clarity-repl = { path = "../clarity-repl", default-features = false, features = ["web"] }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/components/clarity-lsp/src/common/requests/definitions.rs
+++ b/components/clarity-lsp/src/common/requests/definitions.rs
@@ -8,7 +8,7 @@ use clarity_repl::clarity::vm::types::{QualifiedContractIdentifier, StandardPrin
 use clarity_repl::clarity::{ClarityName, SymbolicExpression};
 use lsp_types::Range;
 
-#[cfg(feature = "wasm")]
+#[cfg(target_arch = "wasm32")]
 #[allow(unused_imports)]
 use crate::utils::log;
 

--- a/components/clarity-lsp/src/lib.rs
+++ b/components/clarity-lsp/src/lib.rs
@@ -1,6 +1,6 @@
 mod common;
 pub mod utils;
-#[cfg(feature = "wasm")]
+#[cfg(target_arch = "wasm32")]
 pub mod vscode_bridge;
 
 pub use common::backend;

--- a/components/clarity-lsp/src/utils/mod.rs
+++ b/components/clarity-lsp/src/utils/mod.rs
@@ -7,14 +7,14 @@ use lsp_types::Url;
 use lsp_types::{DiagnosticSeverity, Position, Range};
 
 #[allow(unused_macros)]
-#[cfg(feature = "wasm")]
+#[cfg(target_arch = "wasm32")]
 macro_rules! log {
     ( $( $t:tt )* ) => {
         web_sys::console::log_1(&format!( $( $t )* ).into());
     }
 }
 
-#[cfg(feature = "wasm")]
+#[cfg(target_arch = "wasm32")]
 pub(crate) use log;
 
 pub fn clarity_diagnostics_to_lsp_type(diagnostics: &Vec<ClarityDiagnostic>) -> Vec<LspDiagnostic> {

--- a/components/clarity-repl/Cargo.toml
+++ b/components/clarity-repl/Cargo.toml
@@ -22,27 +22,25 @@ categories = [
 ]
 
 [dependencies]
-colored = { workspace = true }
 chrono = "0.4.31"
+colored = { workspace = true }
+prettytable-rs = { version = "0.10.0" }
 regex = "1.7"
+reqwest = { workspace = true, features = ["blocking"] }
 serde = { version = "1", features = ["derive"] }
+serde_derive = "1.0"
 serde_json = { version = "1.0.47", features = ["unbounded_depth"] }
 sha2 = "0.10"
-serde_derive = "1.0"
-clarity = { workspace = true }
-clar2wasm = { git = "https://github.com/stacks-network/clarity-wasm.git", branch = "main", optional = true }
-pox-locking = { git = "https://github.com/stacks-network/stacks-core.git", branch="feat/clarity-wasm-develop", optional = true, default-features = false }
-prettytable-rs = { version = "0.10.0" }
 
-# wasm
-wasm-bindgen = { workspace = true, optional = true }
-serde-wasm-bindgen = { version = "0.6.4", optional = true }
-web-sys = { workspace = true, optional = true }
-js-sys = { version = "0.3", optional = true }
-getrandom = { version = "0.2.3", optional = true, features = ["js"] }
-
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+pico-args = { version = "0.5.0" }
+rustyline = { version = "14.0.0" }
+clarity = { workspace = true, default-features = false, features = ["canonical", "developer-mode", "devtools", "log"] }
+clar2wasm = { git = "https://github.com/stacks-network/clarity-wasm.git", branch = "main" }
+pox-locking = { workspace = true, default-features = true }
+hiro-system-kit = { path = "../hiro-system-kit", default-features = false, features = ["tokio_helpers"] }
 # DAP Debugger
-tokio = { version = "1.35.1", features = ["full"], optional = true}
+tokio = { version = "1.35.1", features = ["full"], optional = true }
 tokio-util = { version = "0.7.10", features = ["codec"], optional = true }
 futures = { version = "0.3.12", optional = true }
 debug_types = { version = "1.0.0", optional = true }
@@ -51,11 +49,15 @@ bytes = { version = "1.1.0", optional = true }
 log = { version = "0.4.16", optional = true }
 memchr = { version = "2.4.1", optional = true }
 
-# CLI
-pico-args = { version = "0.5.0", optional = true }
-rustyline = { version = "14.0.0", optional = true }
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+clarity = { workspace = true, features = ["wasm", "developer-mode", "devtools"] }
+pox-locking = { workspace = true, default-features = false, features = ["wasm"] }
+wasm-bindgen = { workspace = true }
+serde-wasm-bindgen = { version = "0.6.4" }
+web-sys = { workspace = true }
+js-sys = { version = "0.3" }
+getrandom = { version = "0.2.3", features = ["js"] }
 hiro-system-kit = { path = "../hiro-system-kit", default-features = false }
-reqwest = { workspace = true, features = ["blocking"] }
 
 [dev-dependencies]
 test-case = "*"
@@ -75,21 +77,7 @@ name = "simnet"
 harness = false
 
 [features]
-default = ["cli", "dap"]
-sdk = [
-    "clarity/canonical",
-    "clarity/developer-mode",
-    "clarity/devtools",
-    "clarity/log",
-    "hiro-system-kit/tokio_helpers",
-    "pox-locking/default",
-]
-cli = [
-    "sdk",
-    "pico-args",
-    "rustyline",
-    "clar2wasm",
-]
+default = ["dap"]
 dap = [
     "tokio",
     "tokio-util",
@@ -99,17 +87,6 @@ dap = [
     "bytes",
     "memchr",
     "log",
-]
-wasm = [
-    "clarity/wasm",
-    "clarity/developer-mode",
-    "clarity/devtools",
-    "pox-locking/wasm",
-    "wasm-bindgen",
-    "serde-wasm-bindgen",
-    "web-sys",
-    "js-sys",
-    "getrandom",
 ]
 web = [
     "web-sys/XmlHttpRequest",

--- a/components/clarity-repl/src/lib.rs
+++ b/components/clarity-repl/src/lib.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "cli")]
+#[cfg(not(target_arch = "wasm32"))]
 #[macro_use]
 pub extern crate prettytable;
 
@@ -26,8 +26,8 @@ pub mod utils;
 #[cfg(test)]
 pub mod test_fixtures;
 
-#[cfg(feature = "cli")]
+#[cfg(not(target_arch = "wasm32"))]
 pub mod frontend;
 
-#[cfg(feature = "cli")]
+#[cfg(not(target_arch = "wasm32"))]
 pub use frontend::Terminal;

--- a/components/clarity-repl/src/repl/datastore.rs
+++ b/components/clarity-repl/src/repl/datastore.rs
@@ -530,7 +530,7 @@ impl ClarityBackingStore for ClarityDatastore {
         Some(&handle_contract_call_special_cases)
     }
 
-    #[cfg(feature = "sdk")]
+    #[cfg(not(target_arch = "wasm32"))]
     fn get_side_store(&mut self) -> &::clarity::rusqlite::Connection {
         panic!("Datastore cannot get_side_store")
     }

--- a/components/clarity-repl/src/repl/debug/mod.rs
+++ b/components/clarity-repl/src/repl/debug/mod.rs
@@ -14,7 +14,7 @@ use clarity::vm::types::{QualifiedContractIdentifier, StandardPrincipalData, Val
 use clarity::vm::{eval, ClarityVersion};
 use clarity::vm::{ContractName, SymbolicExpressionType};
 
-#[cfg(feature = "cli")]
+#[cfg(not(target_arch = "wasm32"))]
 pub mod cli;
 #[cfg(feature = "dap")]
 pub mod dap;

--- a/components/clarity-repl/src/repl/interpreter.rs
+++ b/components/clarity-repl/src/repl/interpreter.rs
@@ -9,7 +9,7 @@ use clarity::consts::{CHAIN_ID_MAINNET, CHAIN_ID_TESTNET};
 use clarity::types::StacksEpochId;
 use clarity::vm::analysis::ContractAnalysis;
 use clarity::vm::ast::{build_ast_with_diagnostics, ContractAST};
-#[cfg(feature = "cli")]
+#[cfg(not(target_arch = "wasm32"))]
 use clarity::vm::clarity_wasm::{call_function, initialize_contract};
 use clarity::vm::contexts::{CallStack, ContractContext, Environment, GlobalContext, LocalContext};
 use clarity::vm::contracts::Contract;
@@ -90,13 +90,13 @@ impl ClarityInterpreter {
         cost_track: bool,
         eval_hooks: Option<Vec<&mut dyn EvalHook>>,
     ) -> Result<ExecutionResult, Vec<Diagnostic>> {
-        #[cfg(feature = "cli")]
+        #[cfg(not(target_arch = "wasm32"))]
         if self.repl_settings.clarity_wasm_mode {
             self.run_wasm(contract, ast, cost_track, None)
         } else {
             self.run_interpreter(contract, ast, cost_track, eval_hooks)
         }
-        #[cfg(not(feature = "cli"))]
+        #[cfg(target_arch = "wasm32")]
         self.run_interpreter(contract, ast, cost_track, eval_hooks)
     }
 
@@ -148,7 +148,7 @@ impl ClarityInterpreter {
         Ok(result)
     }
 
-    #[cfg(feature = "cli")]
+    #[cfg(not(target_arch = "wasm32"))]
     fn run_wasm(
         &mut self,
         contract: &ClarityContract,
@@ -435,7 +435,7 @@ impl ClarityInterpreter {
         let mut contract_context =
             ContractContext::new(contract_id.clone(), contract.clarity_version);
 
-        #[cfg(not(feature = "wasm"))]
+        #[cfg(not(target_arch = "wasm32"))]
         let show_timings = self.repl_settings.show_timings;
 
         let tx_sender: PrincipalData = self.tx_sender.clone().into();
@@ -628,7 +628,7 @@ impl ClarityInterpreter {
         Ok(execution_result)
     }
 
-    #[cfg(feature = "cli")]
+    #[cfg(not(target_arch = "wasm32"))]
     fn execute_wasm(
         &mut self,
         contract: &ClarityContract,

--- a/components/clarity-repl/src/repl/mod.rs
+++ b/components/clarity-repl/src/repl/mod.rs
@@ -8,7 +8,7 @@ pub mod session;
 pub mod settings;
 pub mod tracer;
 
-#[cfg(any(feature = "cli", feature = "dap"))]
+#[cfg(any(not(target_arch = "wasm32"), feature = "dap"))]
 pub mod debug;
 
 use serde::ser::{Serialize, SerializeMap, Serializer};

--- a/components/clarity-repl/src/repl/session.rs
+++ b/components/clarity-repl/src/repl/session.rs
@@ -28,7 +28,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::fmt;
 use std::num::ParseIntError;
 
-#[cfg(feature = "cli")]
+#[cfg(not(target_arch = "wasm32"))]
 use clarity::vm::analysis::ContractAnalysis;
 
 use super::SessionSettings;
@@ -158,7 +158,7 @@ impl Session {
         }
     }
 
-    #[cfg(feature = "cli")]
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn process_console_input(
         &mut self,
         command: &str,
@@ -171,15 +171,15 @@ impl Session {
 
         let mut reload = false;
         match command {
-            #[cfg(feature = "cli")]
+            #[cfg(not(target_arch = "wasm32"))]
             cmd if cmd.starts_with("::reload") => reload = true,
-            #[cfg(feature = "cli")]
+            #[cfg(not(target_arch = "wasm32"))]
             cmd if cmd.starts_with("::read") => self.read(&mut output, cmd),
-            #[cfg(feature = "cli")]
+            #[cfg(not(target_arch = "wasm32"))]
             cmd if cmd.starts_with("::debug") => self.debug(&mut output, cmd),
-            #[cfg(feature = "cli")]
+            #[cfg(not(target_arch = "wasm32"))]
             cmd if cmd.starts_with("::trace") => self.trace(&mut output, cmd),
-            #[cfg(feature = "cli")]
+            #[cfg(not(target_arch = "wasm32"))]
             cmd if cmd.starts_with("::get_costs") => self.get_costs(&mut output, cmd),
 
             cmd if cmd.starts_with("::") => {
@@ -199,15 +199,15 @@ impl Session {
         match command {
             "::help" => self.display_help(),
 
-            #[cfg(feature = "cli")]
+            #[cfg(not(target_arch = "wasm32"))]
             cmd if cmd.starts_with("::functions") => self.display_functions(),
-            #[cfg(feature = "cli")]
+            #[cfg(not(target_arch = "wasm32"))]
             cmd if cmd.starts_with("::keywords") => self.keywords(),
-            #[cfg(feature = "cli")]
+            #[cfg(not(target_arch = "wasm32"))]
             cmd if cmd.starts_with("::describe") => self.display_doc(cmd),
-            #[cfg(feature = "cli")]
+            #[cfg(not(target_arch = "wasm32"))]
             cmd if cmd.starts_with("::toggle_costs") => self.toggle_costs(),
-            #[cfg(feature = "cli")]
+            #[cfg(not(target_arch = "wasm32"))]
             cmd if cmd.starts_with("::toggle_timings") => self.toggle_timings(),
 
             cmd if cmd.starts_with("::mint_stx") => self.mint_stx(cmd),
@@ -237,7 +237,7 @@ impl Session {
         }
     }
 
-    #[cfg(feature = "cli")]
+    #[cfg(not(target_arch = "wasm32"))]
     fn run_snippet(
         &mut self,
         output: &mut Vec<String>,
@@ -320,7 +320,7 @@ impl Session {
         execution_result
     }
 
-    #[cfg(feature = "cli")]
+    #[cfg(not(target_arch = "wasm32"))]
     fn get_costs_percentage(consumed: &u64, limit: &u64) -> String {
         let calc = (*consumed as f64 / *limit as f64) * 100_f64;
 
@@ -375,7 +375,7 @@ impl Session {
         }
     }
 
-    #[cfg(feature = "cli")]
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn debug(&mut self, output: &mut Vec<String>, cmd: &str) {
         use crate::repl::debug::cli::CLIDebugger;
 
@@ -404,7 +404,7 @@ impl Session {
         output.append(&mut result);
     }
 
-    #[cfg(feature = "cli")]
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn trace(&mut self, output: &mut Vec<String>, cmd: &str) {
         use super::tracer::Tracer;
 
@@ -427,7 +427,7 @@ impl Session {
         };
     }
 
-    #[cfg(feature = "cli")]
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn start(&mut self) -> Result<(String, Vec<(ContractAnalysis, String, String)>), String> {
         let mut output_err = Vec::<String>::new();
         let output = Vec::<String>::new();
@@ -464,7 +464,7 @@ impl Session {
         }
     }
 
-    #[cfg(feature = "cli")]
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn read(&mut self, output: &mut Vec<String>, cmd: &str) {
         let filename = match cmd.split_once(' ') {
             Some((_, filename)) => filename,
@@ -711,27 +711,27 @@ impl Session {
     fn display_help(&self) -> String {
         let mut output: Vec<String> = vec![];
 
-        #[cfg(feature = "cli")]
+        #[cfg(not(target_arch = "wasm32"))]
         output.push(format!(
             "{}",
             "::functions\t\t\t\tDisplay all the native functions available in clarity".yellow()
         ));
-        #[cfg(feature = "cli")]
+        #[cfg(not(target_arch = "wasm32"))]
         output.push(format!(
             "{}",
             "::keywords\t\t\t\tDisplay all the native keywords available in clarity".yellow()
         ));
-        #[cfg(feature = "cli")]
+        #[cfg(not(target_arch = "wasm32"))]
         output.push(format!(
             "{}",
                 "::describe <function> | <keyword>\tDisplay documentation for a given native function or keyword".yellow()
         ));
-        #[cfg(feature = "cli")]
+        #[cfg(not(target_arch = "wasm32"))]
         output.push(format!(
             "{}",
             "::toggle_costs\t\t\t\tDisplay cost analysis after every expression".yellow()
         ));
-        #[cfg(feature = "cli")]
+        #[cfg(not(target_arch = "wasm32"))]
         output.push(format!(
             "{}",
             "::toggle_timings\t\t\tDisplay the execution duration".yellow()
@@ -779,27 +779,27 @@ impl Session {
             "::get_epoch\t\t\t\tGet current epoch".yellow()
         ));
 
-        #[cfg(feature = "cli")]
+        #[cfg(not(target_arch = "wasm32"))]
         output.push(format!(
             "{}",
             "::debug <expr>\t\t\t\tStart an interactive debug session executing <expr>".yellow()
         ));
-        #[cfg(feature = "cli")]
+        #[cfg(not(target_arch = "wasm32"))]
         output.push(format!(
             "{}",
             "::trace <expr>\t\t\t\tGenerate an execution trace for <expr>".yellow()
         ));
-        #[cfg(feature = "cli")]
+        #[cfg(not(target_arch = "wasm32"))]
         output.push(format!(
             "{}",
             "::get_costs <expr>\t\t\tDisplay the cost analysis".yellow()
         ));
-        #[cfg(feature = "cli")]
+        #[cfg(not(target_arch = "wasm32"))]
         output.push(format!(
             "{}",
             "::reload \t\t\t\tReload the existing contract(s) in the session".yellow()
         ));
-        #[cfg(feature = "cli")]
+        #[cfg(not(target_arch = "wasm32"))]
         output.push(format!(
             "{}",
             "::read <filename>\t\t\tRead expressions from a file".yellow()
@@ -1052,7 +1052,7 @@ impl Session {
         format!("{}", value_to_string(&value).green())
     }
 
-    #[cfg(feature = "cli")]
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn get_costs(&mut self, output: &mut Vec<String>, cmd: &str) {
         let expr = match cmd.split_once(' ') {
             Some((_, expr)) => expr,
@@ -1102,7 +1102,7 @@ impl Session {
         Some(format!("{}", table))
     }
 
-    #[cfg(feature = "cli")]
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn get_contracts(&self) -> Option<String> {
         use super::boot::{BOOT_MAINNET_ADDRESS, BOOT_TESTNET_ADDRESS, SBTC_MAINNET_ADDRESS};
 
@@ -1140,7 +1140,7 @@ impl Session {
         Some(format!("{}", table))
     }
 
-    #[cfg(not(feature = "cli"))]
+    #[cfg(target_arch = "wasm32")]
     fn get_contracts(&self) -> Option<String> {
         if self.contracts.is_empty() {
             return None;
@@ -1179,13 +1179,13 @@ impl Session {
         }
     }
 
-    #[cfg(feature = "cli")]
+    #[cfg(not(target_arch = "wasm32"))]
     fn display_functions(&self) -> String {
         let api_reference_index = self.get_api_reference_index();
         format!("{}", api_reference_index.join("\n").yellow())
     }
 
-    #[cfg(feature = "cli")]
+    #[cfg(not(target_arch = "wasm32"))]
     fn display_doc(&self, command: &str) -> String {
         let keyword = {
             let mut s = command.to_string();
@@ -1203,7 +1203,7 @@ impl Session {
         }
     }
 
-    #[cfg(feature = "cli")]
+    #[cfg(not(target_arch = "wasm32"))]
     fn keywords(&self) -> String {
         let keywords = self.get_clarity_keywords();
         format!("{}", keywords.join("\n").yellow())

--- a/components/clarity-vscode/web-extension.code-workspace
+++ b/components/clarity-vscode/web-extension.code-workspace
@@ -9,14 +9,12 @@
   ],
   "settings": {
     "rust-analyzer.cargo.noDefaultFeatures": true,
-    "rust-analyzer.cargo.features": ["clarity-lsp/wasm"],
     "rust-analyzer.check.overrideCommand": [
       "cargo",
       "clippy",
       "--target=wasm32-unknown-unknown",
       "--no-default-features",
       "--package=clarity-lsp",
-      "--features=wasm",
       "--message-format=json",
     ],
   },

--- a/components/clarity-vscode/webpack.config.dev.js
+++ b/components/clarity-vscode/webpack.config.dev.js
@@ -23,7 +23,7 @@ serverBrowserConfig.plugins = [
   }),
   new WasmPackPlugin({
     crateDirectory: path.resolve(__dirname, "../clarity-lsp"),
-    extraArgs: "--release --target=web --no-default-features --features=wasm",
+    extraArgs: "--release --target=web",
     outDir: path.resolve(__dirname, "server/src/clarity-lsp-browser"),
     outName: "lsp-browser",
   }),

--- a/components/clarity-vscode/webpack.config.js
+++ b/components/clarity-vscode/webpack.config.js
@@ -99,7 +99,7 @@ const serverBrowserConfig = {
     new WasmPackPlugin({
       crateDirectory: path.resolve(__dirname, "../clarity-lsp"),
       forceMode: "production",
-      extraArgs: "--release --target=web --no-default-features --features=wasm",
+      extraArgs: "--release --target=web",
       outDir: path.resolve(__dirname, "server/src/clarity-lsp-browser"),
       outName: "lsp-browser",
     }),
@@ -128,8 +128,7 @@ const serverNodeConfig = {
     new WasmPackPlugin({
       crateDirectory: path.resolve(__dirname, "../clarity-lsp"),
       forceMode: "production",
-      extraArgs:
-        "--release --target=nodejs --no-default-features --features=wasm ",
+      extraArgs: "--release --target=nodejs",
       outDir: path.resolve(__dirname, "server/src/clarity-lsp-node"),
       outName: "lsp-node",
     }),

--- a/components/stacks-network/Cargo.toml
+++ b/components/stacks-network/Cargo.toml
@@ -35,8 +35,8 @@ chainhook-sdk = { version = "0.12" }
 chainhook-types = { version = "1.3.7" }
 
 stacks-rpc-client = { path = "../stacks-rpc-client" }
-clarinet-files = { path = "../clarinet-files", features = ["cli"] }
-clarinet-deployments = { path = "../clarinet-deployments", features = ["cli"] }
+clarinet-files = { path = "../clarinet-files" }
+clarinet-deployments = { path = "../clarinet-deployments" }
 hiro-system-kit = { path = "../hiro-system-kit", features = ["log"] }
 stacks-codec = { path = "../stacks-codec" }
 


### PR DESCRIPTION
## Context

Because it compiles to both native and wasm platform, clarinet uses conditional dependency management and compilation.
I could make dependency management mrpoe difficult than it should be

## Description

Instead of managing conditional dependencies with cargo feature, we can use cargo target dependencies instead.

So instead of this
```toml
# package-a
[dependencies]
clap = { optional = true }

[features]
default = ["cli"]
cli = ["clap"]
wasm  = []

##########
#package-b
[dependencies]
package-a = { path = "../package-a", optional = true }

[features]
default = ["cli"]
cli = ["package-a/cli"]
wasm  = ["package-a/cli"]
```

We now do this

```toml
# package-a
[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
clap = { optional = true }

##########
#package-b
[dependencies]
package-a = { path = "../package-a" }
```


With this feature, we remove 100 of toml config.

## Future work

The idea of simplifying this depedency management topic on the repo, is mainly to famalirise myself with it so that I can use it in stacks-core to have a clean of handling clarity-vm compilation to wasm