### PR TITLE
ci: set hiro_api_key in test env vars

### DIFF
--- a/.github/workflows/ci-sdk.yaml
+++ b/.github/workflows/ci-sdk.yaml
@@ -99,4 +99,6 @@ jobs:
         run: npm ci
 
       - name: Run tests
+        env:
+          HIRO_API_KEY: ${{ secrets.HIRO_KONG_API_KEY }}
         run: npm run test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -116,6 +116,8 @@ jobs:
           tool: cargo-llvm-cov,nextest
 
       - name: Run unit test with coverage
+        env:
+          HIRO_API_KEY: ${{ secrets.HIRO_KONG_API_KEY }}
         run: cargo cov
 
       - name: Upload coverage data to codecov


### PR DESCRIPTION
### Description

To avoid reaching hiro api rate limits in integrations test (especially, tx simulation integration test), set an hiro api key in env.
(Clarinet is specifically looking for `HIRO_API_KEY` in the env)
