### PR TITLE
Fix: preserve inner expr newlines (#1790)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,6 +750,7 @@ version = "0.1.0"
 dependencies = [
  "clarity",
  "divan",
+ "indoc",
  "pretty_assertions",
 ]
 

--- a/components/clarinet-format/Cargo.toml
+++ b/components/clarinet-format/Cargo.toml
@@ -12,6 +12,7 @@ clarity = { workspace = true, features = ["wasm", "developer-mode", "devtools"] 
 [dev-dependencies]
 pretty_assertions = { workspace = true }
 divan = "0.1"
+indoc = { workspace = true }
 
 [[bench]]
 name = "formatter"

--- a/components/clarinet-format/src/formatter/mod.rs
+++ b/components/clarinet-format/src/formatter/mod.rs
@@ -1384,6 +1384,8 @@ mod tests_formatter {
     #[allow(unused_imports)]
     use std::assert_eq;
 
+    use indoc::indoc;
+
     use super::{ClarityFormatter, Settings};
     use crate::formatter::Indentation;
     #[macro_export]
@@ -1436,11 +1438,14 @@ mod tests_formatter {
 
     #[test]
     fn intact_comment_spacing() {
-        let src = r#";; (define-read-only (has-access)
-;;   (begin
-;;     (ok true)
-;;   )
-;; )"#;
+        let src = indoc!(
+            r#"
+          ;; (define-read-only (has-access)
+          ;;   (begin
+          ;;     (ok true)
+          ;;   )
+          ;; )"#
+        );
         let result = format_with_default(&String::from(src));
         assert_eq!(src, result);
 
@@ -1452,13 +1457,16 @@ mod tests_formatter {
     fn test_multi_function() {
         let src = "(define-public (my-func) (ok true))\n(define-public (my-func2) (ok true))";
         let result = format_with_default(&String::from(src));
-        let expected = r#"(define-public (my-func)
-  (ok true)
-)
-(define-public (my-func2)
-  (ok true)
-)
-"#;
+        let expected = indoc!(
+            r#"
+            (define-public (my-func)
+              (ok true)
+            )
+            (define-public (my-func2)
+              (ok true)
+            )
+            "#
+        );
         assert_eq!(expected, result);
     }
     #[test]
@@ -1487,14 +1495,17 @@ mod tests_formatter {
     }
     #[test]
     fn test_preserve_newlines_inner_function() {
-        let src = r#"(define-public (increment)
-  (begin
-    (try! (stx-transfer? (var-get cost) tx-sender (var-get contract-owner)))
+        let src = indoc!(
+            r#"
+            (define-public (increment)
+              (begin
+                (try! (stx-transfer? (var-get cost) tx-sender (var-get contract-owner)))
 
-    (ok (var-set count (+ (var-get count) u1)))
-  )
-)
-"#;
+                (ok (var-set count (+ (var-get count) u1)))
+              )
+            )
+            "#
+        );
         let result = format_with_default(&String::from(src));
         assert_eq!(result, src);
     }
@@ -1525,22 +1536,28 @@ mod tests_formatter {
 
     #[test]
     fn test_booleans_with_comments() {
-        let src = r#"(or
-  true
-  ;; pre comment
-  (is-eq 1 2) ;; comment
-  (is-eq 1 1) ;; b
-)"#;
+        let src = indoc!(
+            r#"
+            (or
+              true
+              ;; pre comment
+              (is-eq 1 2) ;; comment
+              (is-eq 1 1) ;; b
+            )"#
+        );
         let result = format_with_default(&String::from(src));
         assert_eq!(src, result);
 
-        let src = r#"(asserts!
-  (or
-    (is-eq merkle-root txid) ;; true, if the transaction is the only transaction
-    (try! (verify-merkle-proof reversed-txid (reverse-buff32 merkle-root) proof))
-  )
-  (err ERR-INVALID-MERKLE-PROOF)
-)"#;
+        let src = indoc!(
+            r#"
+            (asserts!
+              (or
+                (is-eq merkle-root txid) ;; true, if the transaction is the only transaction
+                (try! (verify-merkle-proof reversed-txid (reverse-buff32 merkle-root) proof))
+              )
+              (err ERR-INVALID-MERKLE-PROOF)
+            )"#
+        );
         let result = format_with_default(&String::from(src));
         assert_eq!(src, result);
     }
@@ -1549,13 +1566,16 @@ mod tests_formatter {
     fn long_line_unwrapping() {
         let src = "(try! (unwrap! (complete-deposit-wrapper (get txid deposit) (get vout-index deposit) (get amount deposit) (get recipient deposit) (get burn-hash deposit) (get burn-height deposit) (get sweep-txid deposit)) (err (+ ERR_DEPOSIT_INDEX_PREFIX (+ u10 index)))))";
         let result = format_with_default(&String::from(src));
-        let expected = r#"(try! (unwrap!
-  (complete-deposit-wrapper (get txid deposit) (get vout-index deposit)
-    (get amount deposit) (get recipient deposit) (get burn-hash deposit)
-    (get burn-height deposit) (get sweep-txid deposit)
-  )
-  (err (+ ERR_DEPOSIT_INDEX_PREFIX (+ u10 index)))
-))"#;
+        let expected = indoc!(
+            r#"
+            (try! (unwrap!
+              (complete-deposit-wrapper (get txid deposit) (get vout-index deposit)
+                (get amount deposit) (get recipient deposit) (get burn-hash deposit)
+                (get burn-height deposit) (get sweep-txid deposit)
+              )
+              (err (+ ERR_DEPOSIT_INDEX_PREFIX (+ u10 index)))
+            ))"#
+        );
         assert_eq!(expected, result);
 
         // non-max-length sanity case
@@ -1571,14 +1591,17 @@ mod tests_formatter {
         assert_eq!(result, "(define-map a\n  uint\n  { n1: (buff 20) }\n)\n");
         let src = "(define-map something { name: (buff 48), a: uint } uint)\n";
         let result = format_with_default(&String::from(src));
-        let expected = r#"(define-map something
-  {
-    name: (buff 48),
-    a: uint,
-  }
-  uint
-)
-"#;
+        let expected = indoc!(
+            r#"
+            (define-map something
+              {
+                name: (buff 48),
+                a: uint,
+              }
+              uint
+            )
+            "#
+        );
         assert_eq!(result, expected);
     }
 
@@ -1586,20 +1609,26 @@ mod tests_formatter {
     fn test_let() {
         let src = "(let ((a 1) (b 2)) (+ a b))";
         let result = format_with_default(&String::from(src));
-        let expected = r#"(let (
-    (a 1)
-    (b 2)
-  )
-  (+ a b)
-)"#;
+        let expected = indoc!(
+            r#"
+            (let (
+                (a 1)
+                (b 2)
+              )
+              (+ a b)
+            )"#
+        );
         assert_eq!(expected, result);
     }
     #[test]
     fn test_single_let() {
-        let src = r#"(let ((current-count (var-get count)))
-  (asserts! (> current-count u0) ERR_COUNT_MUST_BE_POSITIVE)
-  (ok (var-set count (- current-count u1)))
-)"#;
+        let src = indoc!(
+            r#"
+            (let ((current-count (var-get count)))
+              (asserts! (> current-count u0) ERR_COUNT_MUST_BE_POSITIVE)
+              (ok (var-set count (- current-count u1)))
+            )"#
+        );
         let result = format_with_default(&String::from(src));
         assert_eq!(src, result);
     }
