### PR TITLE
chore: Apply `clippy::iter_with_drain`

### DIFF
--- a/components/clarity-lsp/src/common/state.rs
+++ b/components/clarity-lsp/src/common/state.rs
@@ -141,7 +141,7 @@ impl ContractState {
         contract_id: QualifiedContractIdentifier,
         _ast: ContractAST,
         _deps: DependencySet,
-        mut diags: Vec<ClarityDiagnostic>,
+        diags: Vec<ClarityDiagnostic>,
         analysis: Option<ContractAnalysis>,
         definitions: HashMap<ClarityName, Range>,
         location: FileLocation,
@@ -151,7 +151,7 @@ impl ContractState {
         let mut warnings = vec![];
         let mut notes = vec![];
 
-        for diag in diags.drain(..) {
+        for diag in diags.into_iter() {
             match diag.level {
                 ClarityLevel::Error => {
                     errors.push(diag);
@@ -165,10 +165,10 @@ impl ContractState {
             }
         }
 
-        let contract_calls = match analysis {
-            Some(ref analysis) => get_contract_calls(analysis),
-            None => vec![],
-        };
+        let contract_calls = analysis
+            .as_ref()
+            .map(get_contract_calls)
+            .unwrap_or_default();
 
         ContractState {
             contract_id,

--- a/components/clarity-repl/src/repl/interpreter.rs
+++ b/components/clarity-repl/src/repl/interpreter.rs
@@ -447,9 +447,9 @@ impl ClarityInterpreter {
 
         let mut global_context = self.get_global_context(contract.epoch, cost_track)?;
 
-        if let Some(mut in_hooks) = eval_hooks {
+        if let Some(in_hooks) = eval_hooks {
             let mut hooks: Vec<&mut dyn EvalHook> = Vec::new();
-            for hook in in_hooks.drain(..) {
+            for hook in in_hooks {
                 hooks.push(hook);
             }
             global_context.eval_hooks = Some(hooks);
@@ -598,7 +598,7 @@ impl ClarityInterpreter {
 
         global_context.commit().unwrap();
 
-        let (events, mut accounts_to_credit, mut accounts_to_debit) =
+        let (events, accounts_to_credit, accounts_to_debit) =
             Self::process_events(&mut emitted_events);
 
         let mut execution_result = ExecutionResult {
@@ -614,11 +614,11 @@ impl ClarityInterpreter {
             }
         }
 
-        for (account, token, value) in accounts_to_credit.drain(..) {
+        for (account, token, value) in accounts_to_credit {
             self.credit_token(account, token, value);
         }
 
-        for (account, token, value) in accounts_to_debit.drain(..) {
+        for (account, token, value) in accounts_to_debit {
             self.debit_token(account, token, value);
         }
 
@@ -648,13 +648,13 @@ impl ClarityInterpreter {
             ContractContext::new(contract_id.clone(), contract.clarity_version);
 
         let show_timings = self.repl_settings.show_timings;
-        let tx_sender: PrincipalData = self.tx_sender.clone().into();
+        let tx_sender = PrincipalData::from(self.tx_sender.clone());
 
         let mut global_context = self.get_global_context(contract.epoch, cost_track)?;
 
-        if let Some(mut in_hooks) = eval_hooks {
+        if let Some(in_hooks) = eval_hooks {
             let mut hooks: Vec<&mut dyn EvalHook> = Vec::new();
-            for hook in in_hooks.drain(..) {
+            for hook in in_hooks {
                 hooks.push(hook);
             }
             global_context.eval_hooks = Some(hooks);
@@ -815,7 +815,7 @@ impl ClarityInterpreter {
 
         global_context.commit().unwrap();
 
-        let (events, mut accounts_to_credit, mut accounts_to_debit) =
+        let (events, accounts_to_credit, accounts_to_debit) =
             Self::process_events(&mut emitted_events);
 
         let mut execution_result = ExecutionResult {
@@ -831,11 +831,11 @@ impl ClarityInterpreter {
             }
         }
 
-        for (account, token, value) in accounts_to_credit.drain(..) {
+        for (account, token, value) in accounts_to_credit {
             self.credit_token(account, token, value);
         }
 
-        for (account, token, value) in accounts_to_debit.drain(..) {
+        for (account, token, value) in accounts_to_debit {
             self.debit_token(account, token, value);
         }
 
@@ -858,14 +858,14 @@ impl ClarityInterpreter {
         clarity_version: ClarityVersion,
         track_costs: bool,
         allow_private: bool,
-        mut eval_hooks: Vec<&mut dyn EvalHook>,
+        eval_hooks: Vec<&mut dyn EvalHook>,
     ) -> Result<ExecutionResult, String> {
         let tx_sender: PrincipalData = self.tx_sender.clone().into();
 
         let mut global_context = self.get_global_context(epoch, track_costs)?;
 
         let mut hooks: Vec<&mut dyn EvalHook> = Vec::new();
-        for hook in eval_hooks.drain(..) {
+        for hook in eval_hooks {
             hooks.push(hook);
         }
         if !hooks.is_empty() {
@@ -917,7 +917,7 @@ impl ClarityInterpreter {
         let eval_result = EvaluationResult::Snippet(SnippetEvaluationResult { result: value });
         global_context.commit().unwrap();
 
-        let (events, mut accounts_to_credit, mut accounts_to_debit) =
+        let (events, accounts_to_credit, accounts_to_debit) =
             Self::process_events(&mut emitted_events);
 
         let mut execution_result = ExecutionResult {
@@ -933,11 +933,11 @@ impl ClarityInterpreter {
             }
         }
 
-        for (account, token, value) in accounts_to_credit.drain(..) {
+        for (account, token, value) in accounts_to_credit {
             self.credit_token(account, token, value);
         }
 
-        for (account, token, value) in accounts_to_debit.drain(..) {
+        for (account, token, value) in accounts_to_debit {
             self.debit_token(account, token, value);
         }
 


### PR DESCRIPTION
### Description

Apply `clippy::iter_with_drain`, which finds calls to `.drain(..)` which can be replaced by `into_iter()`. `into_iter()` is more efficient because it doesn't have to clear the collection being iterated over, and allows reuse of allocated memory

#### Breaking change?

No

### Example

This code:

```rust
for (account, token, value) in accounts_to_credit.drain(..) {
    self.credit_token(account, token, value);
}
```

Can be simplified to (note that `into_iter()` is implicit):

```rust
for (account, token, value) in accounts_to_credit {
    self.credit_token(account, token, value);
}
```
