### PR TITLE
fix: improve devnet sbtc handling

### DIFF
--- a/components/clarinet-files/src/network_manifest.rs
+++ b/components/clarinet-files/src/network_manifest.rs
@@ -947,7 +947,7 @@ impl NetworkManifest {
                     .unwrap_or(500),
                 stacks_node_next_initiative_delay: devnet_config
                     .stacks_node_next_initiative_delay
-                    .unwrap_or(4000),
+                    .unwrap_or(3000),
                 stacks_api_port: devnet_config.stacks_api_port.unwrap_or(3999),
                 stacks_api_events_port: devnet_config.stacks_api_events_port.unwrap_or(3700),
                 stacks_explorer_port: devnet_config.stacks_explorer_port.unwrap_or(8000),

--- a/components/stacks-network/src/chains_coordinator.rs
+++ b/components/stacks-network/src/chains_coordinator.rs
@@ -421,31 +421,27 @@ pub async fn start_chains_coordinator(
                 };
 
                 // if the sbtc-deposit contract is detected, fund the accounts with sBTC
-                if !boot_completed.load(Ordering::SeqCst) {
-                    stacks_block_update
-                        .block
-                        .transactions
-                        .iter()
-                        .for_each(|tx| {
-                            if let StacksTransactionKind::ContractDeployment(data) =
-                                &tx.metadata.kind
+                stacks_block_update
+                    .block
+                    .transactions
+                    .iter()
+                    .for_each(|tx| {
+                        if let StacksTransactionKind::ContractDeployment(data) = &tx.metadata.kind {
+                            let contract_identifier = data.contract_identifier.clone();
+                            let deployer = config.get_deployer();
+                            if contract_identifier
+                                == format!("{}.sbtc-deposit", deployer.stx_address)
                             {
-                                let contract_identifier = data.contract_identifier.clone();
-                                let deployer = config.get_deployer();
-                                if contract_identifier
-                                    == format!("{}.sbtc-deposit", deployer.stx_address)
-                                {
-                                    fund_genesis_account(
-                                        &devnet_event_tx,
-                                        &config.services_map_hosts,
-                                        &config.accounts,
-                                        config.deployment_fee_rate,
-                                        &boot_completed,
-                                    );
-                                }
+                                fund_genesis_account(
+                                    &devnet_event_tx,
+                                    &config.services_map_hosts,
+                                    &config.accounts,
+                                    config.deployment_fee_rate,
+                                    &boot_completed,
+                                );
                             }
-                        });
-                }
+                        }
+                    });
 
                 let _ = devnet_event_tx.send(DevnetEvent::StacksChainEvent(chain_event));
 
@@ -497,10 +493,10 @@ pub async fn start_chains_coordinator(
                         .saturating_sub(current_burn_height)
                         > 6
                     {
-                        std::thread::sleep(std::time::Duration::from_secs(1));
+                        std::thread::sleep(std::time::Duration::from_millis(750));
                     } else {
                         // as epoch 3.0 gets closer, bitcoin blocks need to slow down
-                        std::thread::sleep(std::time::Duration::from_secs(5));
+                        std::thread::sleep(std::time::Duration::from_millis(4000));
                     }
                     let res = mine_bitcoin_block(
                         &config.services_map_hosts.bitcoin_node_host,


### PR DESCRIPTION
### Description

Because the sbtc contract can be deployed at the end of a deployment plan, is possible that the `boot_completed` is set to true while the sbtc contracts are still in the mempool. So when they are deployed (after boot is completed), the sbtc funding tx were not triggered.
This PR fixes it.

it also tweaks some devnet timing value, that are promising to get a faster and stable devnet start to epoch 3.0