@@ -1609,10 +1638,13 @@ mod tests_formatter {
         let src = "(match opt value (ok (handle-new-value value)) (ok 1))";
         let result = format_with_default(&String::from(src));
         // "(match opt\n
-        let expected = r#"(match opt
-  value (ok (handle-new-value value))
-  (ok 1)
-)"#;
+        let expected = indoc!(
+            r#"
+            (match opt
+              value (ok (handle-new-value value))
+              (ok 1)
+            )"#
+        );
         assert_eq!(result, expected);
     }
 
@@ -1620,33 +1652,45 @@ mod tests_formatter {
     fn test_response_match() {
         let src = "(match x value (ok (+ to-add value)) err-value (err err-value))";
         let result = format_with_default(&String::from(src));
-        let expected = r#"(match x
-  value (ok (+ to-add value))
-  err-value (err err-value)
-)"#;
+        let expected = indoc!(
+            r#"
+            (match x
+              value (ok (+ to-add value))
+              err-value (err err-value)
+            )"#
+        );
         assert_eq!(result, expected);
     }
 
     #[test]
     fn test_comment_spacing() {
-        let src = r#";;comment
-;;    comment
-;;;comment"#;
+        let src = indoc!(
+            r#"
+            ;;comment
+            ;;    comment
+            ;;;comment"#
+        );
         let result = format_with_default(&String::from(src));
-        let expected = r#";; comment
-;;    comment
-;;; comment"#;
+        let expected = indoc!(
+            r#"
+            ;; comment
+            ;;    comment
+            ;;; comment"#
+        );
         assert_eq!(expected, result);
     }
     #[test]
     fn test_commented_match() {
-        let src = r#"(match x
-  ;; comment
-  value
-  ;; comment
-  (ok (+ to-add value))
-  (ok true)
-)"#;
+        let src = indoc!(
+            r#"
+            (match x
+              ;; comment
+              value
+              ;; comment
+              (ok (+ to-add value))
+              (ok true)
+            )"#
+        );
         let result = format_with_default(&String::from(src));
         assert_eq!(src, result);
     }
