### PR TITLE
fix: mxs tenure info

### DIFF
--- a/components/clarity-repl/src/repl/datastore.rs
+++ b/components/clarity-repl/src/repl/datastore.rs
@@ -498,11 +498,9 @@ impl ClarityBackingStore for ClarityDatastore {
     }
 
     fn get_block_at_height(&mut self, height: u32) -> Option<StacksBlockId> {
-        println!("get_block_at_height");
         if let Some(remote_network_info) = &self.remote_network_info {
             if height <= remote_network_info.initial_height {
                 let block_info = self.get_remote_block_info_from_height(height);
-                println!("block_info: {:#?}", block_info);
                 return Some(block_info.index_block_hash);
             }
         }

--- a/components/clarity-repl/src/repl/remote_data/mod.rs
+++ b/components/clarity-repl/src/repl/remote_data/mod.rs
@@ -203,11 +203,13 @@ impl HttpClient {
 
     pub fn fetch_sortition(&self, height: u32) -> Sortition {
         let url = format!("/v3/sortitions/burn_height/{}", height);
+        println!("fetching sortition from {}", url);
         let sortitions = self.get::<Vec<Sortition>>(&url).unwrap();
         sortitions.into_iter().next().unwrap()
     }
 
     pub fn fetch_block(&self, url: &str) -> Block {
+        println!("fetching block from {}", url);
         self.get::<Block>(url).unwrap()
     }
 

--- a/components/clarity-repl/src/repl/remote_data/mod.rs
+++ b/components/clarity-repl/src/repl/remote_data/mod.rs
@@ -203,13 +203,11 @@ impl HttpClient {
 
     pub fn fetch_sortition(&self, height: u32) -> Sortition {
         let url = format!("/v3/sortitions/burn_height/{}", height);
-        println!("fetching sortition from {}", url);
         let sortitions = self.get::<Vec<Sortition>>(&url).unwrap();
         sortitions.into_iter().next().unwrap()
     }
 
     pub fn fetch_block(&self, url: &str) -> Block {
-        println!("fetching block from {}", url);
         self.get::<Block>(url).unwrap()
     }
 

--- a/components/clarity-repl/tests/session_with_remote_data.rs
+++ b/components/clarity-repl/tests/session_with_remote_data.rs
@@ -211,20 +211,45 @@ fn it_can_get_tenure_info_time() {
     let result = eval_snippet(&mut session, "(get-tenure-info? time u50999)");
     assert_eq!(result, Value::some(Value::UInt(1736980481)).unwrap());
 }
+
 #[test]
 fn it_can_get_tenure_info_bhh() {
     let mut session = init_session(57000);
-
     let result = eval_snippet(
         &mut session,
         "(get-tenure-info? burnchain-header-hash u56888)",
     );
-
     let expected_header_hash =
         hex_bytes("026c12afb50b4baabb5cac8b940eda8b437f979b9819eef4cdd14c9f1a78133c").unwrap();
     assert_eq!(
         result,
         Value::some(Value::buff_from(expected_header_hash).unwrap()).unwrap()
+    );
+}
+
+#[test]
+fn it_can_get_tenure_info_vrf_seed() {
+    let mut session = init_session(57000);
+    let result = eval_snippet(&mut session, "(get-tenure-info? vrf-seed u51897)");
+    let expected_vrf_seed =
+        hex_bytes("5b2e70683c3d155621ce0f12fc905f571fc8ce487f3ffa0e9c7e75cea10b0990").unwrap();
+    assert_eq!(
+        result,
+        Value::some(Value::buff_from(expected_vrf_seed).unwrap()).unwrap()
+    );
+    let result = eval_snippet(&mut session, "(get-tenure-info? vrf-seed u51896)");
+    let expected_vrf_seed =
+        hex_bytes("5b2e70683c3d155621ce0f12fc905f571fc8ce487f3ffa0e9c7e75cea10b0990").unwrap();
+    assert_eq!(
+        result,
+        Value::some(Value::buff_from(expected_vrf_seed).unwrap()).unwrap()
+    );
+    let result = eval_snippet(&mut session, "(get-tenure-info? vrf-seed u50896)");
+    let expected_vrf_seed =
+        hex_bytes("33d5f1e379fc9779933f6b8a6d242b520103ceb1d71a75864665d0e036934df3").unwrap();
+    assert_eq!(
+        result,
+        Value::some(Value::buff_from(expected_vrf_seed).unwrap()).unwrap()
     );
 }
 

--- a/components/clarity-repl/tests/session_with_remote_data.rs
+++ b/components/clarity-repl/tests/session_with_remote_data.rs
@@ -204,6 +204,31 @@ fn it_keeps_track_of_historical_data() {
 }
 
 #[test]
+fn it_can_get_tenure_info_time() {
+    let mut session = init_session(57000);
+    let result = eval_snippet(&mut session, "(get-tenure-info? time u56999)");
+    assert_eq!(result, Value::some(Value::UInt(1737053962)).unwrap());
+    let result = eval_snippet(&mut session, "(get-tenure-info? time u50999)");
+    assert_eq!(result, Value::some(Value::UInt(1736980481)).unwrap());
+}
+#[test]
+fn it_can_get_tenure_info_bhh() {
+    let mut session = init_session(57000);
+
+    let result = eval_snippet(
+        &mut session,
+        "(get-tenure-info? burnchain-header-hash u56888)",
+    );
+
+    let expected_header_hash =
+        hex_bytes("026c12afb50b4baabb5cac8b940eda8b437f979b9819eef4cdd14c9f1a78133c").unwrap();
+    assert_eq!(
+        result,
+        Value::some(Value::buff_from(expected_header_hash).unwrap()).unwrap()
+    );
+}
+
+#[test]
 fn it_handles_chain_constants() {
     let mut session = init_session(57000);
     let result = eval_snippet(&mut session, "is-in-mainnet");


### PR DESCRIPTION
### Description

In the context of mainnet-execution simulation, fixes:
- `(get-tenure-info? vrf-seed <height>)` - `vrf-seed` is fetched in `/v3/sortitions/burn_height/<burn-height>`
- `(get-tenure-info? time <height>)` - `burn_block_time` was already fetched in `/extended/v2/blocks/<height>`