### PR TITLE
feat: Add `--stdin` flag to formatter

### DIFF
--- a/components/clarinet-cli/src/frontend/cli.rs
+++ b/components/clarinet-cli/src/frontend/cli.rs
@@ -167,7 +167,7 @@ impl FormatterInputSource {
         }
     }
 
-    fn filename(&self) -> Option<&str> {
+    fn file_path(&self) -> Option<&str> {
         match self {
             FormatterInputSource::File(path) => Some(path),
             FormatterInputSource::Stdin => None,
@@ -1304,7 +1304,7 @@ pub fn main() {
                 let output = formatter.format(&input);
                 if cmd.in_place {
                     let file_path = source
-                        .filename()
+                        .file_path()
                         .expect("No file path for in-place formatting");
                     let _ = overwrite_formatted(file_path, &output);
                 } else if cmd.dry_run || source.is_stdin() {


### PR DESCRIPTION
### Description

Fixes #1816

This is needed to use the formatter with Helix editor (at least until LSP working). May also be useful with other text editors

Also, some refactoring in here so that all files aren't read into RAM at the same time

### Example

#### Command

```sh
echo '(define-public (hello-world (input int)) (begin (print (+ 2 input)) (ok input)))' | clarinet format --stdin
```

#### Output

```clarity
(define-public (hello-world (input int))
  (begin
    (print (+ 2 input))
    (ok input)
  )
)
```

---

### Checklist

- [ ] Tests added in this PR (if applicable)

