### PR TITLE
feat: accept ast only in the formatter

### DIFF
--- a/components/clarinet-format/src/formatter/mod.rs
+++ b/components/clarinet-format/src/formatter/mod.rs
@@ -69,11 +69,16 @@ impl ClarityFormatter {
     /// formatting for files to ensure a newline at the end
     pub fn format_file(&self, source: &str) -> String {
         let pse = clarity::vm::ast::parser::v2::parse(source).unwrap();
-        let agg = Aggregator::new(&self.settings, &pse, source);
+        let agg = Aggregator::new(&self.settings, &pse, Some(source));
         let result = agg.generate();
 
         // make sure the file ends with a newline
         result.trim_end_matches('\n').to_string() + "\n"
+    }
+    /// formatting an AST without a source file
+    pub fn format_ast(&self, pse: &[PreSymbolicExpression]) -> String {
+        let agg = Aggregator::new(&self.settings, pse, None);
+        agg.generate()
     }
     /// Alias `format_file` to `format`
     pub fn format(&self, source: &str) -> String {
@@ -88,7 +93,7 @@ impl ClarityFormatter {
         // `previous_indentation` for format_source_exprs
         let indentation_level = source.chars().take_while(|c| c.is_whitespace()).count();
         let leading_spaces = &source[..indentation_level];
-        let agg = Aggregator::new(&self.settings, &pse, source);
+        let agg = Aggregator::new(&self.settings, &pse, Some(source));
 
         let result = agg.generate();
         if leading_spaces.is_empty() {
@@ -104,13 +109,17 @@ impl ClarityFormatter {
 pub struct Aggregator<'a> {
     settings: &'a Settings,
     pse: &'a [PreSymbolicExpression],
-    source: &'a str,
+    source: Option<&'a str>,
 
     cache: RefCell<HashMap<(usize, String), String>>,
 }
 
 impl<'a> Aggregator<'a> {
-    pub fn new(settings: &'a Settings, pse: &'a [PreSymbolicExpression], source: &'a str) -> Self {
+    pub fn new(
+        settings: &'a Settings,
+        pse: &'a [PreSymbolicExpression],
+        source: Option<&'a str>,
+    ) -> Self {
         Aggregator {
             settings,
             pse,
@@ -123,10 +132,9 @@ impl<'a> Aggregator<'a> {
         // this handles if we're formatting a section of code rather than the whole file
         let indentation_level = self
             .source
-            .chars()
-            .take_while(|c| c.is_whitespace())
-            .count();
-        self.format_source_exprs(self.pse, &self.source[..indentation_level])
+            .map_or(0, |s| s.chars().take_while(|c| c.is_whitespace()).count());
+        let previous_indentation = &self.source.unwrap_or_default()[..indentation_level];
+        self.format_source_exprs(self.pse, previous_indentation)
     }
 
     fn format_source_exprs(
@@ -164,7 +172,7 @@ impl<'a> Aggregator<'a> {
                     if let Some(block) = next.match_list() {
                         iter.next();
                         result.push('\n');
-                        result.push_str(&ignored_exprs(block, self.source));
+                        result.push_str(&ignored_exprs(block, self.source.unwrap_or_default()));
                     }
                 }
                 continue;
@@ -1980,5 +1988,14 @@ mod tests_formatter {
 }"#;
         let result = format_with_default(src);
         assert_eq!(expected, result);
+    }
+
+    #[test]
+    fn format_ast_without_source() {
+        let src = "(define-private (noop) (ok true))";
+        let ast = clarity::vm::ast::parser::v2::parse(src).unwrap();
+        let formatter = ClarityFormatter::new(Settings::default());
+        let result = formatter.format_ast(&ast);
+        assert_eq!(result, "(define-private (noop)\n  (ok true)\n)\n");
     }
 }


### PR DESCRIPTION
### Description

As part of the TS to Clarity transpiler project, I need to be able to format a Clarity AST (with no source) 

This PR makes the source optional in the formatter, and adds a `format_ast` function along with `format_file`