### PR TITLE
perf: Apply `clippy::redundant_clone`

### DIFF
--- a/components/clarinet-cli/src/frontend/cli.rs
+++ b/components/clarinet-cli/src/frontend/cli.rs
@@ -1214,6 +1214,7 @@ pub fn main() {
             );
 
             if cmd.enable_clarity_wasm {
+                #[allow(clippy::redundant_clone)]
                 let mut manifest_wasm = manifest.clone();
                 manifest_wasm.repl_settings.clarity_wasm_mode = true;
                 let (_, _, wasm_artifacts) = load_deployment_and_artifacts_or_exit(

--- a/components/clarinet-deployments/src/lib.rs
+++ b/components/clarinet-deployments/src/lib.rs
@@ -1145,8 +1145,8 @@ mod tests {
             .mint_stx_balance(PrincipalData::Standard(sender_principal.clone()), 1000000);
 
         let stx_transfer_spec = StxTransferSpecification {
-            expected_sender: sender_principal.clone(),
-            recipient: PrincipalData::Standard(receiver_principal).clone(),
+            expected_sender: sender_principal,
+            recipient: PrincipalData::Standard(receiver_principal),
             mstx_amount: 1000,
             cost: 0,
             anchor_block_only: true,

--- a/components/clarinet-deployments/tests/deployment_plan.rs
+++ b/components/clarinet-deployments/tests/deployment_plan.rs
@@ -9,7 +9,7 @@ fn get_test_txs() -> (TransactionSpecification, TransactionSpecification) {
     let contract_id =
         QualifiedContractIdentifier::parse("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.test")
             .unwrap();
-    let tx_sender = contract_id.issuer.clone();
+    let tx_sender = contract_id.issuer;
 
     let contract_publish_tx =
         TransactionSpecification::EmulatedContractPublish(EmulatedContractPublishSpecification {
@@ -26,7 +26,7 @@ fn get_test_txs() -> (TransactionSpecification, TransactionSpecification) {
                 "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.test",
             )
             .unwrap(),
-            emulated_sender: tx_sender.clone(),
+            emulated_sender: tx_sender,
             method: ClarityName::try_from("test".to_string()).unwrap(),
             parameters: vec![],
         });
@@ -72,7 +72,7 @@ fn test_extract_no_contract_publish_txs() {
         new_plan,
         build_test_deployement_plan(vec![TransactionsBatchSpecification {
             id: 0,
-            transactions: vec![contract_publish_tx.clone()],
+            transactions: vec![contract_publish_tx],
             epoch: Some(EpochSpec::Epoch2_4),
         },])
     );
@@ -81,7 +81,7 @@ fn test_extract_no_contract_publish_txs() {
         custom_txs,
         vec![TransactionsBatchSpecification {
             id: 1,
-            transactions: vec![contract_call_txs.clone()],
+            transactions: vec![contract_call_txs],
             epoch: Some(EpochSpec::Epoch2_4),
         }]
     );
@@ -94,12 +94,12 @@ fn test_merge_batches() {
     let plan = build_test_deployement_plan(vec![
         TransactionsBatchSpecification {
             id: 0,
-            transactions: vec![contract_publish_tx.clone()],
+            transactions: vec![contract_publish_tx],
             epoch: Some(EpochSpec::Epoch2_4),
         },
         TransactionsBatchSpecification {
             id: 1,
-            transactions: vec![contract_call_txs.clone()],
+            transactions: vec![contract_call_txs],
             epoch: Some(EpochSpec::Epoch2_4),
         },
     ]);

--- a/components/clarinet-deployments/tests/genesis_accounts_funding.rs
+++ b/components/clarinet-deployments/tests/genesis_accounts_funding.rs
@@ -111,7 +111,7 @@ fn can_fund_initial_sbtc_balance() {
     let batch = TransactionsBatchSpecification {
         id: 0,
         epoch: Some(EpochSpec::Epoch3_0),
-        transactions: contract_requirements_txs.clone(),
+        transactions: contract_requirements_txs,
     };
 
     let genesis = GenesisSpecification {

--- a/components/clarinet-files/src/devnet_diff.rs
+++ b/components/clarinet-files/src/devnet_diff.rs
@@ -234,7 +234,7 @@ mod tests {
     #[test]
     fn test_with_differences() {
         let default_config = DevnetConfig::default();
-        let mut user_config = default_config.clone();
+        let mut user_config = default_config;
         user_config.epoch_3_0 = 150; // Different from default
         user_config.pox_stacking_orders = vec![];
 
@@ -255,7 +255,7 @@ mod tests {
         let differ = DevnetDiffConfig::with_fields(custom_fields);
 
         let default_config = DevnetConfig::default();
-        let mut user_config = default_config.clone();
+        let mut user_config = default_config;
         user_config.epoch_3_0 = 145;
 
         let different_fields = differ.is_compatible(&user_config);

--- a/components/clarinet-files/src/network_manifest.rs
+++ b/components/clarinet-files/src/network_manifest.rs
@@ -1268,7 +1268,7 @@ pub fn compute_addresses(
         get_bip32_keys_from_mnemonic(mnemonic, "", derivation_path).unwrap();
 
     // Enforce a 33 bytes secret key format, expected by Stacks
-    let mut secret_key_bytes = secret_bytes.clone();
+    let mut secret_key_bytes = secret_bytes;
     secret_key_bytes.push(1);
     let miner_secret_key_hex = bytes_to_hex(&secret_key_bytes);
 

--- a/components/clarinet-files/src/project_manifest.rs
+++ b/components/clarinet-files/src/project_manifest.rs
@@ -443,7 +443,7 @@ mod tests {
             ProjectManifest::from_project_manifest_file(manifest_file, &location, true).unwrap();
         assert!(manifest.repl_settings.remote_data.enabled);
 
-        let manifest_file: ProjectManifestFile = manifest_toml.clone().try_into().unwrap();
+        let manifest_file: ProjectManifestFile = manifest_toml.try_into().unwrap();
         let manifest =
             ProjectManifest::from_project_manifest_file(manifest_file, &location, false).unwrap();
         assert!(!manifest.repl_settings.remote_data.enabled);

--- a/components/clarinet-format/src/formatter/mod.rs
+++ b/components/clarinet-format/src/formatter/mod.rs
@@ -177,7 +177,7 @@ impl<'a> Aggregator<'a> {
             cache_ref.get(&key).cloned()
         };
         if let Some(result) = cached_result {
-            return result.clone();
+            return result;
         }
         // Track the end line of the previous expression
         let mut prev_end_line = 0;
@@ -1076,7 +1076,7 @@ impl<'a> Aggregator<'a> {
             cache_ref.get(&key).cloned()
         };
         if let Some(result) = cached_result {
-            return result.clone();
+            return result;
         }
         let result = match pse.pre_expr {
             PreSymbolicExpressionType::Atom(ref value) => t(value.as_str()).to_string(),

--- a/components/clarity-events/src/analysis/mod.rs
+++ b/components/clarity-events/src/analysis/mod.rs
@@ -474,7 +474,7 @@ impl<'a, 'b> EventCollector<'a, 'b> {
     pub fn add_method(&mut self, method: ClarityName) {
         let mut events = vec![];
         events.append(&mut self.last_entries);
-        self.event_map.insert(Some(method.clone()), events);
+        self.event_map.insert(Some(method), events);
     }
 
     pub fn add_event(&mut self, event: StacksTransactionEvent) {

--- a/components/clarity-repl/benches/simnet.rs
+++ b/components/clarity-repl/benches/simnet.rs
@@ -52,7 +52,7 @@ fn init_session() -> Session {
     .join("\n");
 
     let contract = ClarityContract {
-        code_source: ClarityCodeSource::ContractInMemory(src.to_string()),
+        code_source: ClarityCodeSource::ContractInMemory(src),
         name: "contract".into(),
         deployer: ContractDeployer::DefaultDeployer,
         clarity_version: DEFAULT_CLARITY_VERSION,

--- a/components/clarity-repl/src/analysis/coverage_tests.rs
+++ b/components/clarity-repl/src/analysis/coverage_tests.rs
@@ -16,7 +16,7 @@ fn get_coverage_report(contract: &str, snippets: Vec<String>) -> String {
     let (contract_id, contract) = session.contracts.pop_first().unwrap();
     let ast = contract.ast;
 
-    let asts = BTreeMap::from([(contract_id.clone(), ast.clone())]);
+    let asts = BTreeMap::from([(contract_id.clone(), ast)]);
     let paths = BTreeMap::from([(contract_id.name.to_string(), "/contract-0.clar".into())]);
 
     session.collect_lcov_content(&asts, &paths)

--- a/components/clarity-repl/src/repl/datastore.rs
+++ b/components/clarity-repl/src/repl/datastore.rs
@@ -1286,7 +1286,7 @@ mod tests {
             Some(RemoteNetworkInfo {
                 initial_height: 10,
                 is_mainnet: false,
-                api_url: ApiUrl(server.url().to_string()),
+                api_url: ApiUrl(server.url()),
                 network_id: 2147483648,
                 cache_location: Some(PathBuf::from("./.cache")),
             }),
@@ -1436,7 +1436,7 @@ mod tests {
         let current_tip = *clarity_datastore.current_chain_tip.borrow();
         assert_ne!(current_tip, initial_tip);
 
-        let clarity_datastore = cache.clone();
+        let clarity_datastore = cache;
         let current_tip = *clarity_datastore.current_chain_tip.borrow();
         assert_eq!(current_tip, initial_tip);
     }

--- a/components/clarity-repl/src/repl/datastore.rs
+++ b/components/clarity-repl/src/repl/datastore.rs
@@ -1436,7 +1436,8 @@ mod tests {
         let current_tip = *clarity_datastore.current_chain_tip.borrow();
         assert_ne!(current_tip, initial_tip);
 
-        let clarity_datastore = cache;
+        #[allow(clippy::redundant_clone)]
+        let clarity_datastore = cache.clone();
         let current_tip = *clarity_datastore.current_chain_tip.borrow();
         assert_eq!(current_tip, initial_tip);
     }

--- a/components/clarity-repl/src/repl/interpreter.rs
+++ b/components/clarity-repl/src/repl/interpreter.rs
@@ -889,7 +889,7 @@ impl ClarityInterpreter {
 
         let mut global_context = self
             .get_global_context(epoch, track_costs)
-            .map_err(|e| to_contract_call_error(e))?;
+            .map_err(to_contract_call_error)?;
 
         let mut hooks: Vec<&mut dyn EvalHook> = Vec::new();
         for hook in eval_hooks {

--- a/components/clarity-repl/src/repl/interpreter.rs
+++ b/components/clarity-repl/src/repl/interpreter.rs
@@ -889,7 +889,7 @@ impl ClarityInterpreter {
 
         let mut global_context = self
             .get_global_context(epoch, track_costs)
-            .map_err(|e| to_contract_call_error(e.to_string()))?;
+            .map_err(|e| to_contract_call_error(e))?;
 
         let mut hooks: Vec<&mut dyn EvalHook> = Vec::new();
         for hook in eval_hooks {
@@ -944,7 +944,7 @@ impl ClarityInterpreter {
         let eval_result = match value {
             Ok(value) => EvaluationResult::Snippet(SnippetEvaluationResult { result: value }),
             Err(e) => {
-                return Err(to_contract_call_error(e.to_string()));
+                return Err(to_contract_call_error(e));
             }
         };
         global_context.commit().unwrap();

--- a/components/clarity-repl/src/repl/session.rs
+++ b/components/clarity-repl/src/repl/session.rs
@@ -1894,7 +1894,7 @@ mod tests {
 
         let contract = ClarityContractBuilder::new()
             .name("contract-2-5")
-            .code_source(snippet.clone())
+            .code_source(snippet)
             .clarity_version(ClarityVersion::Clarity2)
             .epoch(StacksEpochId::Epoch25)
             .build();

--- a/components/clarity-repl/src/test_fixtures/clarity_contract.rs
+++ b/components/clarity-repl/src/test_fixtures/clarity_contract.rs
@@ -19,7 +19,7 @@ impl ClarityContract {
         .join("\n");
 
         Self {
-            code_source: ClarityCodeSource::ContractInMemory(snippet.to_string()),
+            code_source: ClarityCodeSource::ContractInMemory(snippet),
             name: "contract".into(),
             deployer: ContractDeployer::DefaultDeployer,
             clarity_version: DEFAULT_CLARITY_VERSION,

--- a/components/stacks-rpc-client/src/mock_stacks_rpc.rs
+++ b/components/stacks-rpc-client/src/mock_stacks_rpc.rs
@@ -16,7 +16,7 @@ impl Default for MockStacksRpc {
 impl MockStacksRpc {
     pub fn new() -> Self {
         let client = mockito::Server::new();
-        let url = client.url().to_string();
+        let url = client.url();
         Self { client, url }
     }
 


### PR DESCRIPTION
### Description

Apply `clippy::redundant_clone`, which removes several unnecesary `.clone()` and `.to_string()` calls

