### PR TITLE
ci: fix sdk release workflow trigger

### DIFF
--- a/.github/workflows/ci-sdk-release.yaml
+++ b/.github/workflows/ci-sdk-release.yaml
@@ -7,9 +7,14 @@
 
 name: Publish clarinet-sdk packages to npm
 on:
-  release:
-    types: [published]
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "The tag of the release."
+        required: true
+  repository_dispatch:
+    types:
+      - released
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description

Trigger `ci-sdk-release.yaml` the same way `pkg-version-bump.yaml` [is triggered](https://github.com/hirosystems/clarinet/blob/5639c53af171561a87102bd72e3b9eef1e06bca0/.github/workflows/pkg-version-bump.yaml#L6-L14)