### PR TITLE
fix: sdk tx arg serialization

### DIFF
--- a/components/clarinet-sdk/browser/src/sdkProxy.ts
+++ b/components/clarinet-sdk/browser/src/sdkProxy.ts
@@ -63,12 +63,7 @@ export function getSessionProxy() {
       if (prop === "callReadOnlyFn" || prop === "callPublicFn" || prop === "callPrivateFn") {
         const callFn: CallFn = (contract, method, args, sender) => {
           const response = session[prop](
-            new CallFnArgs(
-              contract,
-              method,
-              args.map((a) => serializeCVBytes(a)),
-              sender,
-            ),
+            new CallFnArgs(contract, method, args.map(serializeCVBytes), sender),
           );
           return parseTxResponse(response);
         };
@@ -112,7 +107,7 @@ export function getSessionProxy() {
               return {
                 callPublicFn: {
                   ...tx.callPublicFn,
-                  args_maps: tx.callPublicFn.args.map(Cl.serialize),
+                  args_maps: tx.callPublicFn.args.map(serializeCVBytes),
                 },
               };
             }
@@ -120,7 +115,7 @@ export function getSessionProxy() {
               return {
                 callPrivateFn: {
                   ...tx.callPrivateFn,
-                  args_maps: tx.callPrivateFn.args.map(Cl.serialize),
+                  args_maps: tx.callPrivateFn.args.map(serializeCVBytes),
                 },
               };
             }

--- a/components/clarinet-sdk/node/src/sdkProxy.ts
+++ b/components/clarinet-sdk/node/src/sdkProxy.ts
@@ -63,12 +63,7 @@ export function getSessionProxy() {
       if (prop === "callReadOnlyFn" || prop === "callPublicFn" || prop === "callPrivateFn") {
         const callFn: CallFn = (contract, method, args, sender) => {
           const response = session[prop](
-            new CallFnArgs(
-              contract,
-              method,
-              args.map((a) => serializeCVBytes(a)),
-              sender,
-            ),
+            new CallFnArgs(contract, method, args.map(serializeCVBytes), sender),
           );
           return parseTxResponse(response);
         };
@@ -112,7 +107,7 @@ export function getSessionProxy() {
               return {
                 callPublicFn: {
                   ...tx.callPublicFn,
-                  args_maps: tx.callPublicFn.args.map(Cl.serialize),
+                  args_maps: tx.callPublicFn.args.map(serializeCVBytes),
                 },
               };
             }
@@ -120,7 +115,7 @@ export function getSessionProxy() {
               return {
                 callPrivateFn: {
                   ...tx.callPrivateFn,
-                  args_maps: tx.callPrivateFn.args.map(Cl.serialize),
+                  args_maps: tx.callPrivateFn.args.map(serializeCVBytes),
                 },
               };
             }

--- a/components/clarinet-sdk/node/tests/simnet-usage.test.ts
+++ b/components/clarinet-sdk/node/tests/simnet-usage.test.ts
@@ -187,6 +187,19 @@ describe("simnet can call contracts function", () => {
     expect(res.result).toStrictEqual(Cl.ok(Cl.bool(true)));
   });
 
+  it("can call public functions in mineBlock", () => {
+    const res = simnet.mineBlock([
+      tx.callPublicFn("counter", "add", [Cl.uint(2)], address1),
+      tx.callPublicFn("counter", "add", [Cl.uint(3)], address1),
+    ]);
+
+    for (const tx of res) {
+      expect(tx.result).toStrictEqual(Cl.ok(Cl.bool(true)));
+    }
+    const count = simnet.getDataVar("counter", "count");
+    expect(count).toStrictEqual(Cl.uint(5));
+  });
+
   it("increases block height when calling public functions", () => {
     const initalBH = simnet.blockHeight;
 


### PR DESCRIPTION
### Description

`simnet.callPublicFn(...)` and `simnet.mineBlock([tx.callPublicFn(...)])` call different code paths.

`Cl.serialize()` has been replaced  with `serializeCVBytes()` but wasn't changed in `mineBlock()`

It wasn't caught because `mineBlock()` lacked unit tests