### PR TITLE
fix: list formatting breakage

### DIFF
--- a/components/clarinet-format/src/formatter/mod.rs
+++ b/components/clarinet-format/src/formatter/mod.rs
@@ -313,7 +313,7 @@ impl<'a> Aggregator<'a> {
                                     inner_content,
                                     if let Some(comment) = trailing_comment {
                                         format!(
-                                            " {}",
+                                            " {}\n",
                                             &self.display_pse(comment, previous_indentation)
                                         )
                                     } else if iter.peek().is_some() {
@@ -1263,7 +1263,7 @@ mod tests_formatter {
         let result = format_with_default(&String::from(src));
         assert_eq!(src, result);
 
-        let src = "(ok true) ;;     spaced";
+        let src = "(ok true) ;;     spaced\n";
         let result = format_with_default(&String::from(src));
         assert_eq!(src, result);
     }
@@ -1313,7 +1313,7 @@ mod tests_formatter {
 
     #[test]
     fn test_inline_comments_included() {
-        let src = "(ok true) ;; this is an inline comment";
+        let src = "(ok true) ;; this is an inline comment\n";
         let result = format_with_default(&String::from(src));
         assert_eq!(src, result);
     }
@@ -1767,6 +1767,47 @@ mod tests_formatter {
         assert_eq!(src, result);
     }
 
+    #[test]
+    fn inner_list_with_maps() {
+        let src = r#"(list
+  { extension: .ccd001-direct-execute,
+    enabled: true
+  }
+  ;; {extension: .ccd008-city-activation, enabled: true}
+  { extension: .ccd009-auth-v2-adapter,
+    enabled: true
+  }
+)"#;
+        let result = format_with_default(src);
+        assert_eq!(src, result);
+    }
+
+    #[test]
+    fn asdf() {
+        let src = r#"(var-set voteStart block-height) ;; vote tracking
+(define-data-var yesVotes uint u0)
+"#;
+        let result = format_with_default(src);
+        assert_eq!(src, result);
+    }
+    #[test]
+    fn significant_newline_preserving_inner() {
+        let src = r#";; comment
+
+;; another
+;; more
+
+
+;; after 2 spaces, now it's 1"#;
+        let result = format_with_default(src);
+        let expected = r#";; comment
+
+;; another
+;; more
+
+;; after 2 spaces, now it's 1"#;
+        assert_eq!(expected, result);
+    }
     #[test]
     fn significant_newline_preserving() {
         let src = r#";; comment

--- a/components/clarinet-format/tests/golden-intended/BNS-V2.clar
+++ b/components/clarinet-format/tests/golden-intended/BNS-V2.clar
@@ -907,8 +907,7 @@
             (price-function {
                 buckets: (list p-func-b1 p-func-b2 p-func-b3 p-func-b4 p-func-b5 p-func-b6
                     p-func-b7 p-func-b8 p-func-b9 p-func-b10 p-func-b11
-                    p-func-b12 p-func-b13 p-func-b14 p-func-b15 p-func-b16
-                ),
+                    p-func-b12 p-func-b13 p-func-b14 p-func-b15 p-func-b16),
                 base: p-func-base,
                 coeff: p-func-coeff,
                 nonalpha-discount: p-func-non-alpha-discount,
@@ -1194,8 +1193,7 @@
             (price-function {
                 buckets: (list p-func-b1 p-func-b2 p-func-b3 p-func-b4 p-func-b5 p-func-b6
                     p-func-b7 p-func-b8 p-func-b9 p-func-b10 p-func-b11
-                    p-func-b12 p-func-b13 p-func-b14 p-func-b15 p-func-b16
-                ),
+                    p-func-b12 p-func-b13 p-func-b14 p-func-b15 p-func-b16),
                 base: p-func-base,
                 coeff: p-func-coeff,
                 nonalpha-discount: p-func-non-alpha-discount,

--- a/components/clarinet-format/tests/golden-intended/clarity-bitcoin.clar
+++ b/components/clarinet-format/tests/golden-intended/clarity-bitcoin.clar
@@ -264,7 +264,8 @@
         index: uint,
       },
       remaining: uint,
-      txins: (list 8 {
+      txins: (list 8
+        {
         outpoint: {
           hash: (buff 32),
           index: uint,


### PR DESCRIPTION
- closes #1799 

- [x] fix inline comment newline issue
- [x] fix comment as item of a list
- [x] actually hand `format_list` for ListCons


This fixes the breakage in citycoins protocol contracts

![Screenshot 2025-05-12 at 11 52 28 AM](https://github.com/user-attachments/assets/5f555462-12b5-4afe-bf98-91b9f8a4328c)

