### PR TITLE
fix: serialize remote_data setting

### DIFF
--- a/components/clarity-repl/src/repl/settings.rs
+++ b/components/clarity-repl/src/repl/settings.rs
@@ -79,7 +79,6 @@ impl fmt::Display for ApiUrl {
 #[derive(Debug, Default, Clone, Deserialize, Serialize)]
 pub struct Settings {
     pub analysis: analysis::Settings,
-    #[serde(skip_serializing_if = "RemoteDataSettings::is_disabled")]
     pub remote_data: RemoteDataSettings,
     #[serde(skip_serializing, skip_deserializing)]
     pub clarity_wasm_mode: bool,

--- a/components/clarity-repl/src/repl/settings.rs
+++ b/components/clarity-repl/src/repl/settings.rs
@@ -171,8 +171,4 @@ impl RemoteDataSettings {
             is_mainnet: info.network_id == 1,
         })
     }
-
-    pub fn is_disabled(&self) -> bool {
-        !self.enabled
-    }
 }


### PR DESCRIPTION
### Description

`skip_serializing_if` was used to avoid adding the remote data setting to every project manifest when we released it.

We should also have hnadled the deserialization if the field wasn't set, especially for devnet-api.
there are multiple way of handling it (we could also handl deserialisation if the field wasn't set), let's just keep it simple and remove skip_serializing