### PR TITLE
feat: Add release build for `x86_64-unknown-linux-musl`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -282,7 +282,9 @@ jobs:
         uses: docker://rust:alpine
         env:
           RUSTFLAGS: -C target-feature=-crt-static
-        run: cargo build --release --features=telemetry --locked --target ${{ matrix.target }}
+        with:
+          entrypoint: /bin/sh
+          args: -c "cargo build --release --features=telemetry --locked --target ${{ matrix.target }}"
 
       # Steps for Windows Code Signing with DigiCert
       - name: Windows - Setup Certificate

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -273,18 +273,14 @@ jobs:
           echo "SHORT_TARGET_NAME=${{ matrix.platform }}-${{ matrix.architecture }}" >> $GITHUB_ENV
           echo "PRE_GYP_TARGET_NAME=${{ matrix.platform }}-${{ matrix.architecture }}-unknown" >> $GITHUB_ENV
 
-      - name: Build - Cargo
-        if: matrix.target != 'x86_64-unknown-linux-musl'
-        run: cargo build --release --features=telemetry --locked --target ${{ matrix.target }}
-
-      - name: Build - Cargo (linux-musl)
+      - name: Install musl-gcc
         if: matrix.target == 'x86_64-unknown-linux-musl'
-        uses: docker://rust:alpine
-        env:
-          RUSTFLAGS: -C target-feature=-crt-static
-        with:
-          entrypoint: /bin/sh
-          args: -c "cargo build --release --features=telemetry --locked --target ${{ matrix.target }}"
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
+
+      - name: Build - Cargo
+        run: cargo build --release --features=telemetry --locked --target ${{ matrix.target }}
 
       # Steps for Windows Code Signing with DigiCert
       - name: Windows - Setup Certificate

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -205,6 +205,11 @@ jobs:
             platform: darwin
             target: aarch64-apple-darwin
             architecture: arm64
+          - os: ubuntu-latest
+            platform: linux
+            target: x86_64-unknown-linux-musl
+            architecture: x64
+            libc: musl
 
     steps:
       - name: Configure git to use LF (Windows)
@@ -270,6 +275,13 @@ jobs:
 
       - name: Build - Cargo
         if: matrix.target != 'x86_64-unknown-linux-musl'
+        run: cargo build --release --features=telemetry --locked --target ${{ matrix.target }}
+
+      - name: Build - Cargo (linux-musl)
+        if: matrix.target == 'x86_64-unknown-linux-musl'
+        uses: docker://rust:alpine
+        env:
+          RUSTFLAGS: -C target-feature=-crt-static
         run: cargo build --release --features=telemetry --locked --target ${{ matrix.target }}
 
       # Steps for Windows Code Signing with DigiCert


### PR DESCRIPTION
### Description

Add target `x86_64-unknown-linux-musl` for Clarinet release build. Having a static binary will simplify Linux packaging
