### PR TITLE
fix: "Go to definition" functionality for native LSP

### DIFF
--- a/components/clarinet-files/src/lib.rs
+++ b/components/clarinet-files/src/lib.rs
@@ -62,7 +62,18 @@ impl fmt::Display for FileLocation {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             FileLocation::FileSystem { path } => write!(f, "{}", path.display()),
-            FileLocation::Url { url } => write!(f, "{}", url),
+            FileLocation::Url { url } => write!(f, "{url}"),
+        }
+    }
+}
+
+impl TryInto<Url> for &FileLocation {
+    type Error = ();
+
+    fn try_into(self) -> Result<Url, Self::Error> {
+        match self {
+            FileLocation::FileSystem { path } => Url::from_file_path(path),
+            FileLocation::Url { url } => Ok(url.clone()),
         }
     }
 }
@@ -101,13 +112,13 @@ impl FileLocation {
 
     pub fn from_url_string(url_string: &str) -> Result<FileLocation, String> {
         let url = Url::from_str(url_string)
-            .map_err(|e| format!("unable to parse {} as a url\n{:?}", url_string, e))?;
+            .map_err(|e| format!("unable to parse {url_string} as a url\n{e:?}"))?;
 
         #[cfg(not(target_arch = "wasm32"))]
         if url.scheme() == "file" {
             let path = url
                 .to_file_path()
-                .map_err(|_| format!("unable to conver url {} to path", url))?;
+                .map_err(|_| format!("unable to conver url {url} to path"))?;
             return Ok(FileLocation::FileSystem { path });
         }
 
@@ -116,13 +127,13 @@ impl FileLocation {
 
     pub fn from_path_string(path_string: &str) -> Result<FileLocation, String> {
         let path = PathBuf::from_str(path_string)
-            .map_err(|e| format!("unable to parse {} as a path\n{:?}", path_string, e))?;
+            .map_err(|e| format!("unable to parse {path_string} as a path\n{e:?}"))?;
         Ok(FileLocation::FileSystem { path })
     }
 
     pub fn append_path(&mut self, path_string: &str) -> Result<(), String> {
         let path_to_append = PathBuf::from_str(path_string)
-            .map_err(|e| format!("unable to read relative path {}\n{:?}", path_string, e))?;
+            .map_err(|e| format!("unable to read relative path {path_string}\n{e:?}"))?;
         match self.borrow_mut() {
             FileLocation::FileSystem { path } => {
                 path.extend(&path_to_append);
@@ -135,7 +146,7 @@ impl FileLocation {
                     let segment = component
                         .as_os_str()
                         .to_str()
-                        .ok_or(format!("unable to format component {:?}", component))?;
+                        .ok_or(format!("unable to format component {component:?}"))?;
                     paths_segments.push(segment);
                 }
             }
@@ -146,7 +157,7 @@ impl FileLocation {
     pub fn read_content_as_utf8(&self) -> Result<String, String> {
         let content = self.read_content()?;
         let contract_as_utf8 = String::from_utf8(content)
-            .map_err(|e| format!("unable to read content as utf8 {}\n{:?}", self, e))?;
+            .map_err(|e| format!("unable to read content as utf8 {self}\n{e:?}"))?;
         Ok(contract_as_utf8)
     }
 

--- a/components/clarity-lsp/src/common/state.rs
+++ b/components/clarity-lsp/src/common/state.rs
@@ -17,7 +17,6 @@ use clarity_repl::clarity::{ClarityName, ClarityVersion, StacksEpochId, Symbolic
 use clarity_repl::repl::{ContractDeployer, DEFAULT_CLARITY_VERSION};
 use lsp_types::{
     CompletionItem, DocumentSymbol, Hover, Location, MessageType, Position, Range, SignatureHelp,
-    Url,
 };
 use std::borrow::BorrowMut;
 use std::collections::{BTreeMap, HashMap, HashSet};
@@ -365,7 +364,7 @@ impl EditorState {
 
         match definitions.get(&position_hash)? {
             DefinitionLocation::Internal(range) => Some(Location {
-                uri: Url::parse(&contract_location.to_string()).ok()?,
+                uri: contract_location.try_into().ok()?,
                 range: *range,
             }),
             DefinitionLocation::External(contract_identifier, function_name) => {
@@ -383,18 +382,18 @@ impl EditorState {
                 {
                     let public_definitions = get_public_function_definitions(expressions);
                     return Some(Location {
+                        uri: contract_location.try_into().ok()?,
                         range: *public_definitions.get(function_name)?,
-                        uri: Url::parse(&definition_contract_location.to_string()).ok()?,
                     });
                 };
 
                 Some(Location {
+                    uri: contract_location.try_into().ok()?,
                     range: *protocol
                         .contracts
                         .get(definition_contract_location)?
                         .definitions
                         .get(function_name)?,
-                    uri: Url::parse(&definition_contract_location.to_string()).ok()?,
                 })
             }
         }


### PR DESCRIPTION
### Description

Fixes: #1829

This PR fixes "Go to definition" functionality for native LSP, which is broken because the following code:

```rust
Url::parse(&definition_contract_location.to_string()).ok()
```

Always returns `None` for `FileLocation::FileSystem` paths (because the `to_string()` output is missing the `file://` prefix). This is fixed by implementing `TryInto<Url>` for `FileLocation` to do the correct type conversion

#### Breaking change?

I don't think this will affect the VSCode extension (I'm guessing it always uses `FileLocation::Url`)

### Notes

In a future PR I think we can get rid of `FileLocation` enum completely and just use `Url` directly
