### PR TITLE
fix: contract id parsing

### DIFF
--- a/components/clarinet-sdk-wasm/src/core.rs
+++ b/components/clarinet-sdk-wasm/src/core.rs
@@ -330,22 +330,6 @@ impl SDK {
         }
     }
 
-    // fn desugar_contract_id(&self, contract: &str) -> Result<QualifiedContractIdentifier, String> {
-    //     let parts_count = contract.split('.').count();
-    //     if parts_count > 2 {
-    //         return Err(format!("Invalid contract identifier: {contract}"));
-    //     }
-
-    //     let is_qualified = parts_count == 2;
-    //     let contract_id = if is_qualified {
-    //         contract.to_string()
-    //     } else {
-    //         format!("{}.{}", self.deployer, contract,)
-    //     };
-
-    //     QualifiedContractIdentifier::parse(&contract_id).map_err(|e| e.to_string())
-    // }
-
     #[wasm_bindgen(js_name=getDefaultEpoch)]
     pub fn get_default_epoch() -> EpochString {
         EpochString {


### PR DESCRIPTION
The previous condition would (obviously) fail to parse contract_id that started with an `S` (eg: `Super_NFT`). I guess we never had the issue because contract names tend to start with a lower case.

This method should be more robust, and has a better error handling (one less `unwrap`