### PR TITLE
fix: publish stacking orders regardless of snapshot

### DIFF
--- a/components/stacks-network/src/chains_coordinator.rs
+++ b/components/stacks-network/src/chains_coordinator.rs
@@ -421,7 +421,6 @@ pub async fn start_chains_coordinator(
                         // Stacking orders can't be published until devnet is ready
                         if !stacks_signers_keys.is_empty()
                             && bitcoin_block_height >= DEFAULT_FIRST_BURN_HEADER_HEIGHT + 10
-                            && !using_snapshot
                         {
                             let res = publish_stacking_orders(
                                 &config.devnet_config,


### PR DESCRIPTION
<img width="1800" height="355" alt="image" src="https://github.com/user-attachments/assets/3e2b0d26-3752-4dc7-ac81-1614518a5383" />
