### PR TITLE
feat: improve simnet epoch handling

### DIFF
--- a/components/clarinet-sdk/node/tests/deployment-plan.test.ts
+++ b/components/clarinet-sdk/node/tests/deployment-plan.test.ts
@@ -43,7 +43,7 @@ describe("deployment plans test", async () => {
     expect(fs.existsSync(deploymentPlanPath)).toBe(true);
 
     // make sure the simnet is running
-    expect(simnet.blockHeight).toBe(1);
+    expect(simnet.blockHeight).toBe(2);
   });
 
   it("can use custom deployment plan", async () => {

--- a/components/clarinet-sdk/node/tests/fixtures/EmptyManifest.toml
+++ b/components/clarinet-sdk/node/tests/fixtures/EmptyManifest.toml
@@ -1,0 +1,6 @@
+[project]
+name = 'fixtures'
+description = 'sample project to test clarinet-sdk'
+telemetry = false
+cache_dir = './.cache'
+requirements = []

--- a/components/clarinet-sdk/node/tests/pox-locking.test.ts
+++ b/components/clarinet-sdk/node/tests/pox-locking.test.ts
@@ -95,7 +95,7 @@ describe("test pox-3", () => {
     ];
     simnet.callPublicFn(poxContract, "stack-stx", stackStxArgs, address1);
 
-    simnet.mineEmptyBlocks(2098);
+    simnet.mineEmptyBlocks(2097);
     const stxAccountBefore = simnet.execute(`(stx-account '${address1})`);
     expect(stxAccountBefore.result).toStrictEqual(
       Cl.tuple({

--- a/components/clarinet-sdk/node/tests/simnet-usage.test.ts
+++ b/components/clarinet-sdk/node/tests/simnet-usage.test.ts
@@ -40,7 +40,7 @@ afterEach(() => {
 
 describe("basic simnet interactions", () => {
   it("initialize simnet", () => {
-    expect(simnet.blockHeight).toBe(1);
+    expect(simnet.blockHeight).toBe(2);
   });
 
   it("can run command", () => {
@@ -277,7 +277,7 @@ describe("simnet can call contracts function", () => {
 });
 
 describe("mineBlock and callPublicFunction properly handle block height incrementation", () => {
-  const expectedReturnedBH = 2;
+  const expectedReturnedBH = 3;
 
   it("increases the block height after the call in callPublicFn", () => {
     const { result } = simnet.callPublicFn("block-height-tests", "get-block-height", [], address1);

--- a/components/clarinet-sdk/node/tests/support-clarity-version.test.ts
+++ b/components/clarinet-sdk/node/tests/support-clarity-version.test.ts
@@ -4,16 +4,18 @@ import { describe, expect, it, beforeEach } from "vitest";
 // test the built package and not the source code
 // makes it simpler to handle wasm build
 import { Simnet, initSimnet } from "..";
+import { assert } from "node:console";
 
 let simnet: Simnet;
 
 beforeEach(async () => {
-  simnet = await initSimnet("tests/fixtures/Clarinet.toml");
+  simnet = await initSimnet("tests/fixtures/EmptyManifest.toml");
 });
 
 describe("the sdk handle all clarity version", () => {
   it("handle clarity 1", () => {
     simnet.setEpoch("2.05");
+    expect(simnet.currentEpoch).toBe("2.05");
     let resOk = simnet.execute('(index-of "stacks" "s")');
     expect(resOk.result).toStrictEqual(Cl.some(Cl.uint(0)));
 
@@ -60,7 +62,7 @@ describe("the sdk handle all clarity version", () => {
 
     // `tenure-height` was introduced in clarity 3
     let resOk3 = simnet.execute("(print tenure-height)");
-    expect(resOk3.result).toStrictEqual(Cl.uint(2));
+    expect(resOk3.result).toStrictEqual(Cl.uint(1));
 
     // `block-height` was removed in clarity 3
     expect(() => simnet.execute("(print block-height)")).toThrowError(


### PR DESCRIPTION
### Description

To get simnet behavior closer to what happens in mainnet, and prevent weird behaviour (when decreasing epoch):
- the epoch in simet can not be decreased
- updating the epoch increments the burn block height

fix: #1669

#### Breaking change?

Both changes can lead to breaking changes in simnet and can require tests to be updated


