### PR TITLE
fix: Incorrect contract path in "Go to definition" reply from copy/paste error

### DIFF
--- a/components/clarity-lsp/src/common/state.rs
+++ b/components/clarity-lsp/src/common/state.rs
@@ -382,13 +382,13 @@ impl EditorState {
                 {
                     let public_definitions = get_public_function_definitions(expressions);
                     return Some(Location {
-                        uri: contract_location.try_into().ok()?,
+                        uri: definition_contract_location.try_into().ok()?,
                         range: *public_definitions.get(function_name)?,
                     });
                 };
 
                 Some(Location {
-                    uri: contract_location.try_into().ok()?,
+                    uri: definition_contract_location.try_into().ok()?,
                     range: *protocol
                         .contracts
                         .get(definition_contract_location)?


### PR DESCRIPTION
### Description

Currently goto definition for `contract-call?` is broken. It takes you to the correct line/column, but always in the current file, not where it is actually defined. I broke this in #1859 due to copy/pasting the first instance of `uri: contract_location.try_into().ok()?`. The following ones should use a different variable (`definition_contract_location`)