@@ -1664,59 +1708,77 @@ mod tests_formatter {
     fn map_in_map() {
         let src = "(ok { a: b, ctx: { a: b, c: d }})";
         let result = format_with_default(src);
-        let expected = r#"(ok {
-  a: b,
-  ctx: {
-    a: b,
-    c: d,
-  },
-})"#;
+        let expected = indoc!(
+            r#"
+            (ok {
+              a: b,
+              ctx: {
+                a: b,
+                c: d,
+              },
+            })"#
+        );
         assert_eq!(expected, result);
-        let src = r#"(ok {
-  varslice: (unwrap! (slice? txbuff slice-start target-index) (err ERR-OUT-OF-BOUNDS)),
-  ctx: {
-    txbuff: tx,
-    index: (+ u1 ptr),
-  },
-})"#;
+        let src = indoc!(
+            r#"
+            (ok {
+              varslice: (unwrap! (slice? txbuff slice-start target-index) (err ERR-OUT-OF-BOUNDS)),
+              ctx: {
+                txbuff: tx,
+                index: (+ u1 ptr),
+              },
+            })"#
+        );
         let result = format_with_default(src);
         assert_eq!(src, result);
     }
 
     #[test]
     fn old_tuple() {
-        let src = r#"(tuple
-  (a uint)
-  (b uint) ;; comment
-  (c bool)
-)"#;
+        let src = indoc!(
+            r#"
+            (tuple
+              (a uint)
+              (b uint) ;; comment
+              (c bool)
+            )"#
+        );
         let result = format_with_default(src);
-        let expected = r#"{
-  a: uint,
-  b: uint, ;; comment
-  c: bool,
-}"#;
+        let expected = indoc!(
+            r#"
+            {
+              a: uint,
+              b: uint, ;; comment
+              c: bool,
+            }"#
+        );
         assert_eq!(result, expected);
     }
 
     #[test]
     fn top_level_exprs() {
-        let src = r#"(let ((x (+ u1 u1)))
-  (map-insert ns x true)
-)
-(define-public (get-value)
-  (ok (map-get? ns u2))
-)
-"#;
+        let src = indoc!(
+            r#"
+            (let ((x (+ u1 u1)))
+              (map-insert ns x true)
+            )
+            (define-public (get-value)
+              (ok (map-get? ns u2))
+            )
+            "#
+        );
         let result = format_with_default(src);
         assert_eq!(result, src);
 
-        let src = r#"(print {
-  notification: "format-me",
-  payload: { message: "Hello, World!" },
-})
-(var-set test-var 1)
-(var-set test-var 2)"#;
+        let src = indoc!(
+            r#"
+            (print {
+              notification: "format-me",
+              payload: { message: "Hello, World!" },
+            })
+            (var-set test-var 1)
+            (var-set test-var 2)"#
+        );
         let result = format_with_default(src);
         assert_eq!(result, src);
     }
@@ -1724,26 +1786,32 @@ mod tests_formatter {
     fn test_indentation_levels() {
         let src = "(begin (let ((a 1) (b 2)) (ok true)))";
         let result = format_with_default(&String::from(src));
-        let expected = r#"(begin
-  (let (
-      (a 1)
-      (b 2)
-    )
-    (ok true)
-  )
-)"#;
+        let expected = indoc!(
+            r#"
+            (begin
+              (let (
+                  (a 1)
+                  (b 2)
+                )
+                (ok true)
+              )
+            )"#
+        );
         assert_eq!(result, expected);
     }
     #[test]
     fn test_let_comments() {
-        let src = r#"(begin
-  (let (
-      (a 1) ;; something
-      (b 2) ;; comment
-    )
-    (ok true)
-  )
-)"#;
+        let src = indoc!(
+            r#"
+            (begin
+              (let (
+                  (a 1) ;; something
+                  (b 2) ;; comment
+                )
+                (ok true)
+              )
+            )"#
+        );
         let result = format_with_default(&String::from(src));
         assert_eq!(src, result);
     }
@@ -1757,11 +1825,14 @@ mod tests_formatter {
 
     #[test]
     fn test_key_value_sugar_comment_midrecord() {
-        let src = r#"{
-  name: (buff 48),
-  ;;; comment
-  owner: send-to, ;; trailing
-}"#;
+        let src = indoc!(
+            r#"
+            {
+              name: (buff 48),
+              ;;; comment
+              owner: send-to, ;; trailing
+            }"#
+        );
         let result = format_with_default(&String::from(src));
         assert_eq!(src, result);
     }
