### PR TITLE
perf: Remove clone of definitions hashmap

### DIFF
--- a/components/clarity-lsp/src/common/state.rs
+++ b/components/clarity-lsp/src/common/state.rs
@@ -362,10 +362,11 @@ impl EditorState {
 
         let expressions = contract.expressions.as_ref()?;
         let position_hash = get_atom_or_field_start_at_position(&position, expressions)?;
-        let definitions = match &contract.definitions {
-            Some(definitions) => definitions.to_owned(),
-            None => get_definitions(expressions, contract.issuer.clone()),
-        };
+        // Use holder variable to make sure temporary definitions live long enough
+        let mut definitions_holder = None;
+        let definitions = contract.definitions.as_ref().unwrap_or_else(|| {
+            definitions_holder.insert(get_definitions(expressions, contract.issuer.clone()))
+        });
 
         match definitions.get(&position_hash)? {
             DefinitionLocation::Internal(range) => Some(Location {

--- a/components/clarity-repl/src/repl/clarity_values.rs
+++ b/components/clarity-repl/src/repl/clarity_values.rs
@@ -67,7 +67,7 @@ pub fn value_to_string(value: &Value) -> String {
                 .join(" ");
             format!("(list {})", data)
         }
-        _ => format!("{}", value),
+        _ => value.to_string(),
     }
 }
 


### PR DESCRIPTION
### Description

This PR removes a clone (via `.to_owned()`) of the entire definitions hashmap that occurs on every definitions lookup. It should make the "Go to definitions" response a bit quicker
