### PR TITLE
chore: improve vscode cargo fmt config

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,9 @@
   "rust-analyzer.check.extraArgs": [
     "--workspace",
     "--exclude=clarinet-sdk-wasm"
+  ],
+  "rust-analyzer.rustfmt.extraArgs": [
+    "--config",
+    "group_imports=StdExternalCrate,imports_granularity=Module"
   ]
 }


### PR DESCRIPTION
### Description

Make vscode rust analyzer setting follow fmt-stacks convention

