### PR TITLE
feat: show stacks trace on test fail

### DIFF
--- a/components/clarinet-sdk-wasm/src/core.rs
+++ b/components/clarinet-sdk-wasm/src/core.rs
@@ -1087,6 +1087,13 @@ impl SDK {
         session.handle_command(&snippet)
     }
 
+    #[wasm_bindgen(js_name=getLastContractCallTrace)]
+    /// Returns the last contract call trace as a string, if available.
+    pub fn get_last_contract_call_trace(&self) -> Option<String> {
+        let session = self.get_session();
+        session.last_contract_call_trace.clone()
+    }
+
     #[wasm_bindgen(js_name=setLocalAccounts)]
     pub fn set_local_accounts(&mut self, addresses: Vec<String>) {
         let principals = addresses

--- a/components/clarinet-sdk/node/vitest-helpers/src/vitest.setup.ts
+++ b/components/clarinet-sdk/node/vitest-helpers/src/vitest.setup.ts
@@ -31,9 +31,16 @@ beforeEach(async (ctx) => {
   }
 });
 
-afterEach(async () => {
+afterEach(async (ctx) => {
   const { coverage, costs, initBeforeEach, includeBootContracts, bootContractsPath } =
     global.options.clarinet;
+
+  if (ctx.task.result?.state === "fail") {
+    const stackTrace = simnet.getLastContractCallTrace();
+    if (stackTrace) {
+      console.log(stackTrace);
+    }
+  }
 
   if (initBeforeEach && (coverage || costs)) {
     const report = simnet.collectReport(includeBootContracts || false, bootContractsPath || "");


### PR DESCRIPTION
### Description

In #1974, I introduced improvement in the stack trace hook and better support for it in the SDK.
It shows the traces with a better error message whenever a contract-call fails (when there's an error in the vm)

This takes it a step further, and allows the test runner to show the stacks trace whenever a test fails.

