### PR TITLE
fix: Use correct `default()` function for initializing LSP options

### DIFF
--- a/components/clarity-lsp/src/common/requests/capabilities.rs
+++ b/components/clarity-lsp/src/common/requests/capabilities.rs
@@ -5,7 +5,7 @@ use lsp_types::{
 };
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase", default)]
 pub struct InitializationOptions {
     completion: bool,
@@ -18,8 +18,8 @@ pub struct InitializationOptions {
     signature_help: bool,
 }
 
-impl InitializationOptions {
-    pub fn default() -> Self {
+impl Default for InitializationOptions {
+    fn default() -> Self {
         InitializationOptions {
             completion: true,
             completion_smart_parenthesis_wrap: true,


### PR DESCRIPTION
### Description

By default, all the LSP initialization options are initialized to `false`, which means that we have to add extra config to the editor to get anything working

This is because the struct `InitializationOptions` is using the `default()` generated by `#[derive(Default)]` rather than the one we wrote. This PR removes the derived `default()` 

#### Breaking change?

No

### Example

We will no longer need this extra JSON to editor configs:

```json
  "lsp": {
    "clarity-lsp": {
      "enable_lsp_tasks": true,
      "initialization_options": {
        "completion": true,
        "completion_smart_parenthesis_wrap": true,
        "completion_include_native_placeholders": true,
        "document_symbols": false,
        "formatting": true,
        "go_to_definition": true,
        "hover": true,
        "signature_help": true
      }
    }
  },
``` 

### Checklist

- [ ] Tests added in this PR (if applicable)