@@ -1840,16 +1911,19 @@ mod tests_formatter {
     }
     #[test]
     fn test_detailed_traits() {
-        let src = r#"(define-public (parse-and-verify-vaa
-    (core-contract <core-trait>)
-    (vaa-bytes (buff 8192))
-  )
-  (begin
-    (try! (check-active-wormhole-core-contract core-contract))
-    (contract-call? core-contract parse-and-verify-vaa vaa-bytes)
-  )
-)
-"#;
+        let src = indoc!(
+            r#"
+            (define-public (parse-and-verify-vaa
+                (core-contract <core-trait>)
+                (vaa-bytes (buff 8192))
+              )
+              (begin
+                (try! (check-active-wormhole-core-contract core-contract))
+                (contract-call? core-contract parse-and-verify-vaa vaa-bytes)
+              )
+            )
+            "#
+        );
         let result = format_with_default(&String::from(src));
         assert_eq!(src, result);
     }
@@ -1862,10 +1936,13 @@ mod tests_formatter {
 
     #[test]
     fn too_many_newlines() {
-        let src = r#"(ok (at-block
-  (unwrap! (get-stacks-block-info? id-header-hash block) ERR_BLOCK_NOT_FOUND)
-  (var-get count)
-))"#;
+        let src = indoc!(
+            r#"
+            (ok (at-block
+              (unwrap! (get-stacks-block-info? id-header-hash block) ERR_BLOCK_NOT_FOUND)
+              (var-get count)
+            ))"#
+        );
         let result = format_with_default(&String::from(src));
         assert_eq!(src, result);
     }
@@ -1883,81 +1960,96 @@ mod tests_formatter {
     fn closing_if_parens() {
         let src = "(something (if (true) (list) (list 1 2 3)))";
         let result = format_with_default(src);
-        let expected = r#"(something (if (true)
-  (list)
-  (list 1 2 3)
-))"#;
+        let expected = indoc!(
+            r#"
+            (something (if (true)
+              (list)
+              (list 1 2 3)
+            ))"#
+        );
         assert_eq!(expected, result);
     }
     #[test]
     fn ok_map() {
         let src = "(ok { a: b, c: d })";
         let result = format_with_default(src);
-        let expected = r#"(ok {
-  a: b,
-  c: d,
-})"#;
+        let expected = indoc!(
+            r#"
+            (ok {
+              a: b,
+              c: d,
+            })"#
+        );
         assert_eq!(expected, result);
     }
 
     #[test]
     fn if_let_if() {
-        let src = r#"(if (true)
-  (let ((a (if (true)
-      (list)
-      (list)
-    )))
-    (list)
-  )
-  (list)
-)"#;
+        let src = indoc!(
+            r#"
+            (if (true)
+              (let ((a (if (true)
+                  (list)
+                  (list)
+                )))
+                (list)
+              )
+              (list)
+            )"#
+        );
         let result = format_with_default(src);
         assert_eq!(src, result);
     }
 
     #[test]
     fn weird_nesting() {
-        let src = r#"(merge name-props {
-  something: u1,
-  ;; comment
-  renewal-height:
-    ;; If still within lifetime, extend from current renewal height; otherwise, use new renewal height
-    (if (< burn-block-height
-        (unwrap-panic (get-renewal-height (unwrap-panic (get-id-from-bns name namespace))))
-      )
-      (+
-        (unwrap-panic (get-renewal-height (unwrap-panic (get-id-from-bns name namespace))))
-        lifetime
-      )
-      new-renewal-height
-    ),
-})"#;
+        let src = indoc!(
+            r#"
+            (merge name-props {
+              something: u1,
+              ;; comment
+              renewal-height:
+                ;; If still within lifetime, extend from current renewal height; otherwise, use new renewal height
+                (if (< burn-block-height
+                    (unwrap-panic (get-renewal-height (unwrap-panic (get-id-from-bns name namespace))))
+                  )
+                  (+
+                    (unwrap-panic (get-renewal-height (unwrap-panic (get-id-from-bns name namespace))))
+                    lifetime
+                  )
+                  new-renewal-height
+                ),
+            })"#
+        );
         let result = format_with_default(src);
         assert_eq!(src, result);
     }
 
     #[test]
     fn weird_nesting_single_value() {
-        let src = r#"(begin
-  (map-set name-properties {
-    name: name,
-    namespace: namespace,
-  }
-    (merge name-props {
-      renewal-height:
-        ;; If still within lifetime, extend from current renewal height; otherwise, use new renewal height
-        (if (< burn-block-height
-            (unwrap-panic (get-renewal-height (unwrap-panic (get-id-from-bns name namespace))))
-          )
-          (+
-            (unwrap-panic (get-renewal-height (unwrap-panic (get-id-from-bns name namespace))))
-            lifetime
-          )
-          new-renewal-height
-        ),
-    })
-  )
-)"#;
+        let src = indoc!(
+            r#"
+            (begin
+              (map-set name-properties {
+                name: name,
+                namespace: namespace,
+              }
+                (merge name-props {
+                  renewal-height:
+                    ;; If still within lifetime, extend from current renewal height; otherwise, use new renewal height
+                    (if (< burn-block-height
+                        (unwrap-panic (get-renewal-height (unwrap-panic (get-id-from-bns name namespace))))
+                      )
+                      (+
+                        (unwrap-panic (get-renewal-height (unwrap-panic (get-id-from-bns name namespace))))
+                        lifetime
+                      )
+                      new-renewal-height
+                    ),
+                })
+              )
+            )"#
+        );
         let result = format_with_default(src);
         assert_eq!(src, result);
     }
