### PR TITLE
fix: preserve user newlines 

### DIFF
--- a/components/clarinet-format/src/formatter/mod.rs
+++ b/components/clarinet-format/src/formatter/mod.rs
@@ -347,6 +347,8 @@ impl<'a> Aggregator<'a> {
                             result_with_comment
                                 .push_str(&self.display_pse(comment, previous_indentation));
                             format!("{}\n", result_with_comment)
+                        } else if result.ends_with('\n') {
+                            result.to_string()
                         } else {
                             format!("{}\n", result)
                         }
@@ -1248,7 +1250,7 @@ mod tests_formatter {
     #[test]
     fn test_function_formatter() {
         let result = format_with_default(&String::from("(define-private (my-func) (ok true))"));
-        assert_eq!(result, "(define-private (my-func)\n  (ok true)\n)\n\n");
+        assert_eq!(result, "(define-private (my-func)\n  (ok true)\n)\n");
     }
 
     #[test]
@@ -1272,11 +1274,9 @@ mod tests_formatter {
         let expected = r#"(define-public (my-func)
   (ok true)
 )
-
 (define-public (my-func2)
   (ok true)
 )
-
 "#;
         assert_eq!(expected, result);
     }
@@ -1286,13 +1286,13 @@ mod tests_formatter {
         let result = format_with_default(&String::from(src));
         assert_eq!(
             result,
-            "(define-public (my-func (amount uint))\n  (ok true)\n)\n\n"
+            "(define-public (my-func (amount uint))\n  (ok true)\n)\n"
         );
         let src = "(define-public (my-func (amount uint)) (ok true))";
         let result = format_with_default(&String::from(src));
         assert_eq!(
             result,
-            "(define-public (my-func (amount uint))\n  (ok true)\n)\n\n"
+            "(define-public (my-func (amount uint))\n  (ok true)\n)\n"
         );
     }
     #[test]
@@ -1301,7 +1301,7 @@ mod tests_formatter {
         let result = format_with_default(&String::from(src));
         assert_eq!(
             result,
-            "(define-public (my-func\n    (amount uint)\n    (sender principal)\n  )\n  (ok true)\n)\n\n"
+            "(define-public (my-func\n    (amount uint)\n    (sender principal)\n  )\n  (ok true)\n)\n"
         );
     }
     #[test]
@@ -1502,7 +1502,6 @@ mod tests_formatter {
 (define-public (get-value)
   (ok (map-get? ns u2))
 )
-
 "#;
         let result = format_with_default(src);
         assert_eq!(result, src);
@@ -1636,7 +1635,6 @@ mod tests_formatter {
     (contract-call? core-contract parse-and-verify-vaa vaa-bytes)
   )
 )
-
 "#;
         let result = format_with_default(&String::from(src));
         assert_eq!(src, result);

--- a/components/clarinet-format/tests/golden-intended/BNS-V2.clar
+++ b/components/clarinet-format/tests/golden-intended/BNS-V2.clar
@@ -1,11 +1,13 @@
 ;; title: BNS-V2
 ;; version: V-2
 ;; summary: Updated BNS contract, handles the creation of new namespaces and new names on each namespace
+
 ;; traits
 ;; (new) Import SIP-09 NFT trait
 (impl-trait 'SP2PABAF9FTAJYNFZH93XENAJ8FVY99RRM50D2JG9.nft-trait.nft-trait)
 ;; (new) Import a custom commission trait for handling commissions for NFT marketplaces functions
 (use-trait commission-trait .commission-trait.commission)
+
 ;; token definition
 ;; (new) Define the non-fungible token (NFT) called BNS-V2 with unique identifiers as unsigned integers
 (define-non-fungible-token BNS-V2 uint)
@@ -25,10 +27,13 @@
     u64000000000 u64000000000
     u6400000000 u6400000000 u6400000000 u6400000000
     u640000000 u640000000 u640000000 u640000000 u640000000 u640000000 u640000000 u640000000 u640000000 u640000000 u640000000 u640000000 u640000000)
-);; Only authorized caller to flip the switch and update URI
+)
+;; Only authorized caller to flip the switch and update URI
 (define-constant DEPLOYER tx-sender)
+
 ;; (new) Var to store the token URI, allowing for metadata association with the NFT
 (define-data-var token-uri (string-ascii 256) "ipfs://QmUQY1aZ799SPRaNBFqeCvvmZ4fTQfZvWHauRvHAukyQDB")
