### PR TITLE
chore: Apply `clippy::manual_let_else`

### DIFF
--- a/components/clarinet-cli/src/deployments/mod.rs
+++ b/components/clarinet-cli/src/deployments/mod.rs
@@ -52,9 +52,8 @@ fn get_deployments_files(
     let mut project_dir = project_root_location.clone();
     let prefix_len = project_dir.to_string().len() + 1;
     project_dir.append_path("deployments")?;
-    let paths = match fs::read_dir(project_dir.to_string()) {
-        Ok(paths) => paths,
-        Err(_) => return Ok(vec![]),
+    let Ok(paths) = fs::read_dir(project_dir.to_string()) else {
+        return Ok(vec![]);
     };
     let mut plans_paths = vec![];
     for path in paths {

--- a/components/clarinet-cli/src/frontend/cli.rs
+++ b/components/clarinet-cli/src/frontend/cli.rs
@@ -1144,12 +1144,9 @@ pub fn main() {
             settings.repl_settings.analysis.enable_all_passes();
 
             let mut session = repl::Session::new(settings.clone());
-            let code_source = match fs::read_to_string(&file) {
-                Ok(code) => code,
-                _ => {
-                    eprintln!("{} unable to read file: '{}'", red!("error:"), file);
-                    std::process::exit(1);
-                }
+            let Ok(code_source) = fs::read_to_string(&file) else {
+                eprintln!("{} unable to read file: '{file}'", red!("error:"));
+                std::process::exit(1);
             };
             let contract_id = QualifiedContractIdentifier::transient();
             let epoch = DEFAULT_EPOCH;
@@ -1932,12 +1929,9 @@ fn devnet_start(cmd: DevnetStart, clarinetrc: ClarinetRC) {
     let result = match cmd.deployment_plan_path {
         None => {
             let res = if let Some(package) = cmd.package {
-                let package_file = match File::open(package) {
-                    Ok(file) => file,
-                    Err(_) => {
-                        eprintln!("{} package file not found", red!("error:"));
-                        std::process::exit(1);
-                    }
+                let Ok(package_file) = File::open(package) else {
+                    eprintln!("{} package file not found", red!("error:"));
+                    std::process::exit(1);
                 };
                 let deployment: ConfigurationPackage = serde_json::from_reader(package_file)
                     .expect("error while reading deployment specification");

--- a/components/clarinet-cli/src/lsp/mod.rs
+++ b/components/clarinet-cli/src/lsp/mod.rs
@@ -120,9 +120,7 @@ fn test_opening_counter_contract_should_return_fresh_analysis() {
 
     let _ = notification_tx.send(LspNotification::ContractOpened(contract_location.clone()));
     let response = response_rx.recv().expect("Unable to get response");
-    let response = if let LspResponse::Notification(response) = response {
-        response
-    } else {
+    let LspResponse::Notification(response) = response else {
         panic!("Unable to get response")
     };
 
@@ -134,9 +132,7 @@ fn test_opening_counter_contract_should_return_fresh_analysis() {
     // re-opening this contract should not trigger a full analysis
     let _ = notification_tx.send(LspNotification::ContractOpened(contract_location));
     let response = response_rx.recv().expect("Unable to get response");
-    let response = if let LspResponse::Notification(response) = response {
-        response
-    } else {
+    let LspResponse::Notification(response) = response else {
         panic!("Unable to get response")
     };
 
@@ -172,9 +168,7 @@ fn test_opening_counter_manifest_should_return_fresh_analysis() {
 
     let _ = notification_tx.send(LspNotification::ManifestOpened(manifest_location.clone()));
     let response = response_rx.recv().expect("Unable to get response");
-    let response = if let LspResponse::Notification(response) = response {
-        response
-    } else {
+    let LspResponse::Notification(response) = response else {
         panic!("Unable to get response")
     };
 
@@ -186,9 +180,7 @@ fn test_opening_counter_manifest_should_return_fresh_analysis() {
     // re-opening this manifest should not trigger a full analysis
     let _ = notification_tx.send(LspNotification::ManifestOpened(manifest_location));
     let response = response_rx.recv().expect("Unable to get response");
-    let response = if let LspResponse::Notification(response) = response {
-        response
-    } else {
+    let LspResponse::Notification(response) = response else {
         panic!("Unable to get response")
     };
     assert_eq!(response, LspNotificationResponse::default());
@@ -222,9 +214,7 @@ fn test_opening_simple_nft_manifest_should_return_fresh_analysis() {
         manifest_location,
     )));
     let response = response_rx.recv().expect("Unable to get response");
-    let response = if let LspResponse::Notification(response) = response {
-        response
-    } else {
+    let LspResponse::Notification(response) = response else {
         panic!("Unable to get response")
     };
 

--- a/components/clarinet-deployments/src/types.rs
+++ b/components/clarinet-deployments/src/types.rs
@@ -324,25 +324,19 @@ impl StxTransferSpecification {
     pub fn from_specifications(
         specs: &StxTransferSpecificationFile,
     ) -> Result<StxTransferSpecification, String> {
-        let expected_sender = match PrincipalData::parse_standard_principal(&specs.expected_sender)
-        {
-            Ok(res) => res,
-            Err(_) => {
-                return Err(format!(
-                    "unable to parse expected sender '{}' as a valid Stacks address",
-                    specs.expected_sender
-                ))
-            }
+        let Ok(expected_sender) = PrincipalData::parse_standard_principal(&specs.expected_sender)
+        else {
+            return Err(format!(
+                "unable to parse expected sender '{}' as a valid Stacks address",
+                specs.expected_sender
+            ));
         };
 
-        let recipient = match PrincipalData::parse(&specs.recipient) {
-            Ok(res) => res,
-            Err(_) => {
-                return Err(format!(
-                    "unable to parse recipient '{}' as a valid Stacks address",
-                    specs.expected_sender
-                ))
-            }
+        let Ok(recipient) = PrincipalData::parse(&specs.recipient) else {
+            return Err(format!(
+                "unable to parse recipient '{}' as a valid Stacks address",
+                specs.expected_sender
+            ));
         };
 
         let mut memo = [0u8; 34];
@@ -408,35 +402,26 @@ impl ContractCallSpecification {
     pub fn from_specifications(
         specs: &ContractCallSpecificationFile,
     ) -> Result<ContractCallSpecification, String> {
-        let contract_id = match QualifiedContractIdentifier::parse(&specs.contract_id) {
-            Ok(res) => res,
-            Err(_) => {
-                return Err(format!(
-                    "unable to parse '{}' as a valid contract identifier",
-                    specs.contract_id
-                ))
-            }
+        let Ok(contract_id) = QualifiedContractIdentifier::parse(&specs.contract_id) else {
+            return Err(format!(
+                "unable to parse '{}' as a valid contract identifier",
+                specs.contract_id
+            ));
         };
 
-        let expected_sender = match PrincipalData::parse_standard_principal(&specs.expected_sender)
-        {
-            Ok(res) => res,
-            Err(_) => {
-                return Err(format!(
-                    "unable to parse emulated sender '{}' as a valid Stacks address",
-                    specs.expected_sender
-                ))
-            }
+        let Ok(expected_sender) = PrincipalData::parse_standard_principal(&specs.expected_sender)
+        else {
+            return Err(format!(
+                "unable to parse emulated sender '{}' as a valid Stacks address",
+                specs.expected_sender
+            ));
         };
 
-        let method = match ClarityName::try_from(specs.method.to_string()) {
-            Ok(res) => res,
-            Err(_) => {
-                return Err(format!(
-                    "unable to parse '{}' as a valid contract name",
-                    specs.method
-                ))
-            }
+        let Ok(method) = ClarityName::try_from(specs.method.to_string()) else {
+            return Err(format!(
+                "unable to parse '{}' as a valid contract name",
+                specs.method
+            ));
         };
 
         Ok(ContractCallSpecification {
@@ -469,25 +454,19 @@ impl ContractPublishSpecification {
         specs: &ContractPublishSpecificationFile,
         project_root_location: &FileLocation,
     ) -> Result<ContractPublishSpecification, String> {
-        let contract_name = match ContractName::try_from(specs.contract_name.to_string()) {
-            Ok(res) => res,
-            Err(_) => {
-                return Err(format!(
-                    "unable to parse '{}' as a valid contract name",
-                    specs.contract_name
-                ))
-            }
+        let Ok(contract_name) = ContractName::try_from(specs.contract_name.to_string()) else {
+            return Err(format!(
+                "unable to parse '{}' as a valid contract name",
+                specs.contract_name
+            ));
         };
 
-        let expected_sender = match PrincipalData::parse_standard_principal(&specs.expected_sender)
-        {
-            Ok(res) => res,
-            Err(_) => {
-                return Err(format!(
-                    "unable to parse expected sender '{}' as a valid Stacks address",
-                    specs.expected_sender
-                ))
-            }
+        let Ok(expected_sender) = PrincipalData::parse_standard_principal(&specs.expected_sender)
+        else {
+            return Err(format!(
+                "unable to parse expected sender '{}' as a valid Stacks address",
+                specs.expected_sender
+            ));
         };
 
         let location = match (&specs.path, &specs.url) {
@@ -694,46 +673,34 @@ impl RequirementPublishSpecification {
         specs: &RequirementPublishSpecificationFile,
         project_root_location: &FileLocation,
     ) -> Result<RequirementPublishSpecification, String> {
-        let contract_id = match QualifiedContractIdentifier::parse(&specs.contract_id) {
-            Ok(res) => res,
-            Err(_) => {
-                return Err(format!(
-                    "unable to parse '{}' as a valid contract identifier",
-                    specs.contract_id
-                ))
-            }
+        let Ok(contract_id) = QualifiedContractIdentifier::parse(&specs.contract_id) else {
+            return Err(format!(
+                "unable to parse '{}' as a valid contract identifier",
+                specs.contract_id
+            ));
         };
 
-        let remap_sender = match PrincipalData::parse_standard_principal(&specs.remap_sender) {
-            Ok(res) => res,
-            Err(_) => {
-                return Err(format!(
-                    "unable to parse remap sender '{}' as a valid Stacks address",
-                    specs.remap_sender
-                ))
-            }
+        let Ok(remap_sender) = PrincipalData::parse_standard_principal(&specs.remap_sender) else {
+            return Err(format!(
+                "unable to parse remap sender '{}' as a valid Stacks address",
+                specs.remap_sender
+            ));
         };
 
         let mut remap_principals = BTreeMap::new();
         if let Some(ref remap_principals_spec) = specs.remap_principals {
             for (src_spec, dst_spec) in remap_principals_spec {
-                let src = match PrincipalData::parse_standard_principal(src_spec) {
-                    Ok(res) => res,
-                    Err(_) => {
-                        return Err(format!(
-                            "unable to parse remap source '{}' as a valid Stacks address",
-                            specs.remap_sender
-                        ))
-                    }
+                let Ok(src) = PrincipalData::parse_standard_principal(src_spec) else {
+                    return Err(format!(
+                        "unable to parse remap source '{}' as a valid Stacks address",
+                        specs.remap_sender
+                    ));
                 };
-                let dst = match PrincipalData::parse_standard_principal(dst_spec) {
-                    Ok(res) => res,
-                    Err(_) => {
-                        return Err(format!(
-                            "unable to parse remap destination '{}' as a valid Stacks address",
-                            specs.remap_sender
-                        ))
-                    }
+                let Ok(dst) = PrincipalData::parse_standard_principal(dst_spec) else {
+                    return Err(format!(
+                        "unable to parse remap destination '{}' as a valid Stacks address",
+                        specs.remap_sender
+                    ));
                 };
                 remap_principals.insert(src, dst);
             }
@@ -792,35 +759,26 @@ impl EmulatedContractCallSpecification {
     pub fn from_specifications(
         specs: &EmulatedContractCallSpecificationFile,
     ) -> Result<EmulatedContractCallSpecification, String> {
-        let contract_id = match QualifiedContractIdentifier::parse(&specs.contract_id) {
-            Ok(res) => res,
-            Err(_) => {
-                return Err(format!(
-                    "unable to parse '{}' as a valid contract_id",
-                    specs.contract_id
-                ))
-            }
+        let Ok(contract_id) = QualifiedContractIdentifier::parse(&specs.contract_id) else {
+            return Err(format!(
+                "unable to parse '{}' as a valid contract_id",
+                specs.contract_id
+            ));
         };
 
-        let emulated_sender = match PrincipalData::parse_standard_principal(&specs.emulated_sender)
-        {
-            Ok(res) => res,
-            Err(_) => {
-                return Err(format!(
-                    "unable to parse emulated sender '{}' as a valid Stacks address",
-                    specs.emulated_sender
-                ))
-            }
+        let Ok(emulated_sender) = PrincipalData::parse_standard_principal(&specs.emulated_sender)
+        else {
+            return Err(format!(
+                "unable to parse emulated sender '{}' as a valid Stacks address",
+                specs.emulated_sender
+            ));
         };
 
-        let method = match ClarityName::try_from(specs.method.to_string()) {
-            Ok(res) => res,
-            Err(_) => {
-                return Err(format!(
-                    "unable to parse '{}' as a valid contract name",
-                    specs.method
-                ))
-            }
+        let Ok(method) = ClarityName::try_from(specs.method.to_string()) else {
+            return Err(format!(
+                "unable to parse '{}' as a valid contract name",
+                specs.method
+            ));
         };
 
         Ok(EmulatedContractCallSpecification {
@@ -849,25 +807,19 @@ impl EmulatedContractPublishSpecification {
         project_root_location: &FileLocation,
         source: Option<String>,
     ) -> Result<EmulatedContractPublishSpecification, String> {
-        let contract_name = match ContractName::try_from(specs.contract_name.to_string()) {
-            Ok(res) => res,
-            Err(_) => {
-                return Err(format!(
-                    "unable to parse '{}' as a valid contract name",
-                    specs.contract_name
-                ))
-            }
+        let Ok(contract_name) = ContractName::try_from(specs.contract_name.to_string()) else {
+            return Err(format!(
+                "unable to parse '{}' as a valid contract name",
+                specs.contract_name
+            ));
         };
 
-        let emulated_sender = match PrincipalData::parse_standard_principal(&specs.emulated_sender)
-        {
-            Ok(res) => res,
-            Err(_) => {
-                return Err(format!(
-                    "unable to parse emulated sender '{}' as a valid Stacks address",
-                    specs.emulated_sender
-                ))
-            }
+        let Ok(emulated_sender) = PrincipalData::parse_standard_principal(&specs.emulated_sender)
+        else {
+            return Err(format!(
+                "unable to parse emulated sender '{}' as a valid Stacks address",
+                specs.emulated_sender
+            ));
         };
 
         let location = match (&specs.path, &specs.url) {

--- a/components/clarinet-files/src/project_manifest.rs
+++ b/components/clarinet-files/src/project_manifest.rs
@@ -78,9 +78,8 @@ where
         serde::Deserialize::deserialize(des)?;
 
     for (contract_name, contract_settings) in container {
-        let contract_path = match contract_settings.get("path") {
-            Some(JsonValue::String(path)) => path,
-            _ => continue,
+        let Some(JsonValue::String(contract_path)) = contract_settings.get("path") else {
+            continue;
         };
 
         let code_source = match PathBuf::from_str(contract_path) {
@@ -303,14 +302,14 @@ impl ProjectManifest {
         if let Some(TomlValue::Table(contracts)) = project_manifest_file.contracts {
             for (contract_name, contract_settings) in contracts.iter() {
                 if let TomlValue::Table(contract_settings) = contract_settings {
-                    let contract_path = match contract_settings.get("path") {
-                        Some(TomlValue::String(path)) => path,
-                        _ => continue,
+                    let Some(TomlValue::String(contract_path)) = contract_settings.get("path")
+                    else {
+                        continue;
                     };
                     let code_source = match PathBuf::from_str(contract_path) {
                         Ok(path) => ClarityCodeSource::ContractOnDisk(path),
                         Err(e) => {
-                            return Err(format!("unable to parse path {} ({})", contract_path, e))
+                            return Err(format!("unable to parse path {contract_path} ({e})"))
                         }
                     };
                     let deployer = match contract_settings.get("deployer") {

--- a/components/clarity-lsp/src/common/state.rs
+++ b/components/clarity-lsp/src/common/state.rs
@@ -297,9 +297,8 @@ impl EditorState {
         contract_location: &FileLocation,
         position: &Position,
     ) -> Vec<lsp_types::CompletionItem> {
-        let active_contract = match self.active_contracts.get(contract_location) {
-            Some(contract) => contract,
-            None => return vec![],
+        let Some(active_contract) = self.active_contracts.get(contract_location) else {
+            return vec![];
         };
 
         let contract_calls = self
@@ -335,14 +334,12 @@ impl EditorState {
         &self,
         contract_location: &FileLocation,
     ) -> Vec<DocumentSymbol> {
-        let active_contract = match self.active_contracts.get(contract_location) {
-            Some(contract) => contract,
-            None => return vec![],
+        let Some(active_contract) = self.active_contracts.get(contract_location) else {
+            return vec![];
         };
 
-        let expressions = match &active_contract.expressions {
-            Some(expressions) => expressions,
-            None => return vec![],
+        let Some(expressions) = &active_contract.expressions else {
+            return vec![];
         };
 
         let ast_symbols = ASTSymbols::new();
@@ -570,20 +567,16 @@ impl ProtocolState {
 
         // Add / Replace new paths
         for (contract_id, contract_location) in locations.iter() {
-            let (contract_id, ast) = match asts.remove_entry(contract_id) {
-                Some(ast) => ast,
-                None => continue,
+            let Some((contract_id, ast)) = asts.remove_entry(contract_id) else {
+                continue;
             };
-            let deps = match deps.remove(&contract_id) {
-                Some(deps) => deps,
-                None => DependencySet::new(),
-            };
+            let deps = deps.remove(&contract_id).unwrap_or_default();
             let diags = diags.remove(&contract_id).unwrap_or_default();
             let analysis = analyses.remove(&contract_id).unwrap_or_default();
-            let clarity_version = match clarity_versions.remove(&contract_id) {
-                Some(analysis) => analysis,
-                None => DEFAULT_CLARITY_VERSION,
-            };
+            let clarity_version = clarity_versions
+                .remove(&contract_id)
+                .unwrap_or(DEFAULT_CLARITY_VERSION);
+
             let definitions = definitions.remove(&contract_id).unwrap_or_default();
 
             let contract_state = ContractState::new(
@@ -657,9 +650,8 @@ pub async fn build_state(
         Some(StacksEpochId::Epoch21),
     );
     for (contract_id, mut result) in contracts.into_iter() {
-        let (_, contract_location) = match deployment.contracts.get(&contract_id) {
-            Some(entry) => entry,
-            None => continue,
+        let Some((_, contract_location)) = deployment.contracts.get(&contract_id) else {
+            continue;
         };
         locations.insert(contract_id.clone(), contract_location.clone());
         if let Some(contract_metadata) = manifest.contracts_settings.get(contract_location) {

--- a/components/clarity-repl/src/analysis/ast_dependency_detector.rs
+++ b/components/clarity-repl/src/analysis/ast_dependency_detector.rs
@@ -289,14 +289,11 @@ impl<'a> ASTDependencyDetector<'a> {
                 if contract_epoch < dep_epoch {
                     return Err(CheckErrors::NoSuchContract(dep.contract_id.to_string()).into());
                 }
-                let dep_id = match lookup.get(&dep.contract_id) {
-                    Some(id) => id,
-                    None => {
-                        // No need to report an error here, it will be caught
-                        // and reported with proper location information by the
-                        // later analyses. Just skip it.
-                        continue;
-                    }
+                let Some(dep_id) = lookup.get(&dep.contract_id) else {
+                    // No need to report an error here, it will be caught
+                    // and reported with proper location information by the
+                    // later analyses. Just skip it.
+                    continue;
                 };
                 graph.add_directed_edge(*contract_id, *dep_id);
             }
@@ -448,9 +445,8 @@ impl<'a> ASTDependencyDetector<'a> {
         // Since this may run before checkers, the function may not be valid.
         // If the key does not exist, just return an empty set and the error
         // will be reported elsewhere.
-        let function_signature = match trait_definition.get(function_name) {
-            Some(signature) => signature,
-            None => return BTreeSet::new(),
+        let Some(function_signature) = trait_definition.get(function_name) else {
+            return BTreeSet::new();
         };
         self.check_callee_type(&function_signature.args, args)
     }
@@ -458,9 +454,8 @@ impl<'a> ASTDependencyDetector<'a> {
     // A trait can only come from a parameter (cannot be a let binding or a return value), so
     // find the corresponding parameter and return it.
     fn get_param_trait(&self, name: &ClarityName) -> Option<&'a TraitIdentifier> {
-        let params = match &self.params {
-            None => return None,
-            Some(params) => params,
+        let Some(params) = &self.params else {
+            return None;
         };
         for param in params {
             if param.name == name {

--- a/components/clarity-repl/src/repl/debug/cli.rs
+++ b/components/clarity-repl/src/repl/debug/cli.rs
@@ -228,20 +228,16 @@ impl CLIDebugger {
                 if arg_list.len() == 1 {
                     self.state.delete_all_breakpoints();
                 } else {
-                    let id = match arg_list[1].parse::<usize>() {
-                        Ok(id) => id,
-                        Err(_) => {
-                            println!("{}", format_err!("unable to parse breakpoint identifier"));
-                            return;
-                        }
+                    let Ok(id) = arg_list[1].parse::<usize>() else {
+                        println!("{}", format_err!("unable to parse breakpoint identifier"));
+                        return;
                     };
                     if self.state.delete_breakpoint(id) {
                         println!("breakpoint deleted");
                     } else {
                         println!(
-                            "{} '{}' is not a currently valid breakpoint id",
+                            "{} '{id}' is not a currently valid breakpoint id",
                             red!("error:"),
-                            id
                         );
                     }
                 }
@@ -295,13 +291,10 @@ impl CLIDebugger {
                         }
                     };
 
-                    let line = match parts[1].parse::<u32>() {
-                        Ok(line) => line,
-                        Err(_) => {
-                            println!("{}", format_err!("invalid breakpoint format"),);
-                            print_help_breakpoint();
-                            return;
-                        }
+                    let Ok(line) = parts[1].parse::<u32>() else {
+                        println!("{}", format_err!("invalid breakpoint format"),);
+                        print_help_breakpoint();
+                        return;
                     };
 
                     let column = if parts.len() == 3 {
@@ -412,7 +405,7 @@ impl CLIDebugger {
                     println!("No watchpoints set.")
                 } else {
                     for watchpoint in self.state.watchpoints.values() {
-                        println!("{}", watchpoint);
+                        println!("{watchpoint}");
                     }
                 }
             }
@@ -421,20 +414,16 @@ impl CLIDebugger {
                 if arg_list.len() == 1 {
                     self.state.delete_all_watchpoints();
                 } else {
-                    let id = match arg_list[1].parse::<usize>() {
-                        Ok(id) => id,
-                        Err(_) => {
-                            println!("{}", format_err!("unable to parse watchpoint identifier"));
-                            return;
-                        }
+                    let Ok(id) = arg_list[1].parse::<usize>() else {
+                        println!("{}", format_err!("unable to parse watchpoint identifier"));
+                        return;
                     };
                     if self.state.delete_watchpoint(id) {
                         println!("watchpoint deleted");
                     } else {
                         println!(
-                            "{} '{}' is not a currently valid watchpoint id",
+                            "{} '{id}' is not a currently valid watchpoint id",
                             red!("error:"),
-                            id
                         );
                     }
                 }

--- a/components/clarity-repl/src/repl/debug/mod.rs
+++ b/components/clarity-repl/src/repl/debug/mod.rs
@@ -367,9 +367,8 @@ impl DebugState {
                     continue;
                 }
 
-                let breakpoint = match self.breakpoints.get(id) {
-                    Some(breakpoint) => breakpoint,
-                    None => panic!("internal error: breakpoint {} not found", id),
+                let Some(breakpoint) = self.breakpoints.get(id) else {
+                    panic!("internal error: breakpoint {} not found", id);
                 };
 
                 if let Some(break_span) = &breakpoint.span {
@@ -430,12 +429,8 @@ impl DebugState {
                                 let key = (contract_id.clone(), name);
                                 if let Some(set) = self.watch_variables.get(&key) {
                                     for id in set {
-                                        let watchpoint = match self.watchpoints.get(id) {
-                                            Some(watchpoint) => watchpoint,
-                                            None => panic!(
-                                                "internal error: watchpoint {} not found",
-                                                id
-                                            ),
+                                        let Some(watchpoint) = self.watchpoints.get(id) else {
+                                            panic!("internal error: watchpoint {} not found", id);
                                         };
 
                                         if let BreakpointData::Data(data) = &watchpoint.data {

--- a/components/clarity-repl/src/repl/interpreter.rs
+++ b/components/clarity-repl/src/repl/interpreter.rs
@@ -473,14 +473,13 @@ impl ClarityInterpreter {
                 if let List(expression) = &contract_ast.expressions[0].expr {
                     if let Atom(name) = &expression[0].expr {
                         if name.to_string() == "contract-call?" {
-                            let contract_id = match expression[1]
+                            let Ok(PrincipalData::Contract(contract_id)) = expression[1]
                                 .match_literal_value()
                                 .unwrap()
                                 .clone()
                                 .expect_principal()
-                            {
-                                Ok(PrincipalData::Contract(contract_id)) => contract_id,
-                                _ => unreachable!(),
+                            else {
+                                unreachable!();
                             };
                             let method = expression[2].match_atom().unwrap().to_string();
                             let mut args = vec![];
@@ -679,14 +678,13 @@ impl ClarityInterpreter {
                 if let List(expression) = &contract_ast.expressions[0].expr {
                     if let Atom(name) = &expression[0].expr {
                         if name.to_string() == "contract-call?" {
-                            let contract_id = match expression[1]
+                            let Ok(PrincipalData::Contract(contract_id)) = expression[1]
                                 .match_literal_value()
                                 .unwrap()
                                 .clone()
                                 .expect_principal()
-                            {
-                                Ok(PrincipalData::Contract(contract_id)) => contract_id,
-                                _ => unreachable!(),
+                            else {
+                                unreachable!();
                             };
                             let method = expression[2].match_atom().unwrap().to_string();
                             let mut args = vec![];
@@ -712,7 +710,7 @@ impl ClarityInterpreter {
                             ) {
                                 Ok(res) => res,
                                 Err(e) => {
-                                    println!("Error while calling function: {:?}", e);
+                                    println!("Error while calling function: {e:?}");
                                     return Err(e);
                                 }
                             };
@@ -1953,9 +1951,8 @@ mod tests {
             "(get-tenure-info? time u2)",
             ClarityVersion::Clarity3,
         );
-        let time_block_1 = match snippet_1.expect_optional() {
-            Ok(Some(Value::UInt(time))) => time,
-            _ => panic!("Unexpected result"),
+        let Ok(Some(Value::UInt(time_block_1))) = snippet_1.expect_optional() else {
+            panic!("Unexpected result");
         };
 
         let snippet_2 = run_snippet(
@@ -1963,9 +1960,8 @@ mod tests {
             "(get-tenure-info? time u3)",
             ClarityVersion::Clarity3,
         );
-        let time_block_2 = match snippet_2.expect_optional() {
-            Ok(Some(Value::UInt(time))) => time,
-            _ => panic!("Unexpected result"),
+        let Ok(Some(Value::UInt(time_block_2))) = snippet_2.expect_optional() else {
+            panic!("Unexpected result");
         };
         assert_eq!(time_block_2 - time_block_1, 600);
     }
@@ -1982,9 +1978,8 @@ mod tests {
             "(get-tenure-info? time (- stacks-block-height u1))",
             ClarityVersion::Clarity3,
         );
-        let last_tenure_time = match snippet_1.expect_optional() {
-            Ok(Some(Value::UInt(time))) => time,
-            _ => panic!("Unexpected result"),
+        let Ok(Some(Value::UInt(last_tenure_time))) = snippet_1.expect_optional() else {
+            panic!("Unexpected result");
         };
 
         let snippet_2 = run_snippet(
@@ -1992,9 +1987,8 @@ mod tests {
             "(get-stacks-block-info? time (- stacks-block-height u1))",
             ClarityVersion::Clarity3,
         );
-        let last_stacks_block_time = match snippet_2.expect_optional() {
-            Ok(Some(Value::UInt(time))) => time,
-            _ => panic!("Unexpected result"),
+        let Ok(Some(Value::UInt(last_stacks_block_time))) = snippet_2.expect_optional() else {
+            panic!("Unexpected result");
         };
         assert_eq!((last_stacks_block_time) - (last_tenure_time), 10);
     }
@@ -2011,9 +2005,8 @@ mod tests {
             "(get-stacks-block-info? time u2)",
             ClarityVersion::Clarity3,
         );
-        let time_block_1 = match snippet_1.expect_optional() {
-            Ok(Some(Value::UInt(time))) => time,
-            _ => panic!("Unexpected result"),
+        let Ok(Some(Value::UInt(time_block_1))) = snippet_1.expect_optional() else {
+            panic!("Unexpected result");
         };
 
         let snippet_2 = run_snippet(
@@ -2021,9 +2014,8 @@ mod tests {
             "(get-stacks-block-info? time u3)",
             ClarityVersion::Clarity3,
         );
-        let time_block_2 = match snippet_2.expect_optional() {
-            Ok(Some(Value::UInt(time))) => time,
-            _ => panic!("Unexpected result"),
+        let Ok(Some(Value::UInt(time_block_2))) = snippet_2.expect_optional() else {
+            panic!("Unexpected result");
         };
         assert_eq!(time_block_2 - time_block_1, 10);
     }
@@ -2043,9 +2035,8 @@ mod tests {
             "(get-stacks-block-info? time u1)",
             ClarityVersion::Clarity3,
         );
-        let stacks_block_time_1 = match snippet_1.expect_optional() {
-            Ok(Some(Value::UInt(time))) => time,
-            _ => panic!("Unexpected result"),
+        let Ok(Some(Value::UInt(stacks_block_time_1))) = snippet_1.expect_optional() else {
+            panic!("Unexpected result");
         };
 
         let snippet_2 = run_snippet(
@@ -2053,9 +2044,8 @@ mod tests {
             "(get-stacks-block-info? time u101)",
             ClarityVersion::Clarity3,
         );
-        let stacks_block_time_2 = match snippet_2.expect_optional() {
-            Ok(Some(Value::UInt(time))) => time,
-            _ => panic!("Unexpected result"),
+        let Ok(Some(Value::UInt(stacks_block_time_2))) = snippet_2.expect_optional() else {
+            panic!("Unexpected result");
         };
         assert_eq!(stacks_block_time_2 - stacks_block_time_1, 1000);
 
@@ -2067,9 +2057,8 @@ mod tests {
             "(get-tenure-info? time u4)",
             ClarityVersion::Clarity3,
         );
-        let tenure_height_1 = match snippet_3.expect_optional() {
-            Ok(Some(Value::UInt(time))) => time,
-            _ => panic!("Unexpected result"),
+        let Ok(Some(Value::UInt(tenure_height_1))) = snippet_3.expect_optional() else {
+            panic!("Unexpected result");
         };
 
         let snippet_4 = run_snippet(
@@ -2077,9 +2066,8 @@ mod tests {
             "(get-tenure-info? time (- stacks-block-height u1))",
             ClarityVersion::Clarity3,
         );
-        let tenure_height_2 = match snippet_4.expect_optional() {
-            Ok(Some(Value::UInt(time))) => time,
-            _ => panic!("Unexpected result"),
+        let Ok(Some(Value::UInt(tenure_height_2))) = snippet_4.expect_optional() else {
+            panic!("Unexpected result");
         };
 
         assert_eq!(1030, tenure_height_2 - tenure_height_1);

--- a/components/clarity-repl/src/repl/tracer.rs
+++ b/components/clarity-repl/src/repl/tracer.rs
@@ -36,9 +36,8 @@ impl EvalHook for Tracer {
         context: &LocalContext,
         expr: &SymbolicExpression,
     ) {
-        let list = match &expr.expr {
-            List(list) => list,
-            _ => return,
+        let List(list) = &expr.expr else {
+            return;
         };
         if let Some((function_name, args)) = list.split_first() {
             if let Some(function_name) = function_name.match_atom() {

--- a/components/stacks-codec/src/codec.rs
+++ b/components/stacks-codec/src/codec.rs
@@ -3234,11 +3234,8 @@ impl StacksMessageCodec for TransactionPayload {
             TransactionPayloadID::CoinbaseToAltRecipient => {
                 let payload: CoinbasePayload = read_next(fd)?;
                 let principal_value: Value = read_next(fd)?;
-                let recipient = match principal_value {
-                    Value::Principal(recipient_principal) => recipient_principal,
-                    _ => {
-                        return Err(CodecError::DeserializeError("Failed to parse coinbase transaction -- did not receive a recipient principal value".to_string()));
-                    }
+                let Value::Principal(recipient) = principal_value else {
+                    return Err(CodecError::DeserializeError("Failed to parse coinbase transaction -- did not receive a recipient principal value".to_string()));
                 };
 
                 TransactionPayload::Coinbase(payload, Some(recipient), None)

--- a/components/stacks-devnet-js/src/lib.rs
+++ b/components/stacks-devnet-js/src/lib.rs
@@ -884,12 +884,11 @@ impl StacksDevnet {
 
         let _ = devnet.mining_tx.send(BitcoinMiningCommand::Mine);
 
-        let blocks = match devnet
+        let Ok(blocks) = devnet
             .stacks_block_rx
             .recv_timeout(std::time::Duration::from_millis(timeout))
-        {
-            Ok(obj) => obj,
-            Err(_) => return Ok(cx.undefined().as_value(&mut cx)),
+        else {
+            return Ok(cx.undefined().as_value(&mut cx));
         };
 
         let js_blocks = serde::to_value(&mut cx, &blocks).expect("Unable to serialize block");
@@ -904,12 +903,11 @@ impl StacksDevnet {
 
         let _ = devnet.mining_tx.send(BitcoinMiningCommand::Mine);
 
-        let block = match devnet
+        let Ok(block) = devnet
             .bitcoin_block_rx
             .recv_timeout(std::time::Duration::from_secs(10))
-        {
-            Ok(obj) => obj,
-            Err(_) => return Ok(cx.undefined().as_value(&mut cx)),
+        else {
+            return Ok(cx.undefined().as_value(&mut cx));
         };
 
         let js_block = serde::to_value(&mut cx, &block).expect("Unable to serialize block");

--- a/components/stacks-network/src/chainhooks.rs
+++ b/components/stacks-network/src/chainhooks.rs
@@ -61,9 +61,8 @@ fn get_chainhooks_files(
     let mut chainhooks_dir = manifest_location.get_project_root_location()?;
     chainhooks_dir.append_path("chainhooks")?;
     let prefix_len = chainhooks_dir.to_string().len() + 1;
-    let paths = match fs::read_dir(chainhooks_dir.to_string()) {
-        Ok(paths) => paths,
-        Err(_) => return Ok(vec![]),
+    let Ok(paths) = fs::read_dir(chainhooks_dir.to_string()) else {
+        return Ok(vec![]);
     };
     let mut hook_paths = vec![];
     for path in paths {

--- a/components/stacks-network/src/chains_coordinator.rs
+++ b/components/stacks-network/src/chains_coordinator.rs
@@ -705,13 +705,12 @@ pub async fn publish_stacking_orders(
             continue;
         }
 
-        let account = match accounts
+        let Some(account) = accounts
             .iter()
             .find(|e| e.label == pox_stacking_order.wallet)
             .cloned()
-        {
-            Some(account) => account,
-            _ => continue,
+        else {
+            continue;
         };
 
         transactions += 1;

--- a/components/stacks-network/src/orchestrator.rs
+++ b/components/stacks-network/src/orchestrator.rs
@@ -955,9 +955,8 @@ rpcport={bitcoin_node_rpc_port}
             ..Default::default()
         });
 
-        let docker = match &self.docker_client {
-            Some(ref docker) => docker,
-            _ => panic!("unable to get Docker client"),
+        let Some(docker) = &self.docker_client else {
+            panic!("unable to get Docker client");
         };
         let res = docker.list_containers(options).await;
         let containers = match res {
@@ -970,9 +969,8 @@ rpcport={bitcoin_node_rpc_port}
         let options = KillContainerOptions { signal: "SIGKILL" };
 
         for container in containers.iter() {
-            let container_id = match &container.id {
-                Some(id) => id,
-                None => continue,
+            let Some(container_id) = &container.id else {
+                continue;
             };
             let _ = docker
                 .kill_container(container_id, Some(options.clone()))
@@ -993,9 +991,8 @@ rpcport={bitcoin_node_rpc_port}
             _ => return Err("unable to boot container".to_string()),
         };
 
-        let docker = match &self.docker_client {
-            Some(ref docker) => docker,
-            _ => return Err("unable to get Docker client".into()),
+        let Some(docker) = &self.docker_client else {
+            return Err("unable to get Docker client".into());
         };
 
         docker
@@ -1353,9 +1350,8 @@ start_height = {epoch_3_1}
             _ => return Err("unable to boot container".to_string()),
         };
 
-        let docker = match &self.docker_client {
-            Some(ref docker) => docker,
-            _ => return Err("unable to get Docker client".into()),
+        let Some(docker) = &self.docker_client else {
+            return Err("unable to get Docker client".into());
         };
 
         docker
@@ -1760,9 +1756,8 @@ events_keys = ["*"]
             _ => return Err("unable to boot container".to_string()),
         };
 
-        let docker = match &self.docker_client {
-            Some(ref docker) => docker,
-            _ => return Err("unable to get Docker client".into()),
+        let Some(docker) = &self.docker_client else {
+            return Err("unable to get Docker client".into());
         };
 
         docker
@@ -1884,9 +1879,8 @@ events_keys = ["*"]
             _ => return Err("unable to boot container".to_string()),
         };
 
-        let docker = match &self.docker_client {
-            Some(ref docker) => docker,
-            _ => return Err("unable to get Docker client".into()),
+        let Some(docker) = &self.docker_client else {
+            return Err("unable to get Docker client".into());
         };
 
         docker
@@ -2048,9 +2042,8 @@ events_keys = ["*"]
             _ => return Err("unable to boot container".to_string()),
         };
 
-        let docker = match &self.docker_client {
-            Some(ref docker) => docker,
-            _ => return Err("unable to get Docker client".into()),
+        let Some(docker) = &self.docker_client else {
+            return Err("unable to get Docker client".into());
         };
 
         docker
@@ -2141,9 +2134,8 @@ events_keys = ["*"]
             _ => return Err("unable to boot container".to_string()),
         };
 
-        let docker = match &self.docker_client {
-            Some(ref docker) => docker,
-            _ => return Err("unable to get Docker client".into()),
+        let Some(docker) = &self.docker_client else {
+            return Err("unable to get Docker client".into());
         };
 
         docker
@@ -2252,9 +2244,8 @@ events_keys = ["*"]
             _ => return Err("unable to boot container".to_string()),
         };
 
-        let docker = match &self.docker_client {
-            Some(ref docker) => docker,
-            _ => return Err("unable to get Docker client".into()),
+        let Some(docker) = &self.docker_client else {
+            return Err("unable to get Docker client".into());
         };
 
         docker
@@ -2372,9 +2363,8 @@ events_keys = ["*"]
             _ => return Err("unable to boot container".to_string()),
         };
 
-        let docker = match &self.docker_client {
-            Some(ref docker) => docker,
-            _ => return Err("unable to get Docker client".into()),
+        let Some(docker) = &self.docker_client else {
+            return Err("unable to get Docker client".into());
         };
 
         docker
@@ -2409,9 +2399,8 @@ events_keys = ["*"]
             postgres_c_id,
         ) = containers_ids;
 
-        let docker = match &self.docker_client {
-            Some(ref docker) => docker,
-            _ => return Err("unable to get Docker client".into()),
+        let Some(docker) = &self.docker_client else {
+            return Err("unable to get Docker client".into());
         };
 
         let options = KillContainerOptions { signal: "SIGKILL" };
@@ -2469,9 +2458,8 @@ events_keys = ["*"]
         let (stacks_api_c_id, stacks_explorer_c_id, bitcoin_explorer_c_id, postgres_c_id) =
             containers_ids;
 
-        let docker = match &self.docker_client {
-            Some(ref docker) => docker,
-            _ => return Err("unable to get Docker client".into()),
+        let Some(docker) = &self.docker_client else {
+            return Err("unable to get Docker client".into());
         };
 
         // TODO(lgalabru): should we spawn
@@ -2607,9 +2595,8 @@ events_keys = ["*"]
     }
 
     pub async fn prune(&self) {
-        let docker = match &self.docker_client {
-            Some(ref docker) => docker,
-            _ => return,
+        let Some(docker) = &self.docker_client else {
+            return;
         };
 
         let mut filters = HashMap::new();


### PR DESCRIPTION
### Description

Apply Clippy lint `manual_let_else`, which finds `match` statements that can be simplified to `let`/`else` statements. This change results in almost 200 fewer LOC in the repository

#### Breaking change?

No

### Example

For example, this code:
```rust
let docker = match &self.docker_client {
    Some(ref docker) => docker,
    _ => return Err("unable to get Docker client".into()),
};
```

Simplifies to:

```rust
let Some(docker) = &self.docker_client else {
    return Err("unable to get Docker client".into());
};
```