@@ -1982,102 +2074,131 @@ mod tests_formatter {
 
     #[test]
     fn inner_list_with_maps() {
-        let src = r#"(list
-  u1
-  {
-    extension: .ccd001-direct-execute,
-    enabled: true,
-  }
-  ;; {extension: .ccd008-city-activation, enabled: true}
-  {
-    extension: .ccd009-auth-v2-adapter,
-    enabled: true,
-  }
-)"#;
+        let src = indoc!(
+            r#"
+            (list
+              u1
+              {
+                extension: .ccd001-direct-execute,
+                enabled: true,
+              }
+              ;; {extension: .ccd008-city-activation, enabled: true}
+              {
+                extension: .ccd009-auth-v2-adapter,
+                enabled: true,
+              }
+            )"#
+        );
         let result = format_with_default(src);
         assert_eq!(src, result);
     }
 
     #[test]
     fn valid_comment_breaking() {
-        let src = r#"(var-set voteStart block-height) ;; vote tracking
-(define-data-var yesVotes uint u0)
-"#;
+        let src = indoc!(
+            r#"
+            (var-set voteStart block-height) ;; vote tracking
+            (define-data-var yesVotes uint u0)
+            "#
+        );
         let result = format_with_default(src);
         assert_eq!(src, result);
     }
     #[test]
     fn significant_newline_preserving_inner() {
-        let src = r#";; comment
+        let src = indoc!(
+            r#"
+            ;; comment
 
-;; another
-;; more
+            ;; another
+            ;; more
 
 
-;; after 2 spaces, now it's 1"#;
+            ;; after 2 spaces, now it's 1"#
+        );
         let result = format_with_default(src);
-        let expected = r#";; comment
+        let expected = indoc!(
+            r#"
+            ;; comment
 
-;; another
-;; more
+            ;; another
+            ;; more
 
-;; after 2 spaces, now it's 1"#;
+            ;; after 2 spaces, now it's 1"#
+        );
         assert_eq!(expected, result);
     }
     #[test]
     fn significant_newline_preserving() {
-        let src = r#";; comment
+        let src = indoc!(
+            r#"
+            ;; comment
 
-;; another
-;; more
+            ;; another
+            ;; more
 
 
-;; after 2 spaces, now it's 1"#;
+            ;; after 2 spaces, now it's 1"#
+        );
         let result = format_with_default(src);
-        let expected = r#";; comment
+        let expected = indoc!(
+            r#"
+            ;; comment
 
-;; another
-;; more
+            ;; another
+            ;; more
 
-;; after 2 spaces, now it's 1"#;
+            ;; after 2 spaces, now it's 1"#
+        );
         assert_eq!(expected, result);
     }
     #[test]
     fn define_trait_test() {
-        let src = r#"(define-trait token-trait (
-  (transfer?
-    (principal principal uint) ;; principal
-    ;; pre comment
-    (response uint uint)       ;; comment
-  )
-  (get-balance
-    (principal)
-    (response uint uint)
-  )
-))
-"#;
+        let src = indoc!(
+            r#"
+            (define-trait token-trait (
+              (transfer?
+                (principal principal uint) ;; principal
+                ;; pre comment
+                (response uint uint)       ;; comment
+              )
+              (get-balance
+                (principal)
+                (response uint uint)
+              )
+            ))
+            "#
+        );
         let result = format_with_default(src);
         assert_eq!(src, result);
     }
     #[test]
     fn unwrap_wrapped_lines() {
-        let src = r#"(new-available-ids (if (is-eq no-to-treasury u0)
-  (var-get available-ids)
-  (unwrap-panic (as-max-len? (concat (var-get available-ids) ids-to-treasury) u10000))
-))"#;
+        let src = indoc!(
+            r#"
+            (new-available-ids (if (is-eq no-to-treasury u0)
+              (var-get available-ids)
+              (unwrap-panic (as-max-len? (concat (var-get available-ids) ids-to-treasury) u10000))
+            ))"#
+        );
         let result = format_with_default(src);
         assert_eq!(src, result);
     }
 
     #[test]
     fn wrapped_list() {
-        let src = r#"{ buckets: (list p-func-b1 p-func-b2 p-func-b3 p-func-b4 p-func-b5 p-func-b6 p-func-b7 p-func-b8 p-func-b9 p-func-b10 p-func-b11 p-func-b12 p-func-b13 p-func-b14 p-func-b15 p-func-b16), something: u1 }"#;
-        let expected = r#"{
-  buckets: (list p-func-b1 p-func-b2 p-func-b3 p-func-b4 p-func-b5 p-func-b6 p-func-b7
-    p-func-b8 p-func-b9 p-func-b10 p-func-b11 p-func-b12 p-func-b13 p-func-b14
-    p-func-b15 p-func-b16),
-  something: u1,
-}"#;
+        let src = indoc!(
+            r#"{ buckets: (list p-func-b1 p-func-b2 p-func-b3 p-func-b4 p-func-b5 p-func-b6 p-func-b7 p-func-b8 p-func-b9 p-func-b10 p-func-b11 p-func-b12 p-func-b13 p-func-b14 p-func-b15 p-func-b16), something: u1 }"#
+        );
+        let expected = indoc!(
+            r#"
+            {
+              buckets: (list p-func-b1 p-func-b2 p-func-b3 p-func-b4 p-func-b5 p-func-b6 p-func-b7
+                p-func-b8 p-func-b9 p-func-b10 p-func-b11 p-func-b12 p-func-b13 p-func-b14
+                p-func-b15 p-func-b16),
+              something: u1,
+            }"#
+        );
         let result = format_with_default(src);
         assert_eq!(expected, result);
     }
