### PR TITLE
fix: set fsStore in globalThis

### DIFF
--- a/components/clarinet-sdk/browser/src/defaultVfs.ts
+++ b/components/clarinet-sdk/browser/src/defaultVfs.ts
@@ -1,7 +1,7 @@
 export const defaultFileStore = new Map<string, string>();
 
 // @ts-ignore
-window.fsStore = defaultFileStore;
+(globalThis as any).fsStore = defaultFileStore;
 
 function fileArrayToString(bufferArray: Uint8Array) {
   return Array.from(bufferArray)

--- a/components/clarinet-sdk/browser/src/defaultVfs.ts
+++ b/components/clarinet-sdk/browser/src/defaultVfs.ts
@@ -1,7 +1,7 @@
 export const defaultFileStore = new Map<string, string>();
 
 // @ts-ignore
-(globalThis as any).fsStore = defaultFileStore;
+globalThis.fsStore = defaultFileStore;
 
 function fileArrayToString(bufferArray: Uint8Array) {
   return Array.from(bufferArray)

--- a/components/clarinet-sdk/browser/src/index.ts
+++ b/components/clarinet-sdk/browser/src/index.ts
@@ -22,7 +22,7 @@ export { init, SDK, getSessionProxy, type Simnet };
 export { defaultVfs, defaultFileStore } from "./defaultVfs.js";
 
 // @ts-ignore
-window.vfs = defaultVfs;
+globalThis.vfs = defaultVfs;
 
 export const initSimnet = async (virtualFileSystem?: Function) => {
   await init();


### PR DESCRIPTION
### Description

In the browser version of the clarinet-sdk, use `globalThis` instead of window, so that it also works in web workers.