### PR TITLE
refactor: rework session api reference

### DIFF
--- a/components/clarity-repl/src/repl/docs.rs
+++ b/components/clarity-repl/src/repl/docs.rs
@@ -1,0 +1,70 @@
+use std::collections::HashMap;
+use std::sync::LazyLock;
+
+use clarity::vm::docs::{
+    make_api_reference, make_define_reference, make_keyword_reference, FunctionAPI,
+};
+use clarity::vm::functions::define::DefineFunctions;
+use clarity::vm::functions::NativeFunctions;
+use clarity::vm::variables::NativeVariables;
+
+fn normalize_description(description: &str) -> String {
+    description.replace('\n', " ")
+}
+
+fn format_api_doc(function_api: &FunctionAPI) -> (String, String) {
+    let description = normalize_description(&function_api.description);
+    let doc = format!(
+        "Usage\n{}\n\nDescription\n{}\n\nExamples\n{}",
+        function_api.signature, description, function_api.example
+    );
+    (function_api.name.clone(), doc)
+}
+
+fn build_api_reference() -> HashMap<String, String> {
+    NativeFunctions::ALL
+        .iter()
+        .map(|func| format_api_doc(&make_api_reference(func)))
+        .chain(
+            DefineFunctions::ALL
+                .iter()
+                .map(|func| format_api_doc(&make_define_reference(func))),
+        )
+        .collect()
+}
+
+fn clarity_keywords() -> HashMap<String, String> {
+    NativeVariables::ALL
+        .iter()
+        .filter_map(|func| {
+            make_keyword_reference(func).map(|key| {
+                let description = normalize_description(key.description);
+                let doc = format!("Description\n{}\n\nExamples\n{}", description, key.example);
+                (key.name.to_string(), doc)
+            })
+        })
+        .collect()
+}
+
+pub static CLARITY_STD_REF: LazyLock<HashMap<String, String>> = LazyLock::new(build_api_reference);
+
+pub static CLARITY_STD_INDEX: LazyLock<Vec<String>> = LazyLock::new(|| {
+    let mut keys = CLARITY_STD_REF
+        .keys()
+        .map(String::from)
+        .collect::<Vec<String>>();
+    keys.sort();
+    keys
+});
+
+pub static CLARITY_KEYWORDS_REF: LazyLock<HashMap<String, String>> =
+    LazyLock::new(clarity_keywords);
+
+pub static CLARITY_KEYWORDS_INDEX: LazyLock<Vec<String>> = LazyLock::new(|| {
+    let mut keys = CLARITY_KEYWORDS_REF
+        .keys()
+        .map(String::from)
+        .collect::<Vec<String>>();
+    keys.sort();
+    keys
+});

--- a/components/clarity-repl/src/repl/mod.rs
+++ b/components/clarity-repl/src/repl/mod.rs
@@ -2,6 +2,8 @@ pub mod boot;
 pub mod clarity_values;
 pub mod datastore;
 pub mod diagnostic;
+#[cfg(not(target_arch = "wasm32"))]
+mod docs;
 pub mod hooks;
 pub mod interpreter;
 pub mod remote_data;

--- a/components/clarity-repl/src/repl/session.rs
+++ b/components/clarity-repl/src/repl/session.rs
@@ -48,8 +48,7 @@ pub struct Session {
     pub interpreter: ClarityInterpreter,
     pub show_costs: bool,
     pub executed: Vec<String>,
-    // api_reference: HashMap<String, String>,
-    // keywords_reference: HashMap<String, String>,
+
     coverage_hook: Option<CoverageHook>,
     logger_hook: Option<LoggerHook>,
 }
@@ -75,8 +74,7 @@ impl Session {
             show_costs: false,
             settings,
             executed: Vec::new(),
-            // api_reference: build_api_reference(),
-            // keywords_reference: clarity_keywords(),
+
             coverage_hook: None,
             logger_hook: None,
         }


### PR DESCRIPTION
### Description

Refactor the get clarity `functions` and `keywords` in the repl session.
It sligthly simplifies the session, and will have a small performance boost. Probably negligible, but that's an easy refactor 