@@ -2104,13 +2225,16 @@ mod tests_formatter {
 
     #[test]
     fn retain_comment_newlines() {
-        let src = r#"(senderBalance (unwrap!
-  (at-block proposalBlockHash
-    ;; /g/.aibtc-faktory/dao_contract_token
-    (contract-call? .aibtc-faktory get-balance contract-caller)
-  )
-  ERR_FETCHING_TOKEN_DATA
-))"#;
+        let src = indoc!(
+            r#"
+            (senderBalance (unwrap!
+              (at-block proposalBlockHash
+                ;; /g/.aibtc-faktory/dao_contract_token
+                (contract-call? .aibtc-faktory get-balance contract-caller)
+              )
+              ERR_FETCHING_TOKEN_DATA
+            ))"#
+        );
         let result = format_with_default(src);
         assert_eq!(src, result);
     }

--- a/components/clarinet-format/src/formatter/mod.rs
+++ b/components/clarinet-format/src/formatter/mod.rs
@@ -563,16 +563,7 @@ impl<'a> Aggregator<'a> {
             let trailing = get_trailing_comment(expr, &mut iter);
 
             // Add extra newlines based on original blank lines (limit to 1 consecutive blank lines)
-            if prev_end_line > 0
-                && expr.span().start_line > 0
-                && expr.span().start_line > prev_end_line
-            {
-                let blank_lines = expr.span().start_line.saturating_sub(prev_end_line + 1);
-                let extra_newlines = std::cmp::min(blank_lines, 1);
-                for _ in 0..extra_newlines {
-                    acc.push('\n');
-                }
-            }
+            push_blank_lines(&mut acc, prev_end_line, expr.span().start_line);
 
             // begin body
             acc.push_str(&format!(
@@ -612,16 +603,7 @@ impl<'a> Aggregator<'a> {
                 let trailing = get_trailing_comment(expr, &mut iter);
 
                 // Add extra newlines based on original blank lines (limit to 1 consecutive blank lines)
-                if prev_end_line > 0
-                    && expr.span().start_line > 0
-                    && expr.span().start_line > prev_end_line
-                {
-                    let blank_lines = expr.span().start_line.saturating_sub(prev_end_line + 1);
-                    let extra_newlines = std::cmp::min(blank_lines, 1);
-                    for _ in 0..extra_newlines {
-                        acc.push('\n');
-                    }
-                }
+                push_blank_lines(&mut acc, prev_end_line, expr.span().start_line);
 
                 acc.push_str(&format!(
                     "\n{}{}",
@@ -672,13 +654,7 @@ impl<'a> Aggregator<'a> {
             let trailing = get_trailing_comment(expr, &mut iter);
 
             // Add extra newlines based on original blank lines (limit to 1 consecutive blank lines)
-            if prev_end_line > 0 {
-                let blank_lines = expr.span().start_line.saturating_sub(prev_end_line + 1);
-                let extra_newlines = std::cmp::min(blank_lines, 1);
-                for _ in 0..extra_newlines {
-                    acc.push('\n');
-                }
-            }
+            push_blank_lines(&mut acc, prev_end_line, expr.span().start_line);
 
             if index > 0 {
                 acc.push('\n');
@@ -732,13 +708,7 @@ impl<'a> Aggregator<'a> {
         let mut prev_end_line = 0;
         for e in exprs.get(2..).unwrap_or_default() {
             // Add extra newlines based on original blank lines (limit to 1 consecutive blank lines)
-            if prev_end_line > 0 && e.span().start_line > 0 && e.span().start_line > prev_end_line {
-                let blank_lines = e.span().start_line.saturating_sub(prev_end_line + 1);
-                let extra_newlines = std::cmp::min(blank_lines, 1);
-                for _ in 0..extra_newlines {
-                    acc.push('\n');
-                }
-            }
+            push_blank_lines(&mut acc, prev_end_line, e.span().start_line);
 
             acc.push_str(&format!(
                 "\n{}{}",
@@ -1395,6 +1365,17 @@ fn chars_since_last_newline(acc: &str) -> usize {
         acc.len() - last_newline_pos - 1
     } else {
         acc.len()
+    }
+}
+
+// Helper to insert at most one blank line if there are blank lines between two expressions
+fn push_blank_lines(acc: &mut String, prev_end_line: u32, curr_start_line: u32) {
+    if prev_end_line > 0 && curr_start_line > 0 && curr_start_line > prev_end_line {
+        let blank_lines = curr_start_line.saturating_sub(prev_end_line + 1);
+        let extra_newlines = std::cmp::min(blank_lines, 1);
+        for _ in 0..extra_newlines {
+            acc.push('\n');
+        }
     }
 }
 

--- a/components/clarinet-format/src/formatter/mod.rs
+++ b/components/clarinet-format/src/formatter/mod.rs
@@ -567,7 +567,7 @@ impl<'a> Aggregator<'a> {
                 && expr.span().start_line > 0
                 && expr.span().start_line > prev_end_line
             {
-                let blank_lines = expr.span().start_line - prev_end_line - 1;
+                let blank_lines = expr.span().start_line.saturating_sub(prev_end_line + 1);
                 let extra_newlines = std::cmp::min(blank_lines, 1);
                 for _ in 0..extra_newlines {
                     acc.push('\n');
@@ -616,7 +616,7 @@ impl<'a> Aggregator<'a> {
                     && expr.span().start_line > 0
                     && expr.span().start_line > prev_end_line
                 {
-                    let blank_lines = expr.span().start_line - prev_end_line - 1;
+                    let blank_lines = expr.span().start_line.saturating_sub(prev_end_line + 1);
                     let extra_newlines = std::cmp::min(blank_lines, 1);
                     for _ in 0..extra_newlines {
                         acc.push('\n');
@@ -670,22 +670,20 @@ impl<'a> Aggregator<'a> {
 
         while let Some(expr) = iter.next() {
             let trailing = get_trailing_comment(expr, &mut iter);
-            if index > 0 {
-                acc.push('\n');
-                acc.push_str(&space);
-            }
 
             // Add extra newlines based on original blank lines (limit to 1 consecutive blank lines)
             if prev_end_line > 0 {
-                let blank_lines = expr.span().start_line - prev_end_line - 1;
+                let blank_lines = expr.span().start_line.saturating_sub(prev_end_line + 1);
                 let extra_newlines = std::cmp::min(blank_lines, 1);
                 for _ in 0..extra_newlines {
                     acc.push('\n');
                 }
             }
 
-            acc.push('\n');
-            acc.push_str(&space);
+            if index > 0 {
+                acc.push('\n');
+                acc.push_str(&space);
+            }
             acc.push_str(&self.format_source_exprs(slice::from_ref(expr), &space));
             if let Some(comment) = trailing {
                 acc.push(' ');
@@ -735,7 +733,7 @@ impl<'a> Aggregator<'a> {
         for e in exprs.get(2..).unwrap_or_default() {
             // Add extra newlines based on original blank lines (limit to 1 consecutive blank lines)
             if prev_end_line > 0 && e.span().start_line > 0 && e.span().start_line > prev_end_line {
-                let blank_lines = e.span().start_line - prev_end_line - 1;
+                let blank_lines = e.span().start_line.saturating_sub(prev_end_line + 1);
                 let extra_newlines = std::cmp::min(blank_lines, 1);
                 for _ in 0..extra_newlines {
                     acc.push('\n');
@@ -860,7 +858,10 @@ impl<'a> Aggregator<'a> {
             let start_line = item.span().start_line;
             acc.push_str(&value.to_string());
             if let Some(comment) = trailing {
-                let count = comment.span().start_column - item.span().end_column - 1;
+                let count = comment
+                    .span()
+                    .start_column
+                    .saturating_sub(item.span().end_column + 1);
                 let spaces = " ".repeat(count as usize);
                 acc.push_str(&spaces);
                 acc.push_str(&self.display_pse(comment, previous_indentation));
@@ -915,7 +916,10 @@ impl<'a> Aggregator<'a> {
             acc.push_str(&value.to_string());
 
             if let Some(comment) = trailing {
-                let count = comment.span().start_column - item.span().end_column - 1;
+                let count = comment
+                    .span()
+                    .start_column
+                    .saturating_sub(item.span().end_column + 1);
                 let spaces = " ".repeat(count as usize);
                 acc.push_str(&spaces);
                 acc.push_str(&self.display_pse(comment, previous_indentation));

--- a/components/clarinet-format/tests/golden-intended/preserve_newlines.clar
+++ b/components/clarinet-format/tests/golden-intended/preserve_newlines.clar
@@ -1,0 +1,32 @@
+(define-public (finalize
+    (token (optional <sip-010>))
+    (with principal)
+  )
+  (let (
+      (pipe-key (try! (get-pipe-key (contract-of-optional token) tx-sender with)))
+      (pipe (unwrap! (map-get? pipes pipe-key) ERR_NO_SUCH_PIPE))
+      (closer (get closer pipe))
+      (expires-at (get expires-at pipe))
+    )
+    ;; A forced closure must be in progress
+    (asserts! (is-some closer) ERR_NO_CLOSE_IN_PROGRESS)
+
+    ;; The waiting period must have passed
+    (asserts! (> burn-block-height expires-at) ERR_NOT_EXPIRED)
+
+    ;; Reset the pipe in the map.
+    (reset-pipe pipe-key (get nonce pipe))
+
+    ;; Emit an event
+    (print {
+      event: "finalize",
+      pipe-key: pipe-key,
+      pipe: pipe,
+      sender: tx-sender,
+    })
+
+    (payout token (get principal-1 pipe-key) (get principal-2 pipe-key)
+      (get balance-1 pipe) (get balance-2 pipe)
+    )
+  )
+)

--- a/components/clarinet-format/tests/golden.rs
+++ b/components/clarinet-format/tests/golden.rs
@@ -61,7 +61,7 @@ fn test_irl_contracts() {
             let src = fs::read_to_string(&path).expect("Failed to read source file");
 
             let file_name = path.file_name().expect("Failed to get file name");
-            println!("file_name: {file_name:?}");
+            println!("file: {file_name:?}");
             let intended_path = Path::new(intended_dir).join(file_name);
 
             let intended =

--- a/components/clarinet-format/tests/golden.rs
+++ b/components/clarinet-format/tests/golden.rs
@@ -61,6 +61,7 @@ fn test_irl_contracts() {
             let src = fs::read_to_string(&path).expect("Failed to read source file");
 
             let file_name = path.file_name().expect("Failed to get file name");
+            println!("file_name: {file_name:?}");
             let intended_path = Path::new(intended_dir).join(file_name);
 
             let intended =

--- a/components/clarinet-format/tests/golden/preserve_newlines.clar
+++ b/components/clarinet-format/tests/golden/preserve_newlines.clar
@@ -1,0 +1,33 @@
+;; max_line_length: 80, indentation: 2
+(define-public (finalize
+    (token (optional <sip-010>))
+    (with principal)
+  )
+  (let (
+      (pipe-key (try! (get-pipe-key (contract-of-optional token) tx-sender with)))
+      (pipe (unwrap! (map-get? pipes pipe-key) ERR_NO_SUCH_PIPE))
+      (closer (get closer pipe))
+      (expires-at (get expires-at pipe))
+    )
+    ;; A forced closure must be in progress
+    (asserts! (is-some closer) ERR_NO_CLOSE_IN_PROGRESS)
+
+    ;; The waiting period must have passed
+    (asserts! (> burn-block-height expires-at) ERR_NOT_EXPIRED)
+
+    ;; Reset the pipe in the map.
+    (reset-pipe pipe-key (get nonce pipe))
+
+    ;; Emit an event
+    (print {
+      event: "finalize",
+      pipe-key: pipe-key,
+      pipe: pipe,
+      sender: tx-sender,
+    })
+
+    (payout token (get principal-1 pipe-key) (get principal-2 pipe-key)
+      (get balance-1 pipe) (get balance-2 pipe)
+    )
+  )
+)


### PR DESCRIPTION
- fixes #1790 



