### PR TITLE
feat: Go to trait definition for `impl-trait` and `use-trait`

### DIFF
--- a/components/clarity-lsp/src/common/requests/definitions.rs
+++ b/components/clarity-lsp/src/common/requests/definitions.rs
@@ -123,16 +123,19 @@ impl<'a> ASTVisitor<'a> for Definitions {
         _name: &'a ClarityName,
         trait_identifier: &TraitIdentifier,
     ) -> bool {
-        eprintln!(
-            "Insert use trait '{_name}' at ({}, {}), defined at {trait_identifier:?}",
-            expr.span.start_line, expr.span.start_column
-        );
+        let Some(keyword) = expr.match_list().and_then(|expr| expr.get(1)) else {
+            return true;
+        };
         self.tokens.insert(
-            (expr.span.start_line, expr.span.start_column),
+            (keyword.span.start_line, keyword.span.start_column),
             DefinitionLocation::External(
                 trait_identifier.contract_identifier.clone(),
                 trait_identifier.name.clone(),
             ),
+        );
+        eprintln!(
+            "Insert use trait '{_name}' at ({}, {}), defined at {trait_identifier:?}",
+            keyword.span.start_line, keyword.span.start_column
         );
         true
     }
@@ -142,16 +145,19 @@ impl<'a> ASTVisitor<'a> for Definitions {
         expr: &'a SymbolicExpression,
         trait_identifier: &TraitIdentifier,
     ) -> bool {
-        eprintln!(
-            "Insert inpl trait '{}' at ({}, {}), defined at {trait_identifier:?}",
-            trait_identifier.name, expr.span.start_line, expr.span.start_column
-        );
+        let Some(keyword) = expr.match_list().and_then(|expr| expr.get(1)) else {
+            return true;
+        };
         self.tokens.insert(
-            (expr.span.start_line, expr.span.start_column),
+            (keyword.span.start_line, keyword.span.start_column),
             DefinitionLocation::External(
                 trait_identifier.contract_identifier.clone(),
                 trait_identifier.name.clone(),
             ),
+        );
+        eprintln!(
+            "Insert inpl trait '{}' at ({}, {}), defined at {trait_identifier:?}",
+            trait_identifier.name, keyword.span.start_line, keyword.span.start_column
         );
         true
     }

--- a/components/clarity-lsp/src/common/requests/definitions.rs
+++ b/components/clarity-lsp/src/common/requests/definitions.rs
@@ -4,7 +4,9 @@ use super::helpers::span_to_range;
 
 use clarity_repl::analysis::ast_visitor::{traverse, ASTVisitor, TypedVar};
 use clarity_repl::clarity::functions::define::DefineFunctions;
-use clarity_repl::clarity::vm::types::{QualifiedContractIdentifier, StandardPrincipalData};
+use clarity_repl::clarity::vm::types::{
+    QualifiedContractIdentifier, StandardPrincipalData, TraitIdentifier,
+};
 use clarity_repl::clarity::{ClarityName, SymbolicExpression};
 use lsp_types::Range;
 
@@ -112,6 +114,45 @@ impl<'a> ASTVisitor<'a> for Definitions {
                 DefinitionLocation::Internal(*range),
             );
         }
+        true
+    }
+
+    fn visit_use_trait(
+        &mut self,
+        expr: &'a SymbolicExpression,
+        _name: &'a ClarityName,
+        trait_identifier: &TraitIdentifier,
+    ) -> bool {
+        eprintln!(
+            "Insert use trait '{_name}' at ({}, {}), defined at {trait_identifier:?}",
+            expr.span.start_line, expr.span.start_column
+        );
+        self.tokens.insert(
+            (expr.span.start_line, expr.span.start_column),
+            DefinitionLocation::External(
+                trait_identifier.contract_identifier.clone(),
+                trait_identifier.name.clone(),
+            ),
+        );
+        true
+    }
+
+    fn visit_impl_trait(
+        &mut self,
+        expr: &'a SymbolicExpression,
+        trait_identifier: &TraitIdentifier,
+    ) -> bool {
+        eprintln!(
+            "Insert inpl trait '{}' at ({}, {}), defined at {trait_identifier:?}",
+            trait_identifier.name, expr.span.start_line, expr.span.start_column
+        );
+        self.tokens.insert(
+            (expr.span.start_line, expr.span.start_column),
+            DefinitionLocation::External(
+                trait_identifier.contract_identifier.clone(),
+                trait_identifier.name.clone(),
+            ),
+        );
         true
     }
 

--- a/components/clarity-lsp/src/common/requests/definitions.rs
+++ b/components/clarity-lsp/src/common/requests/definitions.rs
@@ -82,16 +82,13 @@ impl Definitions {
         identifier: &QualifiedContractIdentifier,
     ) -> QualifiedContractIdentifier {
         if identifier.issuer == StandardPrincipalData::transient() {
-            match &self.deployer {
-                Some(deployer) => {
-                    QualifiedContractIdentifier::parse(&format!("{}.{}", deployer, identifier.name))
-                        .expect("failed to set contract name")
-                }
-                None => identifier.to_owned(),
+            if let Some(deployer) = &self.deployer {
+                let contract = &format!("{deployer}.{}", identifier.name);
+                return QualifiedContractIdentifier::parse(contract)
+                    .expect("Failed to set contract name");
             }
-        } else {
-            identifier.to_owned()
         }
+        identifier.to_owned()
     }
 }
 

--- a/components/clarity-lsp/src/common/requests/definitions.rs
+++ b/components/clarity-lsp/src/common/requests/definitions.rs
@@ -649,9 +649,7 @@ pub fn get_trait_definitions(
                     Some(DefineFunctions::Trait)
                 )
             })
-            .map(|(_, args)| args) // Throw away `define-trait`
-            .inspect(|args| eprintln!("Found trait definition: {args:?}"))
-            .and_then(|args| args.split_first())
+            .and_then(|(_, args)| args.split_first()) // Throw away `define-trait`
             .and_then(|(trait_name, _)| trait_name.match_atom())
             .inspect(|&trait_name| {
                 definitions.insert(trait_name.to_owned(), span_to_range(&expression.span));
@@ -660,12 +658,11 @@ pub fn get_trait_definitions(
 }
 
 pub fn get_public_function_and_trait_definitions(
+    definitions: &mut HashMap<ClarityName, Range>,
     expressions: &[SymbolicExpression],
-) -> HashMap<ClarityName, Range> {
-    let mut definitions = HashMap::new();
-    get_public_function_definitions(&mut definitions, expressions);
-    get_trait_definitions(&mut definitions, expressions);
-    definitions
+) {
+    get_public_function_definitions(definitions, expressions);
+    get_trait_definitions(definitions, expressions);
 }
 
 #[cfg(test)]

--- a/components/clarity-lsp/src/common/requests/definitions.rs
+++ b/components/clarity-lsp/src/common/requests/definitions.rs
@@ -144,10 +144,6 @@ impl<'a> ASTVisitor<'a> for Definitions {
         let contract_identifier =
             self.clone_and_replace_transient(&trait_identifier.contract_identifier);
 
-        eprintln!(
-            "Insert use trait '{_name}' at ({}, {}), defined at {contract_identifier:?}",
-            keyword.span.start_line, keyword.span.start_column
-        );
         self.tokens.insert(
             (keyword.span.start_line, keyword.span.start_column),
             DefinitionLocation::External(contract_identifier, trait_identifier.name.clone()),
@@ -166,10 +162,6 @@ impl<'a> ASTVisitor<'a> for Definitions {
         let contract_identifier =
             self.clone_and_replace_transient(&trait_identifier.contract_identifier);
 
-        eprintln!(
-            "Insert inpl trait '{}' at ({}, {}), defined at {contract_identifier:?}",
-            trait_identifier.name, keyword.span.start_line, keyword.span.start_column
-        );
         self.tokens.insert(
             (keyword.span.start_line, keyword.span.start_column),
             DefinitionLocation::External(contract_identifier, trait_identifier.name.clone()),
@@ -388,10 +380,6 @@ impl<'a> ASTVisitor<'a> for Definitions {
             if let Some(SymbolicExpression { span, .. }) = list.get(2) {
                 let identifier = self.clone_and_replace_transient(identifier);
 
-                eprintln!(
-                    "Insert function '{function_name}' at ({}, {}), defined at {identifier:?}",
-                    span.start_line, span.start_column
-                );
                 self.tokens.insert(
                     (span.start_line, span.start_column),
                     DefinitionLocation::External(identifier, function_name.to_owned()),

--- a/components/clarity-lsp/src/common/state.rs
+++ b/components/clarity-lsp/src/common/state.rs
@@ -361,6 +361,7 @@ impl EditorState {
         };
 
         let position_hash = get_atom_start_at_position(&position, contract.expressions.as_ref()?)?;
+        eprintln!("Getting definitions at {position_hash:?}");
         let definitions = match &contract.definitions {
             Some(definitions) => definitions.to_owned(),
             None => get_definitions(contract.expressions.as_ref()?, contract.issuer.clone()),
@@ -372,6 +373,7 @@ impl EditorState {
                 range: *range,
             }),
             DefinitionLocation::External(contract_identifier, function_name) => {
+                eprintln!("External definition at {contract_identifier}::{function_name}");
                 let metadata = self.contracts_lookup.get(contract_location)?;
                 let protocol = self.protocols.get(&metadata.manifest_location)?;
                 let definition_contract_location =

--- a/components/clarity-lsp/src/common/state.rs
+++ b/components/clarity-lsp/src/common/state.rs
@@ -360,11 +360,11 @@ impl EditorState {
             character: position.character + 1,
         };
 
-        let position_hash =
-            get_atom_or_field_start_at_position(&position, contract.expressions.as_ref()?)?;
+        let expressions = contract.expressions.as_ref()?;
+        let position_hash = get_atom_or_field_start_at_position(&position, expressions)?;
         let definitions = match &contract.definitions {
             Some(definitions) => definitions.to_owned(),
-            None => get_definitions(contract.expressions.as_ref()?, contract.issuer.clone()),
+            None => get_definitions(expressions, contract.issuer.clone()),
         };
 
         match definitions.get(&position_hash)? {

--- a/components/clarity-lsp/src/common/state.rs
+++ b/components/clarity-lsp/src/common/state.rs
@@ -387,10 +387,11 @@ impl EditorState {
                     .get(definition_contract_location)
                     .and_then(|c| c.expressions.as_ref())
                 {
-                    let public_definitions = get_public_function_and_trait_definitions(expressions);
+                    let mut definitions = HashMap::new();
+                    get_public_function_and_trait_definitions(&mut definitions, expressions);
                     return Some(Location {
                         uri,
-                        range: *public_definitions.get(name)?,
+                        range: *definitions.get(name)?,
                     });
                 };
 
@@ -672,10 +673,9 @@ pub async fn build_state(
 
                 if let EvaluationResult::Contract(contract_result) = execution_result.result {
                     if let Some(ast) = artifacts.asts.get(&contract_id) {
-                        definitions.insert(
-                            contract_id.clone(),
-                            get_public_function_and_trait_definitions(&ast.expressions),
-                        );
+                        let mut v = HashMap::new();
+                        get_public_function_and_trait_definitions(&mut v, &ast.expressions);
+                        definitions.insert(contract_id.clone(), v);
                     }
                     analyses.insert(contract_id.clone(), Some(contract_result.contract.analysis));
                 };

--- a/components/clarity-lsp/src/common/state.rs
+++ b/components/clarity-lsp/src/common/state.rs
@@ -30,7 +30,7 @@ use super::requests::definitions::{
     get_definitions, get_public_function_and_trait_definitions, DefinitionLocation,
 };
 use super::requests::document_symbols::ASTSymbols;
-use super::requests::helpers::get_atom_start_at_position;
+use super::requests::helpers::get_atom_or_field_start_at_position;
 use super::requests::hover::get_expression_documentation;
 use super::requests::signature_help::get_signatures;
 
@@ -360,7 +360,8 @@ impl EditorState {
             character: position.character + 1,
         };
 
-        let position_hash = get_atom_start_at_position(&position, contract.expressions.as_ref()?)?;
+        let position_hash =
+            get_atom_or_field_start_at_position(&position, contract.expressions.as_ref()?)?;
         eprintln!("Getting definitions at {position_hash:?}");
         let definitions = match &contract.definitions {
             Some(definitions) => definitions.to_owned(),

--- a/components/clarity-lsp/src/common/state.rs
+++ b/components/clarity-lsp/src/common/state.rs
@@ -362,7 +362,6 @@ impl EditorState {
 
         let position_hash =
             get_atom_or_field_start_at_position(&position, contract.expressions.as_ref()?)?;
-        eprintln!("Getting definitions at {position_hash:?}");
         let definitions = match &contract.definitions {
             Some(definitions) => definitions.to_owned(),
             None => get_definitions(contract.expressions.as_ref()?, contract.issuer.clone()),
@@ -374,7 +373,6 @@ impl EditorState {
                 range: *range,
             }),
             DefinitionLocation::External(contract_identifier, name) => {
-                eprintln!("External definition at {contract_identifier}::{name}");
                 let metadata = self.contracts_lookup.get(contract_location)?;
                 let protocol = self.protocols.get(&metadata.manifest_location)?;
                 let definition_contract_location =

--- a/components/clarity-repl/src/analysis/ast_visitor.rs
+++ b/components/clarity-repl/src/analysis/ast_visitor.rs
@@ -692,7 +692,6 @@ pub trait ASTVisitor<'a> {
         name: &'a ClarityName,
         trait_def: &TraitDefinition,
     ) -> bool {
-        eprintln!("visit_trait_reference() empty");
         true
     }
 

--- a/components/clarity-repl/src/analysis/ast_visitor.rs
+++ b/components/clarity-repl/src/analysis/ast_visitor.rs
@@ -692,6 +692,7 @@ pub trait ASTVisitor<'a> {
         name: &'a ClarityName,
         trait_def: &TraitDefinition,
     ) -> bool {
+        eprintln!("visit_trait_reference() empty");
         true
     }
 
@@ -2552,12 +2553,7 @@ pub trait ASTVisitor<'a> {
 }
 
 pub fn traverse<'a>(visitor: &mut impl ASTVisitor<'a>, exprs: &'a [SymbolicExpression]) -> bool {
-    for expr in exprs {
-        if !visitor.traverse_expr(expr) {
-            return false;
-        }
-    }
-    true
+    exprs.iter().all(|expr| visitor.traverse_expr(expr))
 }
 
 fn match_tuple(

--- a/components/stacks-network/src/chainhooks.rs
+++ b/components/stacks-network/src/chainhooks.rs
@@ -10,17 +10,12 @@ use std::fs;
 pub fn parse_chainhook_full_specification(
     path: &PathBuf,
 ) -> Result<ChainhookSpecificationNetworkMap, String> {
-    let path = match File::open(path) {
-        Ok(path) => path,
-        Err(_e) => {
-            return Err(format!("unable to locate {}", path.display()));
-        }
-    };
+    let path = File::open(path).map_err(|_| format!("unable to locate {}", path.display()))?;
 
     let mut hook_spec_file_reader = BufReader::new(path);
     let specification: ChainhookSpecificationNetworkMap =
         serde_json::from_reader(&mut hook_spec_file_reader)
-            .map_err(|e| format!("unable to parse chainhook spec: {}", e))?;
+            .map_err(|e| format!("unable to parse chainhook spec: {e}"))?;
 
     Ok(specification)
 }


### PR DESCRIPTION
### Description

Fixes: #785

Clicking "Go to Definition" on `impl-trait` and `use-trait` names should go to the corresponding `define-trait` declaration

#### Breaking change?

No

### Status

- [x] Go to trait works for `impl-trait`
- [x] Go to trait works for `use-trait`