+
 (define-public (update-token-uri (new-token-uri (string-ascii 256)))
     (ok (begin
         (asserts! (is-eq contract-caller DEPLOYER) ERR-NOT-AUTHORIZED)
@@ -37,6 +42,7 @@
 )
 
 (define-data-var contract-uri (string-ascii 256) "ipfs://QmWKTZEMQNWngp23i7bgPzkineYC9LDvcxYkwNyVQVoH8y")
+
 (define-public (update-contract-uri (new-contract-uri (string-ascii 256)))
     (ok (begin
         (asserts! (is-eq contract-caller DEPLOYER) ERR-NOT-AUTHORIZED)
@@ -76,11 +82,14 @@
 (define-constant ERR-LIFETIME-EQUAL-0 (err u129))
 (define-constant ERR-MIGRATION-IN-PROGRESS (err u130))
 (define-constant ERR-NO-PRIMARY-NAME (err u131))
+
 ;; variables
 ;; (new) Variable to see if migration is complete
 (define-data-var migration-complete bool false)
+
 ;; (new) Counter to keep track of the last minted NFT ID, ensuring unique identifiers
 (define-data-var bns-index uint u0)
+
 ;; maps
 ;; (new) Map to track market listings, associating NFT IDs with price and commission details
 (define-map market
@@ -90,6 +99,7 @@
         commission: principal,
     }
 )
+
 ;; (new) Define a map to link NFT IDs to their respective names and namespaces.
 (define-map index-to-name
     uint
@@ -106,6 +116,7 @@
     }
     uint
 )
+
 ;; (updated) Contains detailed properties of names, including registration and importation times
 (define-map name-properties
     {
@@ -124,6 +135,7 @@
         owner: principal,
     }
 )
+
 ;; (update) Stores properties of namespaces, including their import principals, reveal and launch times, and pricing functions.
 (define-map namespaces
     (buff 20)
@@ -145,6 +157,7 @@
         },
     }
 )
+
 ;; Records namespace preorder transactions with their creation times, and STX burned.
 (define-map namespace-preorders
     {
@@ -157,16 +170,19 @@
         claimed: bool,
     }
 )
+
 ;; Tracks preorders, to avoid attacks
 (define-map namespace-single-preorder
     (buff 20)
     bool
 )
+
 ;; Tracks preorders, to avoid attacks
 (define-map name-single-preorder
     (buff 20)
     bool
 )
+
 ;; Tracks preorders for names, including their creation times, and STX burned.
 (define-map name-preorders
     {
@@ -179,11 +195,13 @@
         claimed: bool,
     }
 )
+
 ;; It maps a user's principal to the ID of their primary name.
 (define-map primary-name
     principal
     uint
 )
+
 ;; read-only
 ;; @desc (new) SIP-09 compliant function to get the last minted token's ID
 (define-read-only (get-last-token-id)

--- a/components/clarinet-format/tests/golden-intended/clarity-bitcoin.clar
+++ b/components/clarinet-format/tests/golden-intended/clarity-bitcoin.clar
@@ -1,7 +1,10 @@
 ;; source: https://github.com/hirosystems/clarity-examples/blob/main/examples/clarity-bitcoin/contracts/clarity-bitcoin.clar
+
 ;; @contract stateless contract to verify bitcoin transaction
 ;; @version 5
+
 ;; version 5 adds support for txid generation and improves security
+
 ;; Error codes
 (define-constant ERR-OUT-OF-BOUNDS u1)
 (define-constant ERR-TOO-MANY-TXINS u2)
@@ -16,9 +19,11 @@
 (define-constant ERR-WITNESS-TX-NOT-IN-COMMITMENT u11)
 (define-constant ERR-NOT-SEGWIT-TRANSACTION u12)
 (define-constant ERR-LEFTOVER-DATA u13)
+
 ;;
 ;; Helper functions to parse bitcoin transactions
 ;;
+
 ;; Create a list with n elments `true`. n must be smaller than 9.
 (define-private (bool-list-of-len (n uint))
   (unwrap-panic (slice? (list true true true true true true true true) u0 n))
@@ -662,10 +667,12 @@
 
 ;; MOCK section
 (define-constant DEBUG-MODE true)
+
 (define-map mock-burnchain-header-hashes
   uint
   (buff 32)
 )
+
 (define-public (mock-add-burnchain-block-header-hash
     (burn-height uint)
     (hash (buff 32))
@@ -681,6 +688,7 @@
 )
 
 ;; END MOCK section
+
 ;; Verify that a block header hashes to a burnchain header hash at a given height.
 ;; Returns true if so; false if not.
 (define-read-only (verify-block-header
@@ -793,6 +801,7 @@
 )
 
 ;; Helper for wtxid commitments
+
 ;; Gets the scriptPubKey in the last output that follows the 0x6a24aa21a9ed pattern regardless of its content
 ;; as per BIP-0141 (https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki#commitment-structure)
 (define-read-only (get-commitment-scriptPubKey (outs (list 8 {
@@ -827,11 +836,13 @@
 ;;
 ;; Top-level verification functions
 ;;
+
 ;; Determine whether or not a Bitcoin transaction without witnesses
 ;; was mined in a prior Bitcoin block.
 ;; It takes the block height, the transaction, the block header and a merkle proof, and determines that:
 ;; * the block header corresponds to the block that was mined at the given Bitcoin height
 ;; * the transaction's merkle proof links it to the block header's merkle root.
+
 ;; To verify that the merkle root is part of the block header there are two options:
 ;; a) read the merkle root from the header buffer
 ;; b) build the header buffer from its parts including the merkle root

--- a/components/clarinet-format/tests/golden-intended/comments.clar
+++ b/components/clarinet-format/tests/golden-intended/comments.clar
@@ -1,20 +1,22 @@
 ;; comment
+;; comment
+
+;; comment
 (define-read-only (get-offer
     (id uint)
     (w uint)
   )
   (map-get? offers-map id)
 )
-
 (define-read-only (get-offer)
   (ok 1)
 )
-
 ;; top comment
 ;; @format-ignore
 (define-constant something (list
    1     2  3 ;; comment
    4 5 ))
+
 (define-read-only (something-else)
   (begin
     (+ 1 1)

--- a/components/clarinet-format/tests/golden/comments.clar
+++ b/components/clarinet-format/tests/golden/comments.clar
@@ -1,5 +1,8 @@
 ;; max_line_length: 80, indentation: 2
 ;; comment
+;; comment
+
+;; comment
 (define-read-only (get-offer (id uint) (w uint)) (map-get? offers-map id)
 )
 (define-read-only (get-offer) (ok 1))


### PR DESCRIPTION
Preserves user-provided newlines but squashes 2 or more into 1

closes #1697 
