### PR TITLE
ci: allow running ci sdk release manually

### DIFF
--- a/.github/workflows/ci-sdk-release.yaml
+++ b/.github/workflows/ci-sdk-release.yaml
@@ -9,6 +9,7 @@ name: Publish clarinet-sdk packages to npm
 on:
   release:
     types: [published]
+  workflow_dispatch:
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description

Because the job wasn't trigger automatically for 2.16.0. We'll need to triggerit